### PR TITLE
Add routing, shared nav, and slate view

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ CourtAI sits in front of an NBA game-log API and gives the same data three ways:
 
 The natural-language path is the one I cared most about — the structured filters are the fallback when the prompt is ambiguous.
 
+## Routes and navigation
+
+The shared navigation exposes the game-log search at `/` and the date-based NBA slate at
+`/matchups?date=YYYY-MM-DD`. Omitting `date` opens today's Eastern-time slate. Unknown client-side
+paths return to `/`, and Vercel's SPA fallback keeps direct links to `/matchups` working. Signed-out
+visitors keep the shared shell and see a sign-in prompt on the matchups route rather than being
+redirected.
+
 ## Architecture
 
 ```
@@ -83,6 +91,7 @@ This repo is the frontend only. It expects a backend serving:
 - `GET  /api/players`
 - `GET  /api/teams`
 - `GET  /api/games/game_logs`
+- `GET  /api/games/slate?date=YYYY-MM-DD`
 - `GET  /api/players/profile`
 - `GET  /api/teams/stats`
 - `POST /api/nl-query`

--- a/e2e/fixtures/courtai.js
+++ b/e2e/fixtures/courtai.js
@@ -76,6 +76,12 @@ export const slateGame = {
   preseason: false,
 };
 
+const scheduleOnlySlateGame = {
+  ...slateGame,
+  away_team: { ...slateGame.away_team, targetable_player_count: 0 },
+  home_team: { ...slateGame.home_team, targetable_player_count: 0 },
+};
+
 export const slatePayload = (
   date,
   games,
@@ -142,7 +148,7 @@ export const installApiContract = async (page, overrides = {}) => {
 
     if (url.pathname === '/api/games/slate') {
       const date = url.searchParams.get('date') || '2026-01-15';
-      await route.fulfill({ json: slatePayload(date, [slateGame]) });
+      await route.fulfill({ json: slatePayload(date, [scheduleOnlySlateGame]) });
       return;
     }
 

--- a/e2e/fixtures/courtai.js
+++ b/e2e/fixtures/courtai.js
@@ -56,6 +56,36 @@ const averages = {
   TOV: 2.5,
 };
 
+const slateGame = {
+  game_id: '0022500584',
+  away_team: {
+    team_id: 1610612747,
+    tricode: 'LAL',
+    name: 'Los Angeles Lakers',
+    targetable_player_count: 5,
+  },
+  home_team: {
+    team_id: 1610612738,
+    tricode: 'BOS',
+    name: 'Boston Celtics',
+    targetable_player_count: 4,
+  },
+  scheduled_at: '2026-01-16T00:30:00Z',
+  status: { state: 'scheduled', label: 'Scheduled' },
+  classification: 'NBA Paris Game',
+  preseason: false,
+};
+
+const slatePayload = (date, games, poolStatus = 'unavailable') => ({
+  slate_date: date,
+  freshness: {
+    schedule: { status: 'fresh', retrieved_at: '2026-01-15T10:00:00Z' },
+    pool: { status: poolStatus, retrieved_at: null, providers: {} },
+  },
+  pool_status: poolStatus,
+  games,
+});
+
 export const installApiContract = async (page, overrides = {}) => {
   await page.route('**/api/**', async (route) => {
     const request = route.request();
@@ -98,6 +128,42 @@ export const installApiContract = async (page, overrides = {}) => {
           next_game: 'Atlanta Hawks',
         },
       });
+      return;
+    }
+
+    if (url.pathname === '/api/games/slate') {
+      const date = url.searchParams.get('date') || '2026-01-15';
+      if (date === '2026-01-14') {
+        await route.fulfill({ json: slatePayload(date, []) });
+        return;
+      }
+      if (date === '2026-01-10') {
+        await route.fulfill({
+          json: slatePayload(date, [
+            {
+              ...slateGame,
+              game_id: '0022500541',
+              away_team: {
+                ...slateGame.away_team,
+                tricode: 'NYK',
+                name: 'New York Knicks',
+                targetable_player_count: 0,
+              },
+              home_team: {
+                ...slateGame.home_team,
+                tricode: 'MIL',
+                name: 'Milwaukee Bucks',
+                targetable_player_count: 0,
+              },
+              scheduled_at: '2026-01-11T01:00:00Z',
+              status: { state: 'final', label: 'Final' },
+              classification: null,
+            },
+          ]),
+        });
+        return;
+      }
+      await route.fulfill({ json: slatePayload(date, [slateGame]) });
       return;
     }
 

--- a/e2e/fixtures/courtai.js
+++ b/e2e/fixtures/courtai.js
@@ -56,7 +56,7 @@ const averages = {
   TOV: 2.5,
 };
 
-const slateGame = {
+export const slateGame = {
   game_id: '0022500584',
   away_team: {
     team_id: 1610612747,
@@ -76,11 +76,20 @@ const slateGame = {
   preseason: false,
 };
 
-const slatePayload = (date, games, poolStatus = 'unavailable') => ({
+export const slatePayload = (
+  date,
+  games,
+  {
+    poolStatus = 'unavailable',
+    poolFreshnessStatus = 'unavailable',
+    poolRetrievedAt = null,
+    providers = {},
+  } = {},
+) => ({
   slate_date: date,
   freshness: {
     schedule: { status: 'fresh', retrieved_at: '2026-01-15T10:00:00Z' },
-    pool: { status: poolStatus, retrieved_at: null, providers: {} },
+    pool: { status: poolFreshnessStatus, retrieved_at: poolRetrievedAt, providers },
   },
   pool_status: poolStatus,
   games,
@@ -133,36 +142,6 @@ export const installApiContract = async (page, overrides = {}) => {
 
     if (url.pathname === '/api/games/slate') {
       const date = url.searchParams.get('date') || '2026-01-15';
-      if (date === '2026-01-14') {
-        await route.fulfill({ json: slatePayload(date, []) });
-        return;
-      }
-      if (date === '2026-01-10') {
-        await route.fulfill({
-          json: slatePayload(date, [
-            {
-              ...slateGame,
-              game_id: '0022500541',
-              away_team: {
-                ...slateGame.away_team,
-                tricode: 'NYK',
-                name: 'New York Knicks',
-                targetable_player_count: 0,
-              },
-              home_team: {
-                ...slateGame.home_team,
-                tricode: 'MIL',
-                name: 'Milwaukee Bucks',
-                targetable_player_count: 0,
-              },
-              scheduled_at: '2026-01-11T01:00:00Z',
-              status: { state: 'final', label: 'Final' },
-              classification: null,
-            },
-          ]),
-        });
-        return;
-      }
       await route.fulfill({ json: slatePayload(date, [slateGame]) });
       return;
     }

--- a/e2e/specs/slate.spec.js
+++ b/e2e/specs/slate.spec.js
@@ -37,7 +37,7 @@ test('@critical authenticated user opens a slate and navigates dates', async ({
           {
             poolStatus: 'fresh',
             poolFreshnessStatus: 'fresh',
-            poolRetrievedAt: '2026-01-15T10:00:00Z',
+            poolRetrievedAt: '2026-01-15T11:50:00Z',
           },
         );
       }

--- a/e2e/specs/slate.spec.js
+++ b/e2e/specs/slate.spec.js
@@ -1,6 +1,14 @@
-import { E2E_AUTH_STORAGE_KEY, expect, installApiContract, test } from '../fixtures/courtai';
+import {
+  E2E_AUTH_STORAGE_KEY,
+  expect,
+  installApiContract,
+  slateGame,
+  slatePayload,
+  test,
+} from '../fixtures/courtai';
 
 test('@critical authenticated user opens a slate and navigates dates', async ({ page }) => {
+  await page.clock.setFixedTime(new Date('2026-01-15T12:00:00Z'));
   await page.addInitScript((storageKey) => {
     window.localStorage.setItem(storageKey, 'true');
   }, E2E_AUTH_STORAGE_KEY);
@@ -8,7 +16,48 @@ test('@critical authenticated user opens a slate and navigates dates', async ({ 
   page.on('request', (request) => {
     if (new URL(request.url()).pathname === '/api/games/slate') requests.push(request.url());
   });
-  await installApiContract(page);
+  await installApiContract(page, {
+    '/api/games/slate': (request) => {
+      const date = new URL(request.url()).searchParams.get('date') || '2026-01-15';
+      if (date === '2026-01-14') return slatePayload(date, []);
+      if (date === '2026-01-10') {
+        return slatePayload(
+          date,
+          [
+            {
+              ...slateGame,
+              game_id: '0022500541',
+              away_team: {
+                ...slateGame.away_team,
+                tricode: 'NYK',
+                name: 'New York Knicks',
+                targetable_player_count: 0,
+              },
+              home_team: {
+                ...slateGame.home_team,
+                tricode: 'MIL',
+                name: 'Milwaukee Bucks',
+                targetable_player_count: 0,
+              },
+              scheduled_at: '2026-01-11T01:00:00Z',
+              status: { state: 'final', label: 'Final' },
+              classification: null,
+            },
+          ],
+          { poolStatus: 'fresh' },
+        );
+      }
+      return slatePayload(date, [slateGame], {
+        poolStatus: 'stale-served',
+        poolFreshnessStatus: 'stale-served',
+        poolRetrievedAt: '2026-01-15T10:00:00Z',
+        providers: {
+          prizepicks: { status: 'fresh', retrieved_at: '2026-01-15T10:00:00Z' },
+          underdog: { status: 'missing', retrieved_at: null },
+        },
+      });
+    },
+  });
 
   await page.goto('/matchups?date=2026-01-15');
 
@@ -16,9 +65,9 @@ test('@critical authenticated user opens a slate and navigates dates', async ({ 
   await expect(page.getByRole('heading', { name: 'LAL @ BOS' })).toBeVisible();
   await expect(page.getByText('Los Angeles Lakers')).toBeVisible();
   await expect(page.getByText('5 targetable')).toBeVisible();
-  await expect(page.getByRole('article').getByText('Pool unavailable')).toBeVisible();
-  await expect(page.getByText(/schedule as of/i)).toBeVisible();
-  await expect(page.getByLabel('Data freshness').getByText('Pool unavailable')).toBeVisible();
+  await expect(page.getByText(/schedule is fresh.*as of/i)).toBeVisible();
+  await expect(page.getByRole('alert').getByText(/player pool is stale-served/i)).toBeVisible();
+  await expect(page.getByRole('alert').getByText(/underdog pool is missing/i)).toBeVisible();
   await page.screenshot({ path: 'test-results/slate-desktop.png', fullPage: true });
 
   await page.getByRole('button', { name: 'Previous date' }).click();
@@ -28,7 +77,7 @@ test('@critical authenticated user opens a slate and navigates dates', async ({ 
   await page.getByLabel('Slate date').fill('2026-01-10');
   await expect(page).toHaveURL(/date=2026-01-10/);
   await expect(page.getByRole('heading', { name: 'NYK @ MIL' })).toBeVisible();
-  await expect(page.getByText('Past slate — player pool unavailable.')).toBeVisible();
+  await expect(page.getByText(/no player pool is available for historical dates/i)).toBeVisible();
   expect(requests.some((url) => new URL(url).searchParams.get('date') === '2026-01-10')).toBe(true);
 });
 
@@ -68,6 +117,7 @@ test('a rejected slate request leaves date navigation available', async ({ page 
 });
 
 test('slate remains usable at a narrow viewport and from the keyboard', async ({ page }) => {
+  await page.clock.setFixedTime(new Date('2026-01-15T12:00:00Z'));
   await page.setViewportSize({ width: 393, height: 852 });
   await page.addInitScript((storageKey) => {
     window.localStorage.setItem(storageKey, 'true');

--- a/e2e/specs/slate.spec.js
+++ b/e2e/specs/slate.spec.js
@@ -1,17 +1,9 @@
-import {
-  E2E_AUTH_STORAGE_KEY,
-  expect,
-  installApiContract,
-  slateGame,
-  slatePayload,
-  test,
-} from '../fixtures/courtai';
+import { expect, installApiContract, slateGame, slatePayload, test } from '../fixtures/courtai';
 
-test('@critical authenticated user opens a slate and navigates dates', async ({ page }) => {
+test('@critical authenticated user opens a slate and navigates dates', async ({
+  authenticatedPage: page,
+}) => {
   await page.clock.setFixedTime(new Date('2026-01-15T12:00:00Z'));
-  await page.addInitScript((storageKey) => {
-    window.localStorage.setItem(storageKey, 'true');
-  }, E2E_AUTH_STORAGE_KEY);
   const requests = [];
   page.on('request', (request) => {
     if (new URL(request.url()).pathname === '/api/games/slate') requests.push(request.url());
@@ -31,20 +23,22 @@ test('@critical authenticated user opens a slate and navigates dates', async ({ 
                 ...slateGame.away_team,
                 tricode: 'NYK',
                 name: 'New York Knicks',
-                targetable_player_count: 0,
               },
               home_team: {
                 ...slateGame.home_team,
                 tricode: 'MIL',
                 name: 'Milwaukee Bucks',
-                targetable_player_count: 0,
               },
               scheduled_at: '2026-01-11T01:00:00Z',
               status: { state: 'final', label: 'Final' },
               classification: null,
             },
           ],
-          { poolStatus: 'fresh' },
+          {
+            poolStatus: 'fresh',
+            poolFreshnessStatus: 'fresh',
+            poolRetrievedAt: '2026-01-15T10:00:00Z',
+          },
         );
       }
       return slatePayload(date, [slateGame], {
@@ -63,6 +57,12 @@ test('@critical authenticated user opens a slate and navigates dates', async ({ 
 
   await expect(page.getByRole('heading', { name: 'Thursday, January 15' })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'LAL @ BOS' })).toBeVisible();
+  const viewerLocalTip = await page.evaluate((scheduledAt) => {
+    return new Intl.DateTimeFormat(undefined, { hour: 'numeric', minute: '2-digit' }).format(
+      new Date(scheduledAt),
+    );
+  }, slateGame.scheduled_at);
+  await expect(page.getByText(viewerLocalTip, { exact: true })).toBeVisible();
   await expect(page.getByText('Los Angeles Lakers')).toBeVisible();
   await expect(page.getByText('5 targetable')).toBeVisible();
   await expect(page.getByText(/schedule is fresh.*as of/i)).toBeVisible();
@@ -77,7 +77,15 @@ test('@critical authenticated user opens a slate and navigates dates', async ({ 
   await page.getByLabel('Slate date').fill('2026-01-10');
   await expect(page).toHaveURL(/date=2026-01-10/);
   await expect(page.getByRole('heading', { name: 'NYK @ MIL' })).toBeVisible();
-  await expect(page.getByText(/no player pool is available for historical dates/i)).toBeVisible();
+  await expect(
+    page.getByText(/current player pool is not displayed for historical dates/i),
+  ).toBeVisible();
+  await expect(
+    page.getByText(/final game cards retain the posted targetable counts/i),
+  ).toBeVisible();
+  await expect(page.getByText('5 targetable')).toBeVisible();
+  await expect(page.getByText('4 targetable')).toBeVisible();
+  await page.screenshot({ path: 'test-results/slate-past.png', fullPage: true });
   expect(requests.some((url) => new URL(url).searchParams.get('date') === '2026-01-10')).toBe(true);
 });
 
@@ -98,10 +106,9 @@ test('unknown paths return to the search landing page', async ({ page }) => {
   await expect(page.getByRole('heading', { name: 'CourtAI' })).toBeVisible();
 });
 
-test('a rejected slate request leaves date navigation available', async ({ page }) => {
-  await page.addInitScript((storageKey) => {
-    window.localStorage.setItem(storageKey, 'true');
-  }, E2E_AUTH_STORAGE_KEY);
+test('a rejected slate request leaves date navigation available', async ({
+  authenticatedPage: page,
+}) => {
   await installApiContract(page, {
     '/api/games/slate': {
       status: 503,
@@ -116,13 +123,11 @@ test('a rejected slate request leaves date navigation available', async ({ page 
   await expect(page.getByLabel('Slate date')).toBeEnabled();
 });
 
-test('slate remains usable at a narrow viewport and from the keyboard', async ({ page }) => {
+test('slate remains usable at a narrow viewport and from the keyboard', async ({
+  authenticatedPage: page,
+}) => {
   await page.clock.setFixedTime(new Date('2026-01-15T12:00:00Z'));
   await page.setViewportSize({ width: 393, height: 852 });
-  await page.addInitScript((storageKey) => {
-    window.localStorage.setItem(storageKey, 'true');
-  }, E2E_AUTH_STORAGE_KEY);
-  await installApiContract(page);
   await page.goto('/matchups?date=2026-01-15');
   await expect(page.getByRole('heading', { name: 'LAL @ BOS' })).toBeVisible();
 

--- a/e2e/specs/slate.spec.js
+++ b/e2e/specs/slate.spec.js
@@ -69,7 +69,9 @@ test('@critical authenticated user opens a slate and navigates dates', async ({
   const freshness = page.getByRole('group', { name: 'Data freshness' });
   await expect(freshness.getByText(/player pool is stale-served/i)).toBeVisible();
   await expect(freshness.getByText(/underdog pool is missing/i)).toBeVisible();
-  await expect(page.getByText('prizepicks pool is fresh — as of 20m ago')).toBeVisible();
+  await expect(
+    page.getByText(/prizepicks pool is fresh.*older than 15m freshness bar/i),
+  ).toHaveClass(/freshness-warning/);
   await page.screenshot({ path: 'test-results/slate-desktop.png', fullPage: true });
 
   await page.getByRole('button', { name: 'Previous date' }).click();
@@ -190,7 +192,7 @@ test('minimum slate freshness payload renders through the browser contract', asy
     '/api/games/slate': {
       slate_date: '2026-01-15',
       freshness: {
-        schedule: { retrieved_at: '2026-01-15T11:00:00Z' },
+        schedule: { retrieved_at: '2026-01-14T05:00:00Z' },
         pool: {
           retrieved_at: null,
           providers: {
@@ -210,8 +212,12 @@ test('minimum slate freshness payload renders through the browser contract', asy
   await page.goto('/matchups?date=2026-01-15');
 
   await expect(page.getByRole('group', { name: 'Data freshness' })).toBeVisible();
-  await expect(page.getByText('Schedule is fresh — as of 1h ago')).toBeVisible();
-  await expect(page.getByText('Player pool is fresh — as of 20m ago')).toBeVisible();
+  await expect(page.getByText('Schedule is stale — as of 31h ago')).toHaveClass(
+    /freshness-warning/,
+  );
+  await expect(page.getByText(/player pool is fresh.*older than 15m freshness bar/i)).toHaveClass(
+    /freshness-warning/,
+  );
   await expect(page.getByText('Final after review')).toBeVisible();
   await expect(page.getByText(/targetable counts use the current player pool/i)).toBeVisible();
   await page.screenshot({ path: 'test-results/slate-minimum-payload.png', fullPage: true });

--- a/e2e/specs/slate.spec.js
+++ b/e2e/specs/slate.spec.js
@@ -55,7 +55,7 @@ test('@critical authenticated user opens a slate and navigates dates', async ({
 
   await page.goto('/matchups?date=2026-01-15');
 
-  await expect(page.getByRole('heading', { name: 'Thursday, January 15' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Thursday, January 15, 2026' })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'LAL @ BOS' })).toBeVisible();
   const viewerLocalTip = await page.evaluate((scheduledAt) => {
     return new Intl.DateTimeFormat(undefined, { hour: 'numeric', minute: '2-digit' }).format(
@@ -70,9 +70,8 @@ test('@critical authenticated user opens a slate and navigates dates', async ({
   await expect(freshness.getByText(/player pool is stale-served/i)).toBeVisible();
   await expect(freshness.getByText(/underdog pool is missing/i)).toBeVisible();
   await expect(
-    page.getByText(/prizepicks pool is fresh.*older than 15m freshness bar/i),
-  ).toHaveClass(/freshness-warning/);
-  await page.screenshot({ path: 'test-results/slate-desktop.png', fullPage: true });
+    page.getByText(/prizepicks pool is stale.*older than 15m freshness bar/i),
+  ).toBeVisible();
 
   await page.getByRole('button', { name: 'Previous date' }).click();
   await expect(page).toHaveURL(/date=2026-01-14/);
@@ -80,7 +79,7 @@ test('@critical authenticated user opens a slate and navigates dates', async ({
 
   await page.getByLabel('Slate date').fill('');
   await expect(page).toHaveURL(/\/matchups$/);
-  await expect(page.getByRole('heading', { name: 'Thursday, January 15' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Thursday, January 15, 2026' })).toBeVisible();
   expect(requests.some((url) => !new URL(url).searchParams.has('date'))).toBe(true);
 
   await page.getByLabel('Slate date').fill('2026-01-10');
@@ -94,7 +93,6 @@ test('@critical authenticated user opens a slate and navigates dates', async ({
   ).toBeVisible();
   await expect(page.getByText('5 targetable')).toBeVisible();
   await expect(page.getByText('4 targetable')).toBeVisible();
-  await page.screenshot({ path: 'test-results/slate-past.png', fullPage: true });
   expect(requests.some((url) => new URL(url).searchParams.get('date') === '2026-01-10')).toBe(true);
 });
 
@@ -136,9 +134,15 @@ test('an invalid requested date stays neutral until the backend rejects it', asy
   authenticatedPage: page,
 }) => {
   await installApiContract(page, {
-    '/api/games/slate': {
-      status: 400,
-      body: { error: { code: 'invalid_input', message: 'Enter a valid date.' } },
+    '/api/games/slate': (request) => {
+      const date = new URL(request.url()).searchParams.get('date');
+      if (date) {
+        return {
+          status: 400,
+          body: { error: { code: 'invalid_input', message: 'Enter a valid date.' } },
+        };
+      }
+      return slatePayload('2026-01-15', [slateGame]);
     },
   });
 
@@ -149,7 +153,11 @@ test('an invalid requested date stays neutral until the backend rejects it', asy
   await expect(page.getByRole('button', { name: 'Previous date' })).toBeDisabled();
   await expect(page.getByRole('button', { name: 'Next date' })).toBeDisabled();
   await expect(page.getByRole('alert')).toContainText('Enter a valid date.');
-  await page.screenshot({ path: 'test-results/slate-invalid-date.png', fullPage: true });
+  await expect(page.getByRole('button', { name: 'Today' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Today' }).click();
+  await expect(page).toHaveURL(/\/matchups$/);
+  await expect(page.getByRole('heading', { name: 'Thursday, January 15, 2026' })).toBeVisible();
 });
 
 test('explicit unavailable pool status wins over stale provider evidence', async ({
@@ -178,10 +186,9 @@ test('explicit unavailable pool status wins over stale provider evidence', async
 
   await page.goto('/matchups?date=2026-01-15');
 
-  await expect(page.getByText(/player pool unavailable; no targetable players/i)).toBeVisible();
+  await expect(page.getByText(/player pool is unavailable; no targetable players/i)).toBeVisible();
   await expect(page.getByText('prizepicks pool is stale-served — as of 3h ago')).toBeVisible();
   await expect(page.getByText('0 targetable')).toHaveCount(2);
-  await page.screenshot({ path: 'test-results/slate-pool-contradiction.png', fullPage: true });
 });
 
 test('minimum slate freshness payload renders through the browser contract', async ({
@@ -194,9 +201,9 @@ test('minimum slate freshness payload renders through the browser contract', asy
       freshness: {
         schedule: { retrieved_at: '2026-01-14T05:00:00Z' },
         pool: {
-          retrieved_at: null,
           providers: {
             prizepicks: { status: 'fresh', retrieved_at: '2026-01-15T11:40:00Z' },
+            underdog: { status: 'missing', retrieved_at: null },
           },
         },
       },
@@ -211,16 +218,12 @@ test('minimum slate freshness payload renders through the browser contract', asy
 
   await page.goto('/matchups?date=2026-01-15');
 
-  await expect(page.getByRole('group', { name: 'Data freshness' })).toBeVisible();
-  await expect(page.getByText('Schedule is stale — as of 31h ago')).toHaveClass(
-    /freshness-warning/,
-  );
-  await expect(page.getByText(/player pool is fresh.*older than 15m freshness bar/i)).toHaveClass(
-    /freshness-warning/,
-  );
+  const freshness = page.getByRole('group', { name: 'Data freshness' });
+  await expect(freshness).toBeVisible();
+  await expect(page.getByText('Schedule is stale — as of 31h ago')).toBeVisible();
+  await expect(freshness.getByText(/player pool is partial/i)).toBeVisible();
   await expect(page.getByText('Final after review')).toBeVisible();
-  await expect(page.getByText(/targetable counts use the current player pool/i)).toBeVisible();
-  await page.screenshot({ path: 'test-results/slate-minimum-payload.png', fullPage: true });
+  await expect(page.getByText(/counts reflect the available boards/i)).toBeVisible();
 });
 
 test('slate remains usable at a narrow viewport and from the keyboard', async ({
@@ -243,5 +246,4 @@ test('slate remains usable at a narrow viewport and from the keyboard', async ({
   expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(
     true,
   );
-  await page.screenshot({ path: 'test-results/slate-narrow.png', fullPage: true });
 });

--- a/e2e/specs/slate.spec.js
+++ b/e2e/specs/slate.spec.js
@@ -65,6 +65,8 @@ test('@critical authenticated user opens a slate and navigates dates', async ({
   await expect(page.getByText(viewerLocalTip, { exact: true })).toBeVisible();
   await expect(page.getByText('Los Angeles Lakers')).toBeVisible();
   await expect(page.getByText('5 targetable')).toBeVisible();
+  await expect(page.getByText('NBA Paris Game')).toBeVisible();
+  await expect(page.getByText('Preseason')).toHaveCount(0);
   await expect(page.getByText(/schedule is fresh.*as of/i)).toBeVisible();
   const freshness = page.getByRole('group', { name: 'Data freshness' });
   await expect(freshness.getByText(/player pool is stale-served/i)).toBeVisible();
@@ -211,6 +213,8 @@ test('minimum slate freshness payload renders through the browser contract', asy
         {
           ...slateGame,
           status: { state: 'final', label: 'Final after review' },
+          classification: null,
+          preseason: true,
         },
       ],
     },
@@ -223,7 +227,44 @@ test('minimum slate freshness payload renders through the browser contract', asy
   await expect(page.getByText('Schedule is stale — as of 31h ago')).toBeVisible();
   await expect(freshness.getByText(/player pool is partial/i)).toBeVisible();
   await expect(page.getByText('Final after review')).toBeVisible();
+  await expect(page.getByText('Preseason')).toBeVisible();
+  await expect(page.getByText('NBA Paris Game')).toHaveCount(0);
   await expect(page.getByText(/counts reflect the available boards/i)).toBeVisible();
+});
+
+test('provider aggregate uses the oldest timestamp regardless of provider key order', async ({
+  authenticatedPage: page,
+}) => {
+  await page.clock.setFixedTime(new Date('2026-01-15T12:00:00Z'));
+  await installApiContract(page, {
+    '/api/games/slate': (request) => {
+      const date = new URL(request.url()).searchParams.get('date') || '2026-01-15';
+      const entries = [
+        ['newer', { status: 'fresh', retrieved_at: '2026-01-15T11:50:00Z' }],
+        ['older', { status: 'fresh', retrieved_at: '2026-01-15T11:30:00Z' }],
+      ];
+      return {
+        slate_date: date,
+        freshness: {
+          schedule: { status: 'fresh', retrieved_at: '2026-01-15T11:50:00Z' },
+          pool: {
+            providers: Object.fromEntries(date === '2026-01-15' ? entries : entries.reverse()),
+          },
+        },
+        games: [slateGame],
+      };
+    },
+  });
+
+  await page.goto('/matchups?date=2026-01-15');
+  await expect(
+    page.getByText(/player pool is stale — as of 30m ago.*older than 15m freshness bar/i),
+  ).toBeVisible();
+
+  await page.getByLabel('Slate date').fill('2026-01-16');
+  await expect(
+    page.getByText(/player pool is stale — as of 30m ago.*older than 15m freshness bar/i),
+  ).toBeVisible();
 });
 
 test('slate remains usable at a narrow viewport and from the keyboard', async ({

--- a/e2e/specs/slate.spec.js
+++ b/e2e/specs/slate.spec.js
@@ -46,7 +46,7 @@ test('@critical authenticated user opens a slate and navigates dates', async ({
         poolFreshnessStatus: 'stale-served',
         poolRetrievedAt: '2026-01-15T10:00:00Z',
         providers: {
-          prizepicks: { status: 'fresh', retrieved_at: '2026-01-15T10:00:00Z' },
+          prizepicks: { status: 'fresh', retrieved_at: '2026-01-15T11:40:00Z' },
           underdog: { status: 'missing', retrieved_at: null },
         },
       });
@@ -66,13 +66,20 @@ test('@critical authenticated user opens a slate and navigates dates', async ({
   await expect(page.getByText('Los Angeles Lakers')).toBeVisible();
   await expect(page.getByText('5 targetable')).toBeVisible();
   await expect(page.getByText(/schedule is fresh.*as of/i)).toBeVisible();
-  await expect(page.getByRole('alert').getByText(/player pool is stale-served/i)).toBeVisible();
-  await expect(page.getByRole('alert').getByText(/underdog pool is missing/i)).toBeVisible();
+  const freshness = page.getByRole('group', { name: 'Data freshness' });
+  await expect(freshness.getByText(/player pool is stale-served/i)).toBeVisible();
+  await expect(freshness.getByText(/underdog pool is missing/i)).toBeVisible();
+  await expect(page.getByText('prizepicks pool is fresh — as of 20m ago')).toBeVisible();
   await page.screenshot({ path: 'test-results/slate-desktop.png', fullPage: true });
 
   await page.getByRole('button', { name: 'Previous date' }).click();
   await expect(page).toHaveURL(/date=2026-01-14/);
   await expect(page.getByText('No games on this slate.')).toBeVisible();
+
+  await page.getByLabel('Slate date').fill('');
+  await expect(page).toHaveURL(/\/matchups$/);
+  await expect(page.getByRole('heading', { name: 'Thursday, January 15' })).toBeVisible();
+  expect(requests.some((url) => !new URL(url).searchParams.has('date'))).toBe(true);
 
   await page.getByLabel('Slate date').fill('2026-01-10');
   await expect(page).toHaveURL(/date=2026-01-10/);
@@ -173,6 +180,41 @@ test('explicit unavailable pool status wins over stale provider evidence', async
   await expect(page.getByText('prizepicks pool is stale-served — as of 3h ago')).toBeVisible();
   await expect(page.getByText('0 targetable')).toHaveCount(2);
   await page.screenshot({ path: 'test-results/slate-pool-contradiction.png', fullPage: true });
+});
+
+test('minimum slate freshness payload renders through the browser contract', async ({
+  authenticatedPage: page,
+}) => {
+  await page.clock.setFixedTime(new Date('2026-01-15T12:00:00Z'));
+  await installApiContract(page, {
+    '/api/games/slate': {
+      slate_date: '2026-01-15',
+      freshness: {
+        schedule: { retrieved_at: '2026-01-15T11:00:00Z' },
+        pool: {
+          retrieved_at: null,
+          providers: {
+            prizepicks: { status: 'fresh', retrieved_at: '2026-01-15T11:40:00Z' },
+          },
+        },
+      },
+      games: [
+        {
+          ...slateGame,
+          status: { state: 'final', label: 'Final after review' },
+        },
+      ],
+    },
+  });
+
+  await page.goto('/matchups?date=2026-01-15');
+
+  await expect(page.getByRole('group', { name: 'Data freshness' })).toBeVisible();
+  await expect(page.getByText('Schedule is fresh — as of 1h ago')).toBeVisible();
+  await expect(page.getByText('Player pool is fresh — as of 20m ago')).toBeVisible();
+  await expect(page.getByText('Final after review')).toBeVisible();
+  await expect(page.getByText(/targetable counts use the current player pool/i)).toBeVisible();
+  await page.screenshot({ path: 'test-results/slate-minimum-payload.png', fullPage: true });
 });
 
 test('slate remains usable at a narrow viewport and from the keyboard', async ({

--- a/e2e/specs/slate.spec.js
+++ b/e2e/specs/slate.spec.js
@@ -1,0 +1,92 @@
+import { E2E_AUTH_STORAGE_KEY, expect, installApiContract, test } from '../fixtures/courtai';
+
+test('@critical authenticated user opens a slate and navigates dates', async ({ page }) => {
+  await page.addInitScript((storageKey) => {
+    window.localStorage.setItem(storageKey, 'true');
+  }, E2E_AUTH_STORAGE_KEY);
+  const requests = [];
+  page.on('request', (request) => {
+    if (new URL(request.url()).pathname === '/api/games/slate') requests.push(request.url());
+  });
+  await installApiContract(page);
+
+  await page.goto('/matchups?date=2026-01-15');
+
+  await expect(page.getByRole('heading', { name: 'Thursday, January 15' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'LAL @ BOS' })).toBeVisible();
+  await expect(page.getByText('Los Angeles Lakers')).toBeVisible();
+  await expect(page.getByText('5 targetable')).toBeVisible();
+  await expect(page.getByRole('article').getByText('Pool unavailable')).toBeVisible();
+  await expect(page.getByText(/schedule as of/i)).toBeVisible();
+  await expect(page.getByLabel('Data freshness').getByText('Pool unavailable')).toBeVisible();
+  await page.screenshot({ path: 'test-results/slate-desktop.png', fullPage: true });
+
+  await page.getByRole('button', { name: 'Previous date' }).click();
+  await expect(page).toHaveURL(/date=2026-01-14/);
+  await expect(page.getByText('No games on this slate.')).toBeVisible();
+
+  await page.getByLabel('Slate date').fill('2026-01-10');
+  await expect(page).toHaveURL(/date=2026-01-10/);
+  await expect(page.getByRole('heading', { name: 'NYK @ MIL' })).toBeVisible();
+  await expect(page.getByText('Past slate — player pool unavailable.')).toBeVisible();
+  expect(requests.some((url) => new URL(url).searchParams.get('date') === '2026-01-10')).toBe(true);
+});
+
+test('signed-out matchups keeps the shared shell and does not redirect', async ({ page }) => {
+  await installApiContract(page);
+  await page.goto('/matchups?date=2026-01-15');
+
+  await expect(page).toHaveURL(/\/matchups/);
+  await expect(page.getByRole('navigation', { name: 'Primary' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Matchups' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Sign in to view the slate' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Sign in with Google' })).toBeVisible();
+});
+
+test('unknown paths return to the search landing page', async ({ page }) => {
+  await page.goto('/not-a-route');
+  await expect(page).toHaveURL('/');
+  await expect(page.getByRole('heading', { name: 'CourtAI' })).toBeVisible();
+});
+
+test('a rejected slate request leaves date navigation available', async ({ page }) => {
+  await page.addInitScript((storageKey) => {
+    window.localStorage.setItem(storageKey, 'true');
+  }, E2E_AUTH_STORAGE_KEY);
+  await installApiContract(page, {
+    '/api/games/slate': {
+      status: 503,
+      body: { error: { code: 'provider_unavailable', message: 'Schedule is unavailable.' } },
+    },
+  });
+
+  await page.goto('/matchups?date=2026-01-15');
+
+  await expect(page.getByRole('alert')).toContainText('Schedule is unavailable.');
+  await expect(page.getByRole('button', { name: 'Next date' })).toBeEnabled();
+  await expect(page.getByLabel('Slate date')).toBeEnabled();
+});
+
+test('slate remains usable at a narrow viewport and from the keyboard', async ({ page }) => {
+  await page.setViewportSize({ width: 393, height: 852 });
+  await page.addInitScript((storageKey) => {
+    window.localStorage.setItem(storageKey, 'true');
+  }, E2E_AUTH_STORAGE_KEY);
+  await installApiContract(page);
+  await page.goto('/matchups?date=2026-01-15');
+  await expect(page.getByRole('heading', { name: 'LAL @ BOS' })).toBeVisible();
+
+  const searchLink = page.getByRole('link', { name: 'Search' });
+  await searchLink.focus();
+  await page.keyboard.press('Tab');
+  await expect(page.getByRole('link', { name: 'Matchups' })).toBeFocused();
+  await page.keyboard.press('Tab');
+  await expect(page.getByRole('button', { name: /CourtAI Test User/i })).toBeFocused();
+  await page.keyboard.press('Tab');
+  await expect(page.getByRole('button', { name: 'Previous date' })).toBeFocused();
+
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(
+    true,
+  );
+  await page.screenshot({ path: 'test-results/slate-narrow.png', fullPage: true });
+});

--- a/e2e/specs/slate.spec.js
+++ b/e2e/specs/slate.spec.js
@@ -123,6 +123,58 @@ test('a rejected slate request leaves date navigation available', async ({
   await expect(page.getByLabel('Slate date')).toBeEnabled();
 });
 
+test('an invalid requested date stays neutral until the backend rejects it', async ({
+  authenticatedPage: page,
+}) => {
+  await installApiContract(page, {
+    '/api/games/slate': {
+      status: 400,
+      body: { error: { code: 'invalid_input', message: 'Enter a valid date.' } },
+    },
+  });
+
+  await page.goto('/matchups?date=2026-02-30');
+
+  await expect(page.getByRole('heading', { name: 'Invalid slate date' })).toBeVisible();
+  await expect(page.getByText(/requested date.*2026-02-30.*invalid/i)).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Previous date' })).toBeDisabled();
+  await expect(page.getByRole('button', { name: 'Next date' })).toBeDisabled();
+  await expect(page.getByRole('alert')).toContainText('Enter a valid date.');
+  await page.screenshot({ path: 'test-results/slate-invalid-date.png', fullPage: true });
+});
+
+test('explicit unavailable pool status wins over stale provider evidence', async ({
+  authenticatedPage: page,
+}) => {
+  await page.clock.setFixedTime(new Date('2026-01-15T12:00:00Z'));
+  await installApiContract(page, {
+    '/api/games/slate': slatePayload(
+      '2026-01-15',
+      [
+        {
+          ...slateGame,
+          away_team: { ...slateGame.away_team, targetable_player_count: 0 },
+          home_team: { ...slateGame.home_team, targetable_player_count: 0 },
+        },
+      ],
+      {
+        poolStatus: 'unavailable',
+        poolFreshnessStatus: 'unavailable',
+        providers: {
+          prizepicks: { status: 'stale-served', retrieved_at: '2026-01-15T09:00:00Z' },
+        },
+      },
+    ),
+  });
+
+  await page.goto('/matchups?date=2026-01-15');
+
+  await expect(page.getByText(/player pool unavailable; no targetable players/i)).toBeVisible();
+  await expect(page.getByText('prizepicks pool is stale-served — as of 3h ago')).toBeVisible();
+  await expect(page.getByText('0 targetable')).toHaveCount(2);
+  await page.screenshot({ path: 'test-results/slate-pool-contradiction.png', fullPage: true });
+});
+
 test('slate remains usable at a narrow viewport and from the keyboard', async ({
   authenticatedPage: page,
 }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react-bootstrap": "^2.10.2",
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.3.1",
+        "react-router-dom": "^7.18.2",
         "react-slider": "^2.0.6",
         "recharts": "^2.12.7"
       },
@@ -9592,6 +9593,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/core-js-compat": {
       "version": "3.50.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.50.0.tgz",
@@ -17355,6 +17369,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/react-slider": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/react-slider/-/react-slider-2.0.6.tgz",
@@ -17817,6 +17869,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:debug": "playwright test --debug",
     "lint": "eslint .",
-    "format:check": "prettier --check package.json README.md index.html src e2e docs playwright.config.mjs vite.config.mjs babel.config.cjs eslint.config.mjs postcss.config.js tailwind.config.js .github/workflows .prettierrc.json",
-    "format": "prettier --write package.json README.md index.html src e2e docs playwright.config.mjs vite.config.mjs babel.config.cjs eslint.config.mjs postcss.config.js tailwind.config.js .github/workflows .prettierrc.json"
+    "format:check": "prettier --check package.json vercel.json README.md index.html src e2e docs playwright.config.mjs vite.config.mjs babel.config.cjs eslint.config.mjs postcss.config.js tailwind.config.js .github/workflows .prettierrc.json",
+    "format": "prettier --write package.json vercel.json README.md index.html src e2e docs playwright.config.mjs vite.config.mjs babel.config.cjs eslint.config.mjs postcss.config.js tailwind.config.js .github/workflows .prettierrc.json"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-bootstrap": "^2.10.2",
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.3.1",
+    "react-router-dom": "^7.18.2",
     "react-slider": "^2.0.6",
     "recharts": "^2.12.7"
   },

--- a/src/App.css
+++ b/src/App.css
@@ -7,6 +7,71 @@
     -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Inter', 'SF Pro Display', system-ui, sans-serif;
 }
 
+.app-header {
+  position: relative;
+  z-index: 2001;
+  border-bottom: 1px solid var(--ct-line);
+  background: rgba(13, 11, 7, 0.94);
+}
+
+.app-nav {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  width: min(1160px, calc(100% - 32px));
+  min-height: 68px;
+  margin: 0 auto;
+  gap: 24px;
+}
+
+.app-nav a {
+  color: var(--ct-dim);
+  text-decoration: none;
+}
+
+.app-nav a:hover,
+.app-nav a.active {
+  color: var(--ct-gold);
+}
+
+.app-brand {
+  justify-self: start;
+  color: var(--ct-text) !important;
+  font-family: var(--ct-display);
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.app-links {
+  display: flex;
+  gap: 24px;
+  font-size: 0.88rem;
+}
+
+.app-auth {
+  justify-self: end;
+}
+
+@media (max-width: 620px) {
+  .app-nav {
+    grid-template-columns: auto 1fr;
+    width: min(100% - 20px, 1160px);
+    gap: 10px;
+  }
+
+  .app-links {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    justify-content: center;
+    padding-bottom: 12px;
+  }
+
+  .app-auth {
+    grid-column: 2;
+    grid-row: 1;
+  }
+}
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/src/App.css
+++ b/src/App.css
@@ -34,6 +34,11 @@
   color: var(--ct-gold);
 }
 
+.app-nav a:focus-visible {
+  outline: 2px solid var(--ct-gold);
+  outline-offset: 2px;
+}
+
 .app-brand {
   justify-self: start;
   color: var(--ct-text) !important;

--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,7 @@
-import { AuthProvider } from './contexts/AuthContext';
+import { AuthProvider, useAuth } from './contexts/AuthContext';
 import ProtectedRoute from './components/Auth/ProtectedRoute';
 import GameLogFilter from './GameLogFilter.js';
 import { BrowserRouter, Navigate, NavLink, Route, Routes } from 'react-router-dom';
-import { useAuth } from './contexts/AuthContext';
 import LoginButton from './components/Auth/LoginButton';
 import UserProfile from './components/Auth/UserProfile';
 import SlatePage from './SlatePage';

--- a/src/App.js
+++ b/src/App.js
@@ -1,16 +1,51 @@
 import { AuthProvider } from './contexts/AuthContext';
 import ProtectedRoute from './components/Auth/ProtectedRoute';
 import GameLogFilter from './GameLogFilter.js';
+import { BrowserRouter, Navigate, NavLink, Route, Routes } from 'react-router-dom';
+import { useAuth } from './contexts/AuthContext';
+import LoginButton from './components/Auth/LoginButton';
+import UserProfile from './components/Auth/UserProfile';
+import SlatePage from './SlatePage';
 import './App.css';
+
+function AppNav() {
+  const { isAuthenticated } = useAuth();
+
+  return (
+    <header className="app-header">
+      <nav className="app-nav" aria-label="Primary">
+        <NavLink className="app-brand" to="/">
+          CourtAI
+        </NavLink>
+        <div className="app-links">
+          <NavLink to="/" end>
+            Search
+          </NavLink>
+          <NavLink to="/matchups">Matchups</NavLink>
+        </div>
+        <div className="app-auth">
+          {isAuthenticated ? <UserProfile /> : <LoginButton size="sm" />}
+        </div>
+      </nav>
+    </header>
+  );
+}
 
 function App() {
   return (
     <AuthProvider>
-      <div className="App">
-        <ProtectedRoute>
-          <GameLogFilter />
-        </ProtectedRoute>
-      </div>
+      <BrowserRouter>
+        <div className="App">
+          <ProtectedRoute>
+            <AppNav />
+            <Routes>
+              <Route path="/" element={<GameLogFilter />} />
+              <Route path="/matchups" element={<SlatePage />} />
+              <Route path="*" element={<Navigate to="/" replace />} />
+            </Routes>
+          </ProtectedRoute>
+        </div>
+      </BrowserRouter>
     </AuthProvider>
   );
 }

--- a/src/ModernSearch.css
+++ b/src/ModernSearch.css
@@ -55,13 +55,6 @@
   text-align: center;
 }
 
-.landing-auth-section {
-  position: fixed;
-  top: 20px;
-  left: 20px;
-  z-index: 1000;
-}
-
 /* Help icon on right side of search bar */
 .landing-help-icon-right {
   position: absolute;

--- a/src/NaturalLanguageQuery.js
+++ b/src/NaturalLanguageQuery.js
@@ -3,8 +3,6 @@ import { Form, Button, Modal } from 'react-bootstrap';
 import { Search, CheckCircle, AlertCircle, Brain, HelpCircle } from 'lucide-react';
 import { apiClient, getApiUrl } from './config';
 import { useAuth } from './contexts/AuthContext';
-import LoginButton from './components/Auth/LoginButton';
-import UserProfile from './components/Auth/UserProfile';
 import { convertNLToFilters } from './filterUtils';
 import { getRequestErrorMessage, isRequestCancelled } from './gameLogsApi';
 import './ModernSearch.css';
@@ -197,9 +195,6 @@ const NaturalLanguageQuery = ({
         </svg>
         <div className="landing-container">
           <div className="landing-header">
-            <div className="landing-auth-section">
-              {isAuthenticated ? <UserProfile /> : <LoginButton size="sm" />}
-            </div>
             <h1 className="landing-title">
               <span className="dynamic-title-text">CourtAI</span>
             </h1>

--- a/src/SlatePage.css
+++ b/src/SlatePage.css
@@ -1,0 +1,185 @@
+.slate-page {
+  width: min(1080px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 52px 0 80px;
+  text-align: left;
+}
+
+.slate-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: end;
+  gap: 24px;
+  border-bottom: 1px solid var(--ct-line);
+  padding-bottom: 24px;
+}
+
+.slate-heading h1,
+.signed-out-slate h1 {
+  margin: 0;
+  font-size: clamp(2.2rem, 6vw, 4.6rem);
+  line-height: 0.95;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: var(--ct-gold);
+  font-family: var(--ct-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.date-controls {
+  display: flex;
+  align-items: end;
+  gap: 8px;
+}
+
+.date-controls label {
+  display: grid;
+  gap: 5px;
+  color: var(--ct-dim);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.date-controls button,
+.date-controls input {
+  min-height: 42px;
+  border: 1px solid var(--ct-line-strong);
+  border-radius: var(--ct-radius-ctl);
+  background: var(--ct-surface-2);
+  color: var(--ct-text);
+}
+
+.date-controls button {
+  width: 42px;
+  font-size: 1.2rem;
+}
+
+.date-controls button:focus-visible,
+.date-controls input:focus-visible,
+.app-nav a:focus-visible {
+  outline: 2px solid var(--ct-gold);
+  outline-offset: 2px;
+}
+
+.freshness {
+  display: flex;
+  gap: 20px;
+  padding: 18px 0;
+  color: var(--ct-dim);
+  font-family: var(--ct-mono);
+  font-size: 0.76rem;
+}
+
+.freshness-warning,
+.past-notice {
+  color: var(--ct-gold);
+}
+
+.slate-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.slate-card,
+.empty-slate,
+.signed-out-slate {
+  border: 1px solid var(--ct-line);
+  border-radius: var(--ct-radius-card);
+  background: var(--ct-surface);
+}
+
+.slate-card {
+  padding: 22px;
+}
+
+.slate-card-topline,
+.team-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.slate-card-topline {
+  color: var(--ct-dim);
+  font-family: var(--ct-mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+}
+
+.slate-card h2 {
+  margin: 22px 0;
+  font-size: 2.1rem;
+}
+
+.team-row {
+  border-top: 1px solid var(--ct-line);
+  padding: 11px 0;
+}
+
+.team-row span:last-child,
+.pool-status {
+  color: var(--ct-dim);
+  font-family: var(--ct-mono);
+  font-size: 0.76rem;
+}
+
+.badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.slate-badge {
+  border: 1px solid var(--ct-gold);
+  border-radius: 999px;
+  padding: 3px 8px;
+  color: var(--ct-gold);
+  font-size: 0.72rem;
+}
+
+.empty-slate,
+.signed-out-slate {
+  margin-top: 28px;
+  padding: clamp(28px, 6vw, 64px);
+}
+
+@media (max-width: 700px) {
+  .slate-page {
+    width: min(100% - 20px, 1080px);
+    padding-top: 30px;
+  }
+
+  .slate-heading {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .date-controls {
+    justify-content: space-between;
+  }
+
+  .date-controls label {
+    flex: 1;
+  }
+
+  .date-controls input {
+    width: 100%;
+  }
+
+  .freshness {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 5px;
+  }
+
+  .slate-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/SlatePage.css
+++ b/src/SlatePage.css
@@ -59,6 +59,11 @@
   font-size: 1.2rem;
 }
 
+.date-controls .today-reset {
+  width: auto;
+  padding: 0 14px;
+}
+
 .date-controls button:focus-visible,
 .date-controls input:focus-visible {
   outline: 2px solid var(--ct-gold);

--- a/src/SlatePage.css
+++ b/src/SlatePage.css
@@ -145,8 +145,7 @@
   padding: 11px 0;
 }
 
-.team-row span:last-child,
-.pool-status {
+.team-row span:last-child {
   color: var(--ct-dim);
   font-family: var(--ct-mono);
   font-size: 0.76rem;

--- a/src/SlatePage.css
+++ b/src/SlatePage.css
@@ -60,14 +60,14 @@
 }
 
 .date-controls button:focus-visible,
-.date-controls input:focus-visible,
-.app-nav a:focus-visible {
+.date-controls input:focus-visible {
   outline: 2px solid var(--ct-gold);
   outline-offset: 2px;
 }
 
 .freshness {
   display: flex;
+  flex-wrap: wrap;
   gap: 20px;
   padding: 18px 0;
   color: var(--ct-dim);
@@ -75,9 +75,32 @@
   font-size: 0.76rem;
 }
 
-.freshness-warning,
-.past-notice {
+.freshness-warning {
   color: var(--ct-gold);
+}
+
+.pool-summary {
+  margin-bottom: 18px;
+  border: 1px solid var(--ct-line);
+  border-radius: var(--ct-radius-ctl);
+  padding: 14px 18px;
+  background: var(--ct-surface-2);
+}
+
+.pool-summary h2,
+.pool-summary p {
+  margin: 0;
+}
+
+.pool-summary h2 {
+  margin-bottom: 4px;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+}
+
+.pool-summary p {
+  color: var(--ct-dim);
+  font-size: 0.88rem;
 }
 
 .slate-grid {

--- a/src/SlatePage.js
+++ b/src/SlatePage.js
@@ -1,11 +1,11 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useAuth } from './contexts/AuthContext';
 import { fetchSlate } from './slateApi';
 import { getRequestErrorMessage, isRequestCancelled } from './gameLogsApi';
+import { isCalendarDate } from './calendarDate';
 import './SlatePage.css';
 
-const datePattern = /^\d{4}-\d{2}-\d{2}$/;
 const getTodaySlateDate = () => {
   const formatter = new Intl.DateTimeFormat('en-CA', {
     timeZone: 'America/New_York',
@@ -17,11 +17,7 @@ const getTodaySlateDate = () => {
 };
 
 const parseSlateDate = (value) => {
-  if (!value || !datePattern.test(value)) return null;
-  const parsed = new Date(`${value}T12:00:00Z`);
-  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value
-    ? value
-    : null;
+  return isCalendarDate(value) ? value : null;
 };
 
 const shiftDate = (date, days) => {
@@ -74,9 +70,9 @@ const statusPresentations = {
 };
 
 const surfaceStatusText = (name, surface) => {
-  const age = surface.retrievedAt ? ` as of ${formatAge(surface.retrievedAt)}` : '';
+  const age = surface.retrievedAt ? ` — as of ${formatAge(surface.retrievedAt)}` : '';
   const label = statusPresentations[surface.status].label;
-  return `${name} is ${label}${age ? ` — ${age.trimStart()}` : ''}`;
+  return `${name} is ${label}${age}`;
 };
 
 function SurfaceFreshness({ name, surface }) {
@@ -104,9 +100,20 @@ function Freshness({ freshness }) {
 }
 
 function PoolSummary({ isPast, poolStatus }) {
-  const message = isPast
-    ? 'Past slate — no player pool is available for historical dates.'
-    : statusPresentations[poolStatus].poolMessage;
+  let message = statusPresentations[poolStatus].poolMessage;
+  if (isPast) {
+    const historicalMessages = {
+      fresh:
+        'Past slate — the current player pool is not displayed for historical dates. Final game cards retain the posted targetable counts returned for this slate.',
+      'stale-served':
+        'Past slate — the latest available snapshot is not displayed for historical dates. Final game cards retain the posted targetable counts returned for this slate.',
+      missing:
+        'Past slate — the player pool is missing and no current pool is displayed. Game cards retain the targetable counts returned for this slate.',
+      unavailable:
+        'Past slate — the player pool is unavailable and no current pool is displayed. Game cards retain the returned targetable counts for this slate.',
+    };
+    message = historicalMessages[poolStatus];
+  }
 
   return (
     <section className="pool-summary" aria-labelledby="player-pool-heading">
@@ -148,7 +155,7 @@ export default function SlatePage() {
   const { isAuthenticated, loading: authLoading } = useAuth();
   const [searchParams, setSearchParams] = useSearchParams();
   const requestedDate = searchParams.get('date');
-  const todaySlateDate = useMemo(getTodaySlateDate, []);
+  const todaySlateDate = getTodaySlateDate();
   const parsedRequestedDate = parseSlateDate(requestedDate);
   const provisionalDate = parsedRequestedDate || todaySlateDate;
   const [state, setState] = useState({ status: 'idle', slate: null, error: null });

--- a/src/SlatePage.js
+++ b/src/SlatePage.js
@@ -1,0 +1,188 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useAuth } from './contexts/AuthContext';
+import { fetchSlate } from './slateApi';
+import { getRequestErrorMessage, isRequestCancelled } from './gameLogsApi';
+import './SlatePage.css';
+
+const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+const today = () => {
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/New_York',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  return formatter.format(new Date());
+};
+
+const shiftDate = (date, days) => {
+  const value = new Date(`${date}T12:00:00Z`);
+  value.setUTCDate(value.getUTCDate() + days);
+  return value.toISOString().slice(0, 10);
+};
+
+const formatSlateDate = (date) =>
+  new Intl.DateTimeFormat(undefined, {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(`${date}T12:00:00Z`));
+
+const formatTip = (date) =>
+  new Intl.DateTimeFormat(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(new Date(date));
+
+const formatAge = (retrievedAt) => {
+  if (!retrievedAt) return 'unavailable';
+  const minutes = Math.max(0, Math.round((Date.now() - new Date(retrievedAt).getTime()) / 60000));
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) return `${hours}h ago`;
+  return `${Math.round(hours / 24)}d ago`;
+};
+
+function Freshness({ freshness }) {
+  const schedule = freshness.schedule || {};
+  const pool = freshness.pool || {};
+  return (
+    <div className="freshness" aria-label="Data freshness">
+      <span className={schedule.status !== 'fresh' ? 'freshness-warning' : ''}>
+        Schedule as of {formatAge(schedule.retrieved_at)}
+      </span>
+      <span className={pool.status !== 'fresh' ? 'freshness-warning' : ''}>
+        Pool {pool.status === 'fresh' ? `as of ${formatAge(pool.retrieved_at)}` : 'unavailable'}
+      </span>
+    </div>
+  );
+}
+
+function GameCard({ game, poolStatus }) {
+  const status = game.status === 'final' ? 'Final' : game.statusLabel;
+  return (
+    <article className="slate-card">
+      <div className="slate-card-topline">
+        <span>{formatTip(game.scheduledAt)}</span>
+        <span>{status}</span>
+      </div>
+      <h2>
+        {game.away.tricode} @ {game.home.tricode}
+      </h2>
+      <div className="team-row">
+        <span>{game.away.name}</span>
+        <span>{game.targetableCounts.away} targetable</span>
+      </div>
+      <div className="team-row">
+        <span>{game.home.name}</span>
+        <span>{game.targetableCounts.home} targetable</span>
+      </div>
+      <div className="badges">
+        {game.classification && <span className="slate-badge">{game.classification}</span>}
+        {game.preseason && <span className="slate-badge">Preseason</span>}
+        {game.status === 'postponed' && <span className="slate-badge">Postponed</span>}
+      </div>
+      {poolStatus === 'unavailable' && <p className="pool-status">Pool unavailable</p>}
+    </article>
+  );
+}
+
+export default function SlatePage() {
+  const { isAuthenticated, loading: authLoading } = useAuth();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const requestedDate = searchParams.get('date');
+  const date = requestedDate && datePattern.test(requestedDate) ? requestedDate : today();
+  const [state, setState] = useState({ status: 'idle', slate: null, error: null });
+  const isPast = useMemo(() => date < today(), [date]);
+
+  useEffect(() => {
+    if (authLoading || !isAuthenticated) {
+      setState({ status: 'idle', slate: null, error: null });
+      return undefined;
+    }
+    const controller = new AbortController();
+    setState({ status: 'loading', slate: null, error: null });
+    fetchSlate(requestedDate ? date : undefined, { signal: controller.signal })
+      .then((slate) => setState({ status: 'ready', slate, error: null }))
+      .catch((error) => {
+        if (!isRequestCancelled(error)) {
+          const contractMessage = error.response?.data?.error?.message;
+          setState({
+            status: 'error',
+            slate: null,
+            error:
+              typeof contractMessage === 'string'
+                ? contractMessage
+                : getRequestErrorMessage(error, 'Unable to load this slate. Please try again.'),
+          });
+        }
+      });
+    return () => controller.abort();
+  }, [authLoading, date, isAuthenticated, requestedDate]);
+
+  const navigate = (nextDate) => setSearchParams({ date: nextDate });
+
+  if (!authLoading && !isAuthenticated) {
+    return (
+      <main className="slate-page signed-out-slate">
+        <h1>Sign in to view the slate</h1>
+        <p>Use the sign-in control in the navigation to load schedule and player-pool data.</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="slate-page">
+      <section className="slate-heading">
+        <p className="eyebrow">NBA slate</p>
+        <h1>{formatSlateDate(date)}</h1>
+        <div className="date-controls">
+          <button
+            type="button"
+            aria-label="Previous date"
+            onClick={() => navigate(shiftDate(date, -1))}
+          >
+            ←
+          </button>
+          <label>
+            <span>Slate date</span>
+            <input
+              aria-label="Slate date"
+              type="date"
+              value={date}
+              onChange={(event) => navigate(event.target.value)}
+            />
+          </label>
+          <button type="button" aria-label="Next date" onClick={() => navigate(shiftDate(date, 1))}>
+            →
+          </button>
+        </div>
+      </section>
+
+      {state.status === 'loading' && <p role="status">Loading slate…</p>}
+      {state.status === 'error' && <p role="alert">{state.error}</p>}
+      {state.status === 'ready' && (
+        <>
+          <Freshness freshness={state.slate.freshness} />
+          {isPast && state.slate.poolStatus === 'unavailable' && (
+            <p className="past-notice">Past slate — player pool unavailable.</p>
+          )}
+          {state.slate.games.length === 0 ? (
+            <div className="empty-slate">
+              <h2>No games on this slate.</h2>
+              <p>Choose another date to keep browsing the season.</p>
+            </div>
+          ) : (
+            <div className="slate-grid">
+              {state.slate.games.map((game) => (
+                <GameCard key={game.gameId} game={game} poolStatus={state.slate.poolStatus} />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </main>
+  );
+}

--- a/src/SlatePage.js
+++ b/src/SlatePage.js
@@ -32,35 +32,50 @@ const surfaceStatusText = (name, surface, presentation) => {
   return `${name} is ${presentation.status}${age}${thresholdNote}`;
 };
 
-const useMinuteTick = () => {
-  const [, setTick] = useState(0);
+const useMinuteNow = (enabled) => {
+  const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
-    const interval = setInterval(() => setTick((tick) => tick + 1), 60000);
+    if (!enabled) return undefined;
+    setNow(Date.now());
+    const interval = setInterval(() => setNow(Date.now()), 60000);
     return () => clearInterval(interval);
-  }, []);
+  }, [enabled]);
+  return now;
 };
 
-function SurfaceFreshness({ name, surface, surfaceName }) {
-  const presentation = getSurfaceFreshnessPresentation(surface, surfaceName);
+function SurfaceFreshness({ name, surface, surfaceName, now, presentation }) {
+  const effectivePresentation =
+    presentation || getSurfaceFreshnessPresentation(surface, surfaceName, now);
   return (
-    <span className={presentation.warning ? 'freshness-warning' : undefined}>
-      {surfaceStatusText(name, surface, presentation)}
+    <span className={effectivePresentation.warning ? 'freshness-warning' : undefined}>
+      {surfaceStatusText(name, surface, effectivePresentation)}
     </span>
   );
 }
 
-function Freshness({ freshness }) {
-  useMinuteTick();
+function Freshness({ freshness, now, poolPresentation }) {
   return (
     <div className="freshness" role="group" aria-label="Data freshness">
-      <SurfaceFreshness name="Schedule" surface={freshness.schedule} surfaceName="schedule" />
-      <SurfaceFreshness name="Player pool" surface={freshness.pool} surfaceName="pool" />
+      <SurfaceFreshness
+        name="Schedule"
+        surface={freshness.schedule}
+        surfaceName="schedule"
+        now={now}
+      />
+      <SurfaceFreshness
+        name="Player pool"
+        surface={freshness.pool}
+        surfaceName="pool"
+        now={now}
+        presentation={poolPresentation}
+      />
       {freshness.pool.providers.map((provider) => (
         <SurfaceFreshness
           key={provider.name}
           name={`${provider.name} pool`}
           surface={provider}
           surfaceName="pool"
+          now={now}
         />
       ))}
     </div>
@@ -116,6 +131,7 @@ export default function SlatePage() {
   const parsedRequestedDate = parseCalendarDate(requestedDate);
   const invalidRequestedDate = requestedDate !== null && !parsedRequestedDate;
   const [state, setState] = useState({ status: 'idle', slate: null, error: null });
+  const now = useMinuteNow(state.status === 'ready');
   const slateDate =
     state.status === 'ready'
       ? state.slate.slateDate
@@ -123,6 +139,16 @@ export default function SlatePage() {
         ? null
         : parsedRequestedDate || todaySlateDate;
   const isPast = slateDate ? slateDate < todaySlateDate : false;
+  const poolPresentation =
+    state.status === 'ready'
+      ? getSurfaceFreshnessPresentation(state.slate.freshness.pool, 'pool', now)
+      : null;
+  const effectivePoolStatus =
+    state.status === 'ready' && state.slate.poolStatus === 'fresh'
+      ? poolPresentation.status
+      : state.status === 'ready'
+        ? state.slate.poolStatus
+        : null;
 
   useEffect(() => {
     if (authLoading || !isAuthenticated) {
@@ -200,8 +226,12 @@ export default function SlatePage() {
       {state.status === 'error' && <p role="alert">{state.error}</p>}
       {state.status === 'ready' && (
         <>
-          <Freshness freshness={state.slate.freshness} />
-          <PoolSummary isPast={isPast} poolStatus={state.slate.poolStatus} />
+          <Freshness
+            freshness={state.slate.freshness}
+            now={now}
+            poolPresentation={poolPresentation}
+          />
+          <PoolSummary isPast={isPast} poolStatus={effectivePoolStatus} />
           {state.slate.games.length === 0 ? (
             <div className="empty-slate">
               <h2>No games on this slate.</h2>

--- a/src/SlatePage.js
+++ b/src/SlatePage.js
@@ -6,7 +6,7 @@ import { getRequestErrorMessage, isRequestCancelled } from './gameLogsApi';
 import './SlatePage.css';
 
 const datePattern = /^\d{4}-\d{2}-\d{2}$/;
-const today = () => {
+const getTodaySlateDate = () => {
   const formatter = new Intl.DateTimeFormat('en-CA', {
     timeZone: 'America/New_York',
     year: 'numeric',
@@ -14,6 +14,14 @@ const today = () => {
     day: '2-digit',
   });
   return formatter.format(new Date());
+};
+
+const parseSlateDate = (value) => {
+  if (!value || !datePattern.test(value)) return null;
+  const parsed = new Date(`${value}T12:00:00Z`);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value
+    ? value
+    : null;
 };
 
 const shiftDate = (date, days) => {
@@ -37,7 +45,6 @@ const formatTip = (date) =>
   }).format(new Date(date));
 
 const formatAge = (retrievedAt) => {
-  if (!retrievedAt) return 'unavailable';
   const minutes = Math.max(0, Math.round((Date.now() - new Date(retrievedAt).getTime()) / 60000));
   if (minutes < 60) return `${minutes}m ago`;
   const hours = Math.round(minutes / 60);
@@ -45,22 +52,71 @@ const formatAge = (retrievedAt) => {
   return `${Math.round(hours / 24)}d ago`;
 };
 
+const statusPresentations = {
+  fresh: {
+    label: 'fresh',
+    poolMessage: 'Targetable counts use the current player pool.',
+  },
+  stale: { label: 'stale' },
+  'stale-served': {
+    label: 'stale-served',
+    poolMessage:
+      'Player pool is stale-served; targetable counts use the latest available snapshot.',
+  },
+  missing: {
+    label: 'missing',
+    poolMessage: 'Player pool unavailable; no targetable players are currently available.',
+  },
+  unavailable: {
+    label: 'unavailable',
+    poolMessage: 'Player pool unavailable; no targetable players are currently available.',
+  },
+};
+
+const surfaceStatusText = (name, surface) => {
+  const age = surface.retrievedAt ? ` as of ${formatAge(surface.retrievedAt)}` : '';
+  const label = statusPresentations[surface.status].label;
+  return `${name} is ${label}${age ? ` — ${age.trimStart()}` : ''}`;
+};
+
+function SurfaceFreshness({ name, surface }) {
+  const warning = surface.status !== 'fresh';
+  return (
+    <span
+      className={warning ? 'freshness-warning' : undefined}
+      role={warning ? 'alert' : undefined}
+    >
+      {surfaceStatusText(name, surface)}
+    </span>
+  );
+}
+
 function Freshness({ freshness }) {
-  const schedule = freshness.schedule || {};
-  const pool = freshness.pool || {};
   return (
     <div className="freshness" aria-label="Data freshness">
-      <span className={schedule.status !== 'fresh' ? 'freshness-warning' : ''}>
-        Schedule as of {formatAge(schedule.retrieved_at)}
-      </span>
-      <span className={pool.status !== 'fresh' ? 'freshness-warning' : ''}>
-        Pool {pool.status === 'fresh' ? `as of ${formatAge(pool.retrieved_at)}` : 'unavailable'}
-      </span>
+      <SurfaceFreshness name="Schedule" surface={freshness.schedule} />
+      <SurfaceFreshness name="Player pool" surface={freshness.pool} />
+      {freshness.pool.providers.map((provider) => (
+        <SurfaceFreshness key={provider.name} name={`${provider.name} pool`} surface={provider} />
+      ))}
     </div>
   );
 }
 
-function GameCard({ game, poolStatus }) {
+function PoolSummary({ isPast, poolStatus }) {
+  const message = isPast
+    ? 'Past slate — no player pool is available for historical dates.'
+    : statusPresentations[poolStatus].poolMessage;
+
+  return (
+    <section className="pool-summary" aria-labelledby="player-pool-heading">
+      <h2 id="player-pool-heading">Player pool</h2>
+      <p>{message}</p>
+    </section>
+  );
+}
+
+function GameCard({ game }) {
   const status = game.status === 'final' ? 'Final' : game.statusLabel;
   return (
     <article className="slate-card">
@@ -73,18 +129,17 @@ function GameCard({ game, poolStatus }) {
       </h2>
       <div className="team-row">
         <span>{game.away.name}</span>
-        <span>{game.targetableCounts.away} targetable</span>
+        <span>{game.away.targetablePlayerCount} targetable</span>
       </div>
       <div className="team-row">
         <span>{game.home.name}</span>
-        <span>{game.targetableCounts.home} targetable</span>
+        <span>{game.home.targetablePlayerCount} targetable</span>
       </div>
       <div className="badges">
         {game.classification && <span className="slate-badge">{game.classification}</span>}
         {game.preseason && <span className="slate-badge">Preseason</span>}
         {game.status === 'postponed' && <span className="slate-badge">Postponed</span>}
       </div>
-      {poolStatus === 'unavailable' && <p className="pool-status">Pool unavailable</p>}
     </article>
   );
 }
@@ -93,9 +148,12 @@ export default function SlatePage() {
   const { isAuthenticated, loading: authLoading } = useAuth();
   const [searchParams, setSearchParams] = useSearchParams();
   const requestedDate = searchParams.get('date');
-  const date = requestedDate && datePattern.test(requestedDate) ? requestedDate : today();
+  const todaySlateDate = useMemo(getTodaySlateDate, []);
+  const parsedRequestedDate = parseSlateDate(requestedDate);
+  const provisionalDate = parsedRequestedDate || todaySlateDate;
   const [state, setState] = useState({ status: 'idle', slate: null, error: null });
-  const isPast = useMemo(() => date < today(), [date]);
+  const slateDate = state.status === 'ready' ? state.slate.slateDate : provisionalDate;
+  const isPast = slateDate < todaySlateDate;
 
   useEffect(() => {
     if (authLoading || !isAuthenticated) {
@@ -104,23 +162,19 @@ export default function SlatePage() {
     }
     const controller = new AbortController();
     setState({ status: 'loading', slate: null, error: null });
-    fetchSlate(requestedDate ? date : undefined, { signal: controller.signal })
+    fetchSlate(requestedDate || undefined, { signal: controller.signal })
       .then((slate) => setState({ status: 'ready', slate, error: null }))
       .catch((error) => {
         if (!isRequestCancelled(error)) {
-          const contractMessage = error.response?.data?.error?.message;
           setState({
             status: 'error',
             slate: null,
-            error:
-              typeof contractMessage === 'string'
-                ? contractMessage
-                : getRequestErrorMessage(error, 'Unable to load this slate. Please try again.'),
+            error: getRequestErrorMessage(error, 'Unable to load this slate. Please try again.'),
           });
         }
       });
     return () => controller.abort();
-  }, [authLoading, date, isAuthenticated, requestedDate]);
+  }, [authLoading, isAuthenticated, requestedDate]);
 
   const navigate = (nextDate) => setSearchParams({ date: nextDate });
 
@@ -137,12 +191,12 @@ export default function SlatePage() {
     <main className="slate-page">
       <section className="slate-heading">
         <p className="eyebrow">NBA slate</p>
-        <h1>{formatSlateDate(date)}</h1>
+        <h1>{formatSlateDate(slateDate)}</h1>
         <div className="date-controls">
           <button
             type="button"
             aria-label="Previous date"
-            onClick={() => navigate(shiftDate(date, -1))}
+            onClick={() => navigate(shiftDate(slateDate, -1))}
           >
             ←
           </button>
@@ -151,11 +205,15 @@ export default function SlatePage() {
             <input
               aria-label="Slate date"
               type="date"
-              value={date}
+              value={slateDate}
               onChange={(event) => navigate(event.target.value)}
             />
           </label>
-          <button type="button" aria-label="Next date" onClick={() => navigate(shiftDate(date, 1))}>
+          <button
+            type="button"
+            aria-label="Next date"
+            onClick={() => navigate(shiftDate(slateDate, 1))}
+          >
             →
           </button>
         </div>
@@ -166,9 +224,7 @@ export default function SlatePage() {
       {state.status === 'ready' && (
         <>
           <Freshness freshness={state.slate.freshness} />
-          {isPast && state.slate.poolStatus === 'unavailable' && (
-            <p className="past-notice">Past slate — player pool unavailable.</p>
-          )}
+          <PoolSummary isPast={isPast} poolStatus={state.slate.poolStatus} />
           {state.slate.games.length === 0 ? (
             <div className="empty-slate">
               <h2>No games on this slate.</h2>
@@ -177,7 +233,7 @@ export default function SlatePage() {
           ) : (
             <div className="slate-grid">
               {state.slate.games.map((game) => (
-                <GameCard key={game.gameId} game={game} poolStatus={state.slate.poolStatus} />
+                <GameCard key={game.gameId} game={game} />
               ))}
             </div>
           )}

--- a/src/SlatePage.js
+++ b/src/SlatePage.js
@@ -186,6 +186,11 @@ export default function SlatePage() {
           >
             →
           </button>
+          {!slateDate && (
+            <button className="today-reset" type="button" onClick={() => navigate('')}>
+              Today
+            </button>
+          )}
         </div>
       </section>
 

--- a/src/SlatePage.js
+++ b/src/SlatePage.js
@@ -9,7 +9,7 @@ import {
   parseCalendarDate,
   shiftCalendarDate,
 } from './calendarDate';
-import { getStatusPresentation } from './slateStatus';
+import { getStatusPresentation, getSurfaceFreshnessPresentation } from './slateStatus';
 import './SlatePage.css';
 
 const formatTip = (date) =>
@@ -26,9 +26,10 @@ const formatAge = (retrievedAt) => {
   return `${Math.round(hours / 24)}d ago`;
 };
 
-const surfaceStatusText = (name, surface) => {
+const surfaceStatusText = (name, surface, presentation) => {
   const age = surface.retrievedAt ? ` — as of ${formatAge(surface.retrievedAt)}` : '';
-  return `${name} is ${surface.status}${age}`;
+  const thresholdNote = presentation.thresholdNote ? ` (${presentation.thresholdNote})` : '';
+  return `${name} is ${presentation.status}${age}${thresholdNote}`;
 };
 
 const useMinuteTick = () => {
@@ -39,11 +40,11 @@ const useMinuteTick = () => {
   }, []);
 };
 
-function SurfaceFreshness({ name, surface }) {
-  const warning = getStatusPresentation(surface.status).warning;
+function SurfaceFreshness({ name, surface, surfaceName }) {
+  const presentation = getSurfaceFreshnessPresentation(surface, surfaceName);
   return (
-    <span className={warning ? 'freshness-warning' : undefined}>
-      {surfaceStatusText(name, surface)}
+    <span className={presentation.warning ? 'freshness-warning' : undefined}>
+      {surfaceStatusText(name, surface, presentation)}
     </span>
   );
 }
@@ -52,10 +53,15 @@ function Freshness({ freshness }) {
   useMinuteTick();
   return (
     <div className="freshness" role="group" aria-label="Data freshness">
-      <SurfaceFreshness name="Schedule" surface={freshness.schedule} />
-      <SurfaceFreshness name="Player pool" surface={freshness.pool} />
+      <SurfaceFreshness name="Schedule" surface={freshness.schedule} surfaceName="schedule" />
+      <SurfaceFreshness name="Player pool" surface={freshness.pool} surfaceName="pool" />
       {freshness.pool.providers.map((provider) => (
-        <SurfaceFreshness key={provider.name} name={`${provider.name} pool`} surface={provider} />
+        <SurfaceFreshness
+          key={provider.name}
+          name={`${provider.name} pool`}
+          surface={provider}
+          surfaceName="pool"
+        />
       ))}
     </div>
   );
@@ -74,7 +80,8 @@ function PoolSummary({ isPast, poolStatus }) {
 }
 
 function GameCard({ game }) {
-  const status = game.statusLabel || (game.status === 'final' ? 'Final' : game.status);
+  const fallbackLabels = { scheduled: 'Scheduled', postponed: 'Postponed', final: 'Final' };
+  const status = game.statusLabel || fallbackLabels[game.status];
   return (
     <article className="slate-card">
       <div className="slate-card-topline">
@@ -166,7 +173,6 @@ export default function SlatePage() {
           <label>
             <span>Slate date</span>
             <input
-              aria-label="Slate date"
               type="date"
               value={slateDate || ''}
               onChange={(event) => navigate(event.target.value)}

--- a/src/SlatePage.js
+++ b/src/SlatePage.js
@@ -3,36 +3,14 @@ import { useSearchParams } from 'react-router-dom';
 import { useAuth } from './contexts/AuthContext';
 import { fetchSlate } from './slateApi';
 import { getRequestErrorMessage, isRequestCancelled } from './gameLogsApi';
-import { isCalendarDate } from './calendarDate';
+import {
+  formatCalendarDate,
+  getTodaySlateDate,
+  parseCalendarDate,
+  shiftCalendarDate,
+} from './calendarDate';
+import { getStatusPresentation } from './slateStatus';
 import './SlatePage.css';
-
-const getTodaySlateDate = () => {
-  const formatter = new Intl.DateTimeFormat('en-CA', {
-    timeZone: 'America/New_York',
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  });
-  return formatter.format(new Date());
-};
-
-const parseSlateDate = (value) => {
-  return isCalendarDate(value) ? value : null;
-};
-
-const shiftDate = (date, days) => {
-  const value = new Date(`${date}T12:00:00Z`);
-  value.setUTCDate(value.getUTCDate() + days);
-  return value.toISOString().slice(0, 10);
-};
-
-const formatSlateDate = (date) =>
-  new Intl.DateTimeFormat(undefined, {
-    weekday: 'long',
-    month: 'long',
-    day: 'numeric',
-    timeZone: 'UTC',
-  }).format(new Date(`${date}T12:00:00Z`));
 
 const formatTip = (date) =>
   new Intl.DateTimeFormat(undefined, {
@@ -48,35 +26,13 @@ const formatAge = (retrievedAt) => {
   return `${Math.round(hours / 24)}d ago`;
 };
 
-const statusPresentations = {
-  fresh: {
-    label: 'fresh',
-    poolMessage: 'Targetable counts use the current player pool.',
-  },
-  stale: { label: 'stale' },
-  'stale-served': {
-    label: 'stale-served',
-    poolMessage:
-      'Player pool is stale-served; targetable counts use the latest available snapshot.',
-  },
-  missing: {
-    label: 'missing',
-    poolMessage: 'Player pool unavailable; no targetable players are currently available.',
-  },
-  unavailable: {
-    label: 'unavailable',
-    poolMessage: 'Player pool unavailable; no targetable players are currently available.',
-  },
-};
-
 const surfaceStatusText = (name, surface) => {
   const age = surface.retrievedAt ? ` — as of ${formatAge(surface.retrievedAt)}` : '';
-  const label = statusPresentations[surface.status].label;
-  return `${name} is ${label}${age}`;
+  return `${name} is ${surface.status}${age}`;
 };
 
 function SurfaceFreshness({ name, surface }) {
-  const warning = surface.status !== 'fresh';
+  const warning = getStatusPresentation(surface.status).warning;
   return (
     <span
       className={warning ? 'freshness-warning' : undefined}
@@ -100,20 +56,8 @@ function Freshness({ freshness }) {
 }
 
 function PoolSummary({ isPast, poolStatus }) {
-  let message = statusPresentations[poolStatus].poolMessage;
-  if (isPast) {
-    const historicalMessages = {
-      fresh:
-        'Past slate — the current player pool is not displayed for historical dates. Final game cards retain the posted targetable counts returned for this slate.',
-      'stale-served':
-        'Past slate — the latest available snapshot is not displayed for historical dates. Final game cards retain the posted targetable counts returned for this slate.',
-      missing:
-        'Past slate — the player pool is missing and no current pool is displayed. Game cards retain the targetable counts returned for this slate.',
-      unavailable:
-        'Past slate — the player pool is unavailable and no current pool is displayed. Game cards retain the returned targetable counts for this slate.',
-    };
-    message = historicalMessages[poolStatus];
-  }
+  const presentation = getStatusPresentation(poolStatus);
+  const message = isPast ? presentation.historicalPoolMessage : presentation.currentPoolMessage;
 
   return (
     <section className="pool-summary" aria-labelledby="player-pool-heading">
@@ -156,11 +100,16 @@ export default function SlatePage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const requestedDate = searchParams.get('date');
   const todaySlateDate = getTodaySlateDate();
-  const parsedRequestedDate = parseSlateDate(requestedDate);
-  const provisionalDate = parsedRequestedDate || todaySlateDate;
+  const parsedRequestedDate = parseCalendarDate(requestedDate);
+  const invalidRequestedDate = requestedDate !== null && !parsedRequestedDate;
   const [state, setState] = useState({ status: 'idle', slate: null, error: null });
-  const slateDate = state.status === 'ready' ? state.slate.slateDate : provisionalDate;
-  const isPast = slateDate < todaySlateDate;
+  const slateDate =
+    state.status === 'ready'
+      ? state.slate.slateDate
+      : invalidRequestedDate
+        ? null
+        : parsedRequestedDate || todaySlateDate;
+  const isPast = slateDate ? slateDate < todaySlateDate : false;
 
   useEffect(() => {
     if (authLoading || !isAuthenticated) {
@@ -198,12 +147,13 @@ export default function SlatePage() {
     <main className="slate-page">
       <section className="slate-heading">
         <p className="eyebrow">NBA slate</p>
-        <h1>{formatSlateDate(slateDate)}</h1>
+        <h1>{slateDate ? formatCalendarDate(slateDate) : 'Invalid slate date'}</h1>
         <div className="date-controls">
           <button
             type="button"
             aria-label="Previous date"
-            onClick={() => navigate(shiftDate(slateDate, -1))}
+            disabled={!slateDate}
+            onClick={() => navigate(shiftCalendarDate(slateDate, -1))}
           >
             ←
           </button>
@@ -212,19 +162,22 @@ export default function SlatePage() {
             <input
               aria-label="Slate date"
               type="date"
-              value={slateDate}
+              value={slateDate || ''}
               onChange={(event) => navigate(event.target.value)}
             />
           </label>
           <button
             type="button"
             aria-label="Next date"
-            onClick={() => navigate(shiftDate(slateDate, 1))}
+            disabled={!slateDate}
+            onClick={() => navigate(shiftCalendarDate(slateDate, 1))}
           >
             →
           </button>
         </div>
       </section>
+
+      {!slateDate && <p>Requested date “{requestedDate}” is invalid.</p>}
 
       {state.status === 'loading' && <p role="status">Loading slate…</p>}
       {state.status === 'error' && <p role="alert">{state.error}</p>}

--- a/src/SlatePage.js
+++ b/src/SlatePage.js
@@ -31,21 +31,27 @@ const surfaceStatusText = (name, surface) => {
   return `${name} is ${surface.status}${age}`;
 };
 
+const useMinuteTick = () => {
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const interval = setInterval(() => setTick((tick) => tick + 1), 60000);
+    return () => clearInterval(interval);
+  }, []);
+};
+
 function SurfaceFreshness({ name, surface }) {
   const warning = getStatusPresentation(surface.status).warning;
   return (
-    <span
-      className={warning ? 'freshness-warning' : undefined}
-      role={warning ? 'alert' : undefined}
-    >
+    <span className={warning ? 'freshness-warning' : undefined}>
       {surfaceStatusText(name, surface)}
     </span>
   );
 }
 
 function Freshness({ freshness }) {
+  useMinuteTick();
   return (
-    <div className="freshness" aria-label="Data freshness">
+    <div className="freshness" role="group" aria-label="Data freshness">
       <SurfaceFreshness name="Schedule" surface={freshness.schedule} />
       <SurfaceFreshness name="Player pool" surface={freshness.pool} />
       {freshness.pool.providers.map((provider) => (
@@ -68,7 +74,7 @@ function PoolSummary({ isPast, poolStatus }) {
 }
 
 function GameCard({ game }) {
-  const status = game.status === 'final' ? 'Final' : game.statusLabel;
+  const status = game.statusLabel || (game.status === 'final' ? 'Final' : game.status);
   return (
     <article className="slate-card">
       <div className="slate-card-topline">
@@ -132,7 +138,7 @@ export default function SlatePage() {
     return () => controller.abort();
   }, [authLoading, isAuthenticated, requestedDate]);
 
-  const navigate = (nextDate) => setSearchParams({ date: nextDate });
+  const navigate = (nextDate) => setSearchParams(nextDate ? { date: nextDate } : {});
 
   if (!authLoading && !isAuthenticated) {
     return (

--- a/src/SlatePage.test.js
+++ b/src/SlatePage.test.js
@@ -67,7 +67,9 @@ test('shows an age for every available freshness surface and names degraded surf
   expect(await screen.findByText('Schedule is fresh — as of 10m ago')).toBeVisible();
   expect(screen.getByRole('group', { name: 'Data freshness' })).toBeVisible();
   expect(screen.getByText('Player pool is stale-served — as of 30m ago')).toBeVisible();
-  expect(screen.getByText('prizepicks pool is fresh — as of 20m ago')).toBeVisible();
+  expect(screen.getByText(/prizepicks pool is fresh.*older than 15m freshness bar/i)).toHaveClass(
+    'freshness-warning',
+  );
   expect(screen.getByText('underdog pool is missing')).toBeVisible();
   expect(screen.queryAllByRole('alert')).toHaveLength(0);
   expect(screen.getByText(/targetable counts use the latest available snapshot/i)).toBeVisible();
@@ -89,6 +91,55 @@ test('updates freshness ages each minute and cleans up its clock', async () => {
   expect(jest.getTimerCount()).toBe(0);
 });
 
+test('warns when a fresh schedule crosses the 30h bar without refetching', async () => {
+  fetchSlate.mockResolvedValue({
+    ...slate,
+    freshness: {
+      ...slate.freshness,
+      schedule: { status: 'fresh', retrievedAt: '2026-01-14T06:01:00.000Z' },
+    },
+  });
+  render(
+    <MemoryRouter initialEntries={['/matchups?date=2026-01-15']}>
+      <SlatePage />
+    </MemoryRouter>,
+  );
+
+  const fresh = await screen.findByText(/schedule is fresh/i);
+  expect(fresh).not.toHaveClass('freshness-warning');
+  act(() => jest.advanceTimersByTime(120000));
+  expect(screen.getByText(/schedule is stale/i)).toHaveClass('freshness-warning');
+  expect(fetchSlate).toHaveBeenCalledTimes(1);
+});
+
+test('warns when a fresh pool crosses the 15m bar without rewriting its status', async () => {
+  fetchSlate.mockResolvedValue({
+    ...slate,
+    poolStatus: 'fresh',
+    freshness: {
+      ...slate.freshness,
+      pool: {
+        status: 'fresh',
+        retrievedAt: '2026-01-15T11:46:00.000Z',
+        providers: [],
+      },
+    },
+  });
+  render(
+    <MemoryRouter initialEntries={['/matchups?date=2026-01-15']}>
+      <SlatePage />
+    </MemoryRouter>,
+  );
+
+  const fresh = await screen.findByText('Player pool is fresh — as of 14m ago');
+  expect(fresh).not.toHaveClass('freshness-warning');
+  act(() => jest.advanceTimersByTime(120000));
+  expect(screen.getByText(/player pool is fresh.*older than 15m freshness bar/i)).toHaveClass(
+    'freshness-warning',
+  );
+  expect(fetchSlate).toHaveBeenCalledTimes(1);
+});
+
 test('clearing the date requests today without entering an invalid state', async () => {
   render(
     <MemoryRouter initialEntries={['/matchups?date=2026-01-14']}>
@@ -106,12 +157,14 @@ test('clearing the date requests today without entering an invalid state', async
 });
 
 test.each([
-  ['Final/OT', 'Final/OT'],
-  [null, 'Final'],
-])('shows final catalog label %s with a Final fallback', async (statusLabel, expected) => {
+  ['scheduled', null, 'Scheduled'],
+  ['postponed', null, 'Postponed'],
+  ['final', null, 'Final'],
+  ['final', 'Final/OT', 'Final/OT'],
+])('shows %s catalog label %s with a cased fallback', async (status, statusLabel, expected) => {
   fetchSlate.mockResolvedValue({
     ...slate,
-    games: [{ ...game, status: 'final', statusLabel }],
+    games: [{ ...game, status, statusLabel }],
   });
 
   render(
@@ -120,7 +173,7 @@ test.each([
     </MemoryRouter>,
   );
 
-  expect(await screen.findByText(expected)).toBeVisible();
+  expect((await screen.findAllByText(expected))[0]).toBeVisible();
 });
 
 test.each([

--- a/src/SlatePage.test.js
+++ b/src/SlatePage.test.js
@@ -67,7 +67,7 @@ test('shows an age for every available freshness surface and names degraded surf
   expect(await screen.findByText('Schedule is fresh — as of 10m ago')).toBeVisible();
   expect(screen.getByRole('group', { name: 'Data freshness' })).toBeVisible();
   expect(screen.getByText('Player pool is stale-served — as of 30m ago')).toBeVisible();
-  expect(screen.getByText(/prizepicks pool is fresh.*older than 15m freshness bar/i)).toHaveClass(
+  expect(screen.getByText(/prizepicks pool is stale.*older than 15m freshness bar/i)).toHaveClass(
     'freshness-warning',
   );
   expect(screen.getByText('underdog pool is missing')).toBeVisible();
@@ -112,7 +112,7 @@ test('warns when a fresh schedule crosses the 30h bar without refetching', async
   expect(fetchSlate).toHaveBeenCalledTimes(1);
 });
 
-test('warns when a fresh pool crosses the 15m bar without rewriting its status', async () => {
+test('labels a fresh pool snapshot stale when it crosses the 15m bar', async () => {
   fetchSlate.mockResolvedValue({
     ...slate,
     poolStatus: 'fresh',
@@ -134,7 +134,7 @@ test('warns when a fresh pool crosses the 15m bar without rewriting its status',
   const fresh = await screen.findByText('Player pool is fresh — as of 14m ago');
   expect(fresh).not.toHaveClass('freshness-warning');
   act(() => jest.advanceTimersByTime(120000));
-  expect(screen.getByText(/player pool is fresh.*older than 15m freshness bar/i)).toHaveClass(
+  expect(screen.getByText(/player pool is stale.*older than 15m freshness bar/i)).toHaveClass(
     'freshness-warning',
   );
   expect(fetchSlate).toHaveBeenCalledTimes(1);
@@ -146,7 +146,7 @@ test('clearing the date requests today without entering an invalid state', async
       <SlatePage />
     </MemoryRouter>,
   );
-  await screen.findByRole('heading', { name: 'Thursday, January 15' });
+  await screen.findByRole('heading', { name: 'Thursday, January 15, 2026' });
   fetchSlate.mockClear();
 
   fireEvent.change(screen.getByLabelText('Slate date'), { target: { value: '' } });
@@ -154,6 +154,78 @@ test('clearing the date requests today without entering an invalid state', async
   await waitFor(() => expect(fetchSlate).toHaveBeenCalledWith(undefined, expect.any(Object)));
   expect(screen.queryByRole('heading', { name: 'Invalid slate date' })).not.toBeInTheDocument();
   expect(screen.getByLabelText('Slate date')).toHaveValue('2026-01-15');
+});
+
+test('offers Today as a recovery from an invalid requested date', async () => {
+  fetchSlate.mockRejectedValueOnce({
+    response: { data: { error: { code: 'invalid_input', message: 'Enter a valid date.' } } },
+  });
+  render(
+    <MemoryRouter initialEntries={['/matchups?date=2026-02-30']}>
+      <SlatePage />
+    </MemoryRouter>,
+  );
+  await screen.findByRole('heading', { name: 'Invalid slate date' });
+  await screen.findByRole('alert');
+  fetchSlate.mockClear();
+  fetchSlate.mockResolvedValue(slate);
+
+  fireEvent.click(screen.getByRole('button', { name: 'Today' }));
+
+  await waitFor(() => expect(fetchSlate).toHaveBeenCalledWith(undefined, expect.any(Object)));
+  expect(screen.queryByRole('heading', { name: 'Invalid slate date' })).not.toBeInTheDocument();
+});
+
+test('explains mixed provider counts without claiming the whole pool is missing', async () => {
+  fetchSlate.mockResolvedValue({
+    ...slate,
+    poolStatus: 'partial',
+    freshness: {
+      ...slate.freshness,
+      pool: {
+        status: 'partial',
+        retrievedAt: '2026-01-15T11:40:00.000Z',
+        providers: [
+          { name: 'prizepicks', status: 'fresh', retrievedAt: '2026-01-15T11:40:00.000Z' },
+          { name: 'underdog', status: 'missing', retrievedAt: null },
+        ],
+      },
+    },
+  });
+
+  render(
+    <MemoryRouter initialEntries={['/matchups?date=2026-01-15']}>
+      <SlatePage />
+    </MemoryRouter>,
+  );
+
+  expect(await screen.findByText(/counts reflect the available boards/i)).toBeVisible();
+  expect(screen.getByText('5 targetable')).toBeVisible();
+  expect(screen.getByText('4 targetable')).toBeVisible();
+  expect(screen.queryByText(/no targetable players/i)).not.toBeInTheDocument();
+});
+
+test.each([
+  ['missing', /player pool is missing/i],
+  ['unavailable', /player pool is unavailable/i],
+])('renders distinct %s pool copy', async (poolStatus, expected) => {
+  fetchSlate.mockResolvedValue({
+    ...slate,
+    poolStatus,
+    freshness: {
+      ...slate.freshness,
+      pool: { status: poolStatus, retrievedAt: null, providers: [] },
+    },
+  });
+
+  render(
+    <MemoryRouter initialEntries={['/matchups?date=2026-01-15']}>
+      <SlatePage />
+    </MemoryRouter>,
+  );
+
+  const heading = await screen.findByRole('heading', { name: 'Player pool' });
+  expect(within(heading.closest('section')).getByText(expected)).toBeVisible();
 });
 
 test.each([
@@ -236,6 +308,6 @@ test('uses the server slate date for the heading and historical pool state', asy
     </MemoryRouter>,
   );
 
-  expect(await screen.findByRole('heading', { name: 'Wednesday, January 14' })).toBeVisible();
+  expect(await screen.findByRole('heading', { name: 'Wednesday, January 14, 2026' })).toBeVisible();
   expect(screen.getByText(/current player pool is not displayed/i)).toBeVisible();
 });

--- a/src/SlatePage.test.js
+++ b/src/SlatePage.test.js
@@ -248,6 +248,37 @@ test.each([
   expect((await screen.findAllByText(expected))[0]).toBeVisible();
 });
 
+test('shows preseason and unusual classification badges', async () => {
+  fetchSlate.mockResolvedValue({
+    ...slate,
+    games: [{ ...game, classification: 'International Series', preseason: true }],
+  });
+  render(
+    <MemoryRouter initialEntries={['/matchups?date=2026-01-15']}>
+      <SlatePage />
+    </MemoryRouter>,
+  );
+
+  expect(await screen.findByText('International Series')).toBeVisible();
+  expect(screen.getByText('Preseason')).toBeVisible();
+});
+
+test('does not invent a classification badge for an ordinary game', async () => {
+  fetchSlate.mockResolvedValue({
+    ...slate,
+    games: [{ ...game, classification: null, preseason: false }],
+  });
+  render(
+    <MemoryRouter initialEntries={['/matchups?date=2026-01-15']}>
+      <SlatePage />
+    </MemoryRouter>,
+  );
+
+  await screen.findByRole('heading', { name: 'LAL @ BOS' });
+  expect(screen.queryByText('International Series')).not.toBeInTheDocument();
+  expect(screen.queryByText('Preseason')).not.toBeInTheDocument();
+});
+
 test.each([
   ['fresh', 'current player pool is not displayed', 'posted targetable counts'],
   ['stale-served', 'latest available snapshot is not displayed', 'posted targetable counts'],

--- a/src/SlatePage.test.js
+++ b/src/SlatePage.test.js
@@ -1,0 +1,115 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import SlatePage from './SlatePage';
+import { fetchSlate } from './slateApi';
+
+jest.mock('./slateApi', () => ({ fetchSlate: jest.fn() }));
+jest.mock('./contexts/AuthContext', () => ({
+  useAuth: () => ({ isAuthenticated: true, loading: false }),
+}));
+
+const game = {
+  gameId: '0022500584',
+  away: {
+    teamId: 1610612747,
+    tricode: 'LAL',
+    name: 'Los Angeles Lakers',
+    targetablePlayerCount: 5,
+  },
+  home: {
+    teamId: 1610612738,
+    tricode: 'BOS',
+    name: 'Boston Celtics',
+    targetablePlayerCount: 4,
+  },
+  scheduledAt: '2026-01-16T00:30:00.000Z',
+  status: 'scheduled',
+  statusLabel: 'Scheduled',
+  classification: null,
+  preseason: false,
+};
+
+const slate = {
+  slateDate: '2026-01-15',
+  poolStatus: 'stale-served',
+  freshness: {
+    schedule: { status: 'fresh', retrievedAt: '2026-01-15T11:50:00.000Z' },
+    pool: {
+      status: 'stale-served',
+      retrievedAt: '2026-01-15T11:30:00.000Z',
+      providers: [
+        { name: 'prizepicks', status: 'fresh', retrievedAt: '2026-01-15T11:40:00.000Z' },
+        { name: 'underdog', status: 'missing', retrievedAt: null },
+      ],
+    },
+  },
+  games: [game],
+};
+
+beforeEach(() => {
+  jest.useFakeTimers().setSystemTime(new Date('2026-01-15T12:00:00Z'));
+  fetchSlate.mockResolvedValue(slate);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.clearAllMocks();
+});
+
+test('shows an age for every available freshness surface and names degraded surfaces', async () => {
+  render(
+    <MemoryRouter initialEntries={['/matchups?date=2026-01-15']}>
+      <SlatePage />
+    </MemoryRouter>,
+  );
+
+  expect(await screen.findByText('Schedule is fresh — as of 10m ago')).toBeVisible();
+  expect(screen.getByText('Player pool is stale-served — as of 30m ago')).toHaveAttribute(
+    'role',
+    'alert',
+  );
+  expect(screen.getByText('prizepicks pool is fresh — as of 20m ago')).toBeVisible();
+  expect(screen.getByText('underdog pool is missing')).toHaveAttribute('role', 'alert');
+  expect(screen.getByText(/targetable counts use the latest available snapshot/i)).toBeVisible();
+});
+
+test('renders the historical empty pool section regardless of aggregate pool status', async () => {
+  fetchSlate.mockResolvedValue({ ...slate, slateDate: '2026-01-10', poolStatus: 'fresh' });
+
+  render(
+    <MemoryRouter initialEntries={['/matchups?date=2026-01-10']}>
+      <SlatePage />
+    </MemoryRouter>,
+  );
+
+  expect(await screen.findByRole('heading', { name: 'Player pool' })).toBeVisible();
+  expect(screen.getByText(/no player pool is available for historical dates/i)).toBeVisible();
+});
+
+test('forwards an impossible calendar date so the backend can return invalid_input', async () => {
+  fetchSlate.mockRejectedValue({
+    response: { data: { error: { code: 'invalid_input', message: 'Enter a valid date.' } } },
+  });
+
+  render(
+    <MemoryRouter initialEntries={['/matchups?date=2026-02-30']}>
+      <SlatePage />
+    </MemoryRouter>,
+  );
+
+  expect(await screen.findByRole('alert')).toHaveTextContent('Enter a valid date.');
+  await waitFor(() => expect(fetchSlate).toHaveBeenCalledWith('2026-02-30', expect.any(Object)));
+});
+
+test('uses the server slate date for the heading and historical pool state', async () => {
+  fetchSlate.mockResolvedValue({ ...slate, slateDate: '2026-01-14', poolStatus: 'fresh' });
+
+  render(
+    <MemoryRouter initialEntries={['/matchups']}>
+      <SlatePage />
+    </MemoryRouter>,
+  );
+
+  expect(await screen.findByRole('heading', { name: 'Wednesday, January 14' })).toBeVisible();
+  expect(screen.getByText(/no player pool is available for historical dates/i)).toBeVisible();
+});

--- a/src/SlatePage.test.js
+++ b/src/SlatePage.test.js
@@ -116,6 +116,11 @@ test('forwards an impossible calendar date so the backend can return invalid_inp
   );
 
   expect(await screen.findByRole('alert')).toHaveTextContent('Enter a valid date.');
+  expect(screen.getByRole('heading', { name: 'Invalid slate date' })).toBeVisible();
+  expect(screen.getByText(/requested date.*2026-02-30.*invalid/i)).toBeVisible();
+  expect(screen.getByRole('button', { name: 'Previous date' })).toBeDisabled();
+  expect(screen.getByRole('button', { name: 'Next date' })).toBeDisabled();
+  expect(screen.getByLabelText('Slate date')).toHaveValue('');
   await waitFor(() => expect(fetchSlate).toHaveBeenCalledWith('2026-02-30', expect.any(Object)));
 });
 

--- a/src/SlatePage.test.js
+++ b/src/SlatePage.test.js
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import SlatePage from './SlatePage';
 import { fetchSlate } from './slateApi';
@@ -73,18 +73,36 @@ test('shows an age for every available freshness surface and names degraded surf
   expect(screen.getByText(/targetable counts use the latest available snapshot/i)).toBeVisible();
 });
 
-test('renders the historical empty pool section regardless of aggregate pool status', async () => {
-  fetchSlate.mockResolvedValue({ ...slate, slateDate: '2026-01-10', poolStatus: 'fresh' });
+test.each([
+  ['fresh', 'current player pool is not displayed', 'posted targetable counts'],
+  ['stale-served', 'latest available snapshot is not displayed', 'posted targetable counts'],
+  ['unavailable', 'player pool is unavailable', 'returned targetable counts'],
+])(
+  'renders an honest historical empty pool section when the pool is %s',
+  async (poolStatus, statusText, countsText) => {
+    fetchSlate.mockResolvedValue({
+      ...slate,
+      slateDate: '2026-01-10',
+      poolStatus,
+      freshness: {
+        ...slate.freshness,
+        pool: { ...slate.freshness.pool, status: poolStatus },
+      },
+      games: [{ ...game, status: 'final', statusLabel: 'Final' }],
+    });
 
-  render(
-    <MemoryRouter initialEntries={['/matchups?date=2026-01-10']}>
-      <SlatePage />
-    </MemoryRouter>,
-  );
+    render(
+      <MemoryRouter initialEntries={['/matchups?date=2026-01-10']}>
+        <SlatePage />
+      </MemoryRouter>,
+    );
 
-  expect(await screen.findByRole('heading', { name: 'Player pool' })).toBeVisible();
-  expect(screen.getByText(/no player pool is available for historical dates/i)).toBeVisible();
-});
+    const heading = await screen.findByRole('heading', { name: 'Player pool' });
+    const poolSection = heading.closest('section');
+    expect(within(poolSection).getByText(new RegExp(statusText, 'i'))).toBeVisible();
+    expect(within(poolSection).getByText(new RegExp(countsText, 'i'))).toBeVisible();
+  },
+);
 
 test('forwards an impossible calendar date so the backend can return invalid_input', async () => {
   fetchSlate.mockRejectedValue({
@@ -111,5 +129,5 @@ test('uses the server slate date for the heading and historical pool state', asy
   );
 
   expect(await screen.findByRole('heading', { name: 'Wednesday, January 14' })).toBeVisible();
-  expect(screen.getByText(/no player pool is available for historical dates/i)).toBeVisible();
+  expect(screen.getByText(/current player pool is not displayed/i)).toBeVisible();
 });

--- a/src/SlatePage.test.js
+++ b/src/SlatePage.test.js
@@ -1,4 +1,5 @@
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { act } from 'react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import SlatePage from './SlatePage';
 import { fetchSlate } from './slateApi';
@@ -64,13 +65,62 @@ test('shows an age for every available freshness surface and names degraded surf
   );
 
   expect(await screen.findByText('Schedule is fresh — as of 10m ago')).toBeVisible();
-  expect(screen.getByText('Player pool is stale-served — as of 30m ago')).toHaveAttribute(
-    'role',
-    'alert',
-  );
+  expect(screen.getByRole('group', { name: 'Data freshness' })).toBeVisible();
+  expect(screen.getByText('Player pool is stale-served — as of 30m ago')).toBeVisible();
   expect(screen.getByText('prizepicks pool is fresh — as of 20m ago')).toBeVisible();
-  expect(screen.getByText('underdog pool is missing')).toHaveAttribute('role', 'alert');
+  expect(screen.getByText('underdog pool is missing')).toBeVisible();
+  expect(screen.queryAllByRole('alert')).toHaveLength(0);
   expect(screen.getByText(/targetable counts use the latest available snapshot/i)).toBeVisible();
+});
+
+test('updates freshness ages each minute and cleans up its clock', async () => {
+  const { unmount } = render(
+    <MemoryRouter initialEntries={['/matchups?date=2026-01-15']}>
+      <SlatePage />
+    </MemoryRouter>,
+  );
+
+  expect(await screen.findByText('Schedule is fresh — as of 10m ago')).toBeVisible();
+  expect(jest.getTimerCount()).toBe(1);
+  act(() => jest.advanceTimersByTime(60000));
+  expect(screen.getByText('Schedule is fresh — as of 11m ago')).toBeVisible();
+
+  unmount();
+  expect(jest.getTimerCount()).toBe(0);
+});
+
+test('clearing the date requests today without entering an invalid state', async () => {
+  render(
+    <MemoryRouter initialEntries={['/matchups?date=2026-01-14']}>
+      <SlatePage />
+    </MemoryRouter>,
+  );
+  await screen.findByRole('heading', { name: 'Thursday, January 15' });
+  fetchSlate.mockClear();
+
+  fireEvent.change(screen.getByLabelText('Slate date'), { target: { value: '' } });
+
+  await waitFor(() => expect(fetchSlate).toHaveBeenCalledWith(undefined, expect.any(Object)));
+  expect(screen.queryByRole('heading', { name: 'Invalid slate date' })).not.toBeInTheDocument();
+  expect(screen.getByLabelText('Slate date')).toHaveValue('2026-01-15');
+});
+
+test.each([
+  ['Final/OT', 'Final/OT'],
+  [null, 'Final'],
+])('shows final catalog label %s with a Final fallback', async (statusLabel, expected) => {
+  fetchSlate.mockResolvedValue({
+    ...slate,
+    games: [{ ...game, status: 'final', statusLabel }],
+  });
+
+  render(
+    <MemoryRouter initialEntries={['/matchups?date=2026-01-15']}>
+      <SlatePage />
+    </MemoryRouter>,
+  );
+
+  expect(await screen.findByText(expected)).toBeVisible();
 });
 
 test.each([

--- a/src/SlatePage.test.js
+++ b/src/SlatePage.test.js
@@ -133,10 +133,13 @@ test('labels a fresh pool snapshot stale when it crosses the 15m bar', async () 
 
   const fresh = await screen.findByText('Player pool is fresh — as of 14m ago');
   expect(fresh).not.toHaveClass('freshness-warning');
+  expect(screen.getByText('Targetable counts use the current player pool.')).toBeVisible();
   act(() => jest.advanceTimersByTime(120000));
   expect(screen.getByText(/player pool is stale.*older than 15m freshness bar/i)).toHaveClass(
     'freshness-warning',
   );
+  expect(screen.getByText(/player pool snapshot is stale/i)).toBeVisible();
+  expect(screen.queryByText(/use the current player pool/i)).not.toBeInTheDocument();
   expect(fetchSlate).toHaveBeenCalledTimes(1);
 });
 
@@ -292,7 +295,12 @@ test.each([
       poolStatus,
       freshness: {
         ...slate.freshness,
-        pool: { ...slate.freshness.pool, status: poolStatus },
+        pool: {
+          ...slate.freshness.pool,
+          status: poolStatus,
+          retrievedAt:
+            poolStatus === 'fresh' ? '2026-01-15T11:50:00.000Z' : slate.freshness.pool.retrievedAt,
+        },
       },
       games: [{ ...game, status: 'final', statusLabel: 'Final' }],
     });
@@ -331,7 +339,19 @@ test('forwards an impossible calendar date so the backend can return invalid_inp
 });
 
 test('uses the server slate date for the heading and historical pool state', async () => {
-  fetchSlate.mockResolvedValue({ ...slate, slateDate: '2026-01-14', poolStatus: 'fresh' });
+  fetchSlate.mockResolvedValue({
+    ...slate,
+    slateDate: '2026-01-14',
+    poolStatus: 'fresh',
+    freshness: {
+      ...slate.freshness,
+      pool: {
+        ...slate.freshness.pool,
+        status: 'fresh',
+        retrievedAt: '2026-01-15T11:50:00.000Z',
+      },
+    },
+  });
 
   render(
     <MemoryRouter initialEntries={['/matchups']}>

--- a/src/calendarDate.js
+++ b/src/calendarDate.js
@@ -5,3 +5,27 @@ export const isCalendarDate = (value) => {
   const parsed = new Date(`${value}T12:00:00Z`);
   return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
 };
+
+export const parseCalendarDate = (value) => (isCalendarDate(value) ? value : null);
+
+export const getTodaySlateDate = (now = new Date()) =>
+  new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/New_York',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(now);
+
+export const shiftCalendarDate = (date, days) => {
+  const value = new Date(`${date}T12:00:00Z`);
+  value.setUTCDate(value.getUTCDate() + days);
+  return value.toISOString().slice(0, 10);
+};
+
+export const formatCalendarDate = (date) =>
+  new Intl.DateTimeFormat(undefined, {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(`${date}T12:00:00Z`));

--- a/src/calendarDate.js
+++ b/src/calendarDate.js
@@ -1,0 +1,7 @@
+const calendarDatePattern = /^\d{4}-\d{2}-\d{2}$/;
+
+export const isCalendarDate = (value) => {
+  if (typeof value !== 'string' || !calendarDatePattern.test(value)) return false;
+  const parsed = new Date(`${value}T12:00:00Z`);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
+};

--- a/src/calendarDate.js
+++ b/src/calendarDate.js
@@ -27,5 +27,6 @@ export const formatCalendarDate = (date) =>
     weekday: 'long',
     month: 'long',
     day: 'numeric',
+    year: 'numeric',
     timeZone: 'UTC',
   }).format(new Date(`${date}T12:00:00Z`));

--- a/src/config.js
+++ b/src/config.js
@@ -13,6 +13,7 @@ const config = {
     PLAYERS: '/api/players',
     TEAMS: '/api/teams',
     GAME_LOGS: '/api/games/game_logs',
+    SLATE: '/api/games/slate',
     PLAYER_PROFILE: '/api/players/profile',
     TEAM_STATS: '/api/teams/stats',
     NL_QUERY: '/api/nl-query',

--- a/src/gameLogsApi.js
+++ b/src/gameLogsApi.js
@@ -64,5 +64,15 @@ export const isRequestCancelled = (error) =>
       error.message === 'The operation was aborted.'),
   );
 
-export const getRequestErrorMessage = (error, fallback = 'The request failed. Please try again.') =>
-  error?.response?.data?.error || error?.response?.data?.message || error?.message || fallback;
+export const getRequestErrorMessage = (
+  error,
+  fallback = 'The request failed. Please try again.',
+) => {
+  const responseError = error?.response?.data?.error;
+  return (
+    (typeof responseError === 'string' ? responseError : responseError?.message) ||
+    error?.response?.data?.message ||
+    error?.message ||
+    fallback
+  );
+};

--- a/src/gameLogsApi.test.js
+++ b/src/gameLogsApi.test.js
@@ -1,5 +1,5 @@
 import { apiClient, getApiUrl } from './config';
-import { decodeGameLogsResponse, fetchGameLogsData } from './gameLogsApi';
+import { decodeGameLogsResponse, fetchGameLogsData, getRequestErrorMessage } from './gameLogsApi';
 
 jest.mock('./config', () => ({
   apiClient: { get: jest.fn() },
@@ -46,5 +46,13 @@ describe('gameLogsApi', () => {
     expect(() => decodeGameLogsResponse({ game_logs: '{not-json}' })).toThrow(
       /invalid game logs response/i,
     );
+  });
+
+  test('reads the standard backend error shape', () => {
+    expect(
+      getRequestErrorMessage({
+        response: { data: { error: { code: 'provider_unavailable', message: 'Try later.' } } },
+      }),
+    ).toBe('Try later.');
   });
 });

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,6 +3,10 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+import { TextDecoder, TextEncoder } from 'util';
+
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
 
 const mockApiClient = {
   get: jest.fn(() => Promise.resolve({ data: [] })),

--- a/src/slateApi.js
+++ b/src/slateApi.js
@@ -1,0 +1,81 @@
+import { apiClient, getApiUrl } from './config';
+
+const invalidSlate = () => new Error('The slate endpoint returned an invalid response.');
+
+const decodeTeam = (team) => {
+  if (
+    !team ||
+    !Number.isInteger(team.team_id) ||
+    typeof team.tricode !== 'string' ||
+    typeof team.name !== 'string' ||
+    !Number.isInteger(team.targetable_player_count)
+  ) {
+    throw invalidSlate();
+  }
+
+  return {
+    teamId: team.team_id,
+    tricode: team.tricode,
+    name: team.name,
+    targetablePlayerCount: team.targetable_player_count,
+  };
+};
+
+const decodeGame = (game) => {
+  if (
+    !game ||
+    typeof game.game_id !== 'string' ||
+    typeof game.scheduled_at !== 'string' ||
+    !game.status ||
+    !['scheduled', 'postponed', 'final'].includes(game.status.state) ||
+    typeof game.status.label !== 'string' ||
+    typeof game.preseason !== 'boolean'
+  ) {
+    throw invalidSlate();
+  }
+
+  const scheduledAt = new Date(game.scheduled_at);
+  if (Number.isNaN(scheduledAt.getTime())) throw invalidSlate();
+
+  return {
+    gameId: game.game_id,
+    away: decodeTeam(game.away_team),
+    home: decodeTeam(game.home_team),
+    scheduledAt: scheduledAt.toISOString(),
+    status: game.status.state,
+    statusLabel: game.status.label,
+    classification: typeof game.classification === 'string' ? game.classification : null,
+    preseason: game.preseason,
+    targetableCounts: {
+      away: game.away_team.targetable_player_count,
+      home: game.home_team.targetable_player_count,
+    },
+  };
+};
+
+export const decodeSlate = (data) => {
+  if (
+    !data ||
+    typeof data.slate_date !== 'string' ||
+    !Array.isArray(data.games) ||
+    !data.freshness ||
+    typeof data.freshness !== 'object'
+  ) {
+    throw invalidSlate();
+  }
+
+  return {
+    slateDate: data.slate_date,
+    freshness: data.freshness,
+    poolStatus: typeof data.pool_status === 'string' ? data.pool_status : null,
+    games: data.games.map(decodeGame),
+  };
+};
+
+export const fetchSlate = async (date, { signal } = {}) => {
+  const response = await apiClient.get(getApiUrl('SLATE'), {
+    params: date ? { date } : {},
+    signal,
+  });
+  return decodeSlate(response.data);
+};

--- a/src/slateApi.js
+++ b/src/slateApi.js
@@ -61,10 +61,18 @@ const decodeFreshness = (freshness) => {
     poolSurface = decodeFreshnessSurface(freshness.pool, 'pool');
   } else {
     const status = derivePoolStatusFromProviders(providers);
-    if (!status || !('retrieved_at' in freshness.pool)) throw createInvalidSlateError();
+    if (!status) throw createInvalidSlateError();
+    const poolRetrievedAt =
+      'retrieved_at' in freshness.pool ? decodeRetrievedAt(freshness.pool.retrieved_at) : null;
+    const providerRetrievedAt = providers
+      .map(({ retrievedAt }) => retrievedAt)
+      .filter(Boolean)
+      .sort()
+      .at(-1);
     const retrievedAt =
-      decodeRetrievedAt(freshness.pool.retrieved_at) ||
+      poolRetrievedAt ||
       providers.find((provider) => provider.status === status)?.retrievedAt ||
+      providerRetrievedAt ||
       null;
     poolSurface = { status, retrievedAt };
   }

--- a/src/slateApi.js
+++ b/src/slateApi.js
@@ -1,6 +1,46 @@
 import { apiClient, getApiUrl } from './config';
 
-const invalidSlate = () => new Error('The slate endpoint returned an invalid response.');
+const createInvalidSlateError = () => new Error('The slate endpoint returned an invalid response.');
+
+const scheduleStatuses = new Set(['fresh', 'stale', 'missing']);
+const poolStatuses = new Set(['fresh', 'stale-served', 'missing', 'unavailable']);
+
+const decodeRetrievedAt = (value) => {
+  if (value === null) return null;
+  if (typeof value !== 'string') throw createInvalidSlateError();
+  const retrievedAt = new Date(value);
+  if (Number.isNaN(retrievedAt.getTime())) throw createInvalidSlateError();
+  return retrievedAt.toISOString();
+};
+
+const decodeFreshnessSurface = (surface, statuses) => {
+  if (!surface || !statuses.has(surface.status) || !('retrieved_at' in surface)) {
+    throw createInvalidSlateError();
+  }
+  const retrievedAt = decodeRetrievedAt(surface.retrieved_at);
+  if (!retrievedAt && !['missing', 'unavailable'].includes(surface.status)) {
+    throw createInvalidSlateError();
+  }
+  return { status: surface.status, retrievedAt };
+};
+
+const decodeFreshness = (freshness) => {
+  if (!freshness || typeof freshness !== 'object') throw createInvalidSlateError();
+  const schedule = decodeFreshnessSurface(freshness.schedule, scheduleStatuses);
+  const poolSurface = decodeFreshnessSurface(freshness.pool, poolStatuses);
+  if (
+    !freshness.pool.providers ||
+    typeof freshness.pool.providers !== 'object' ||
+    Array.isArray(freshness.pool.providers)
+  ) {
+    throw createInvalidSlateError();
+  }
+  const providers = Object.entries(freshness.pool.providers).map(([name, surface]) => {
+    if (!name) throw createInvalidSlateError();
+    return { name, ...decodeFreshnessSurface(surface, poolStatuses) };
+  });
+  return { schedule, pool: { ...poolSurface, providers } };
+};
 
 const decodeTeam = (team) => {
   if (
@@ -10,7 +50,7 @@ const decodeTeam = (team) => {
     typeof team.name !== 'string' ||
     !Number.isInteger(team.targetable_player_count)
   ) {
-    throw invalidSlate();
+    throw createInvalidSlateError();
   }
 
   return {
@@ -31,11 +71,11 @@ const decodeGame = (game) => {
     typeof game.status.label !== 'string' ||
     typeof game.preseason !== 'boolean'
   ) {
-    throw invalidSlate();
+    throw createInvalidSlateError();
   }
 
   const scheduledAt = new Date(game.scheduled_at);
-  if (Number.isNaN(scheduledAt.getTime())) throw invalidSlate();
+  if (Number.isNaN(scheduledAt.getTime())) throw createInvalidSlateError();
 
   return {
     gameId: game.game_id,
@@ -46,10 +86,6 @@ const decodeGame = (game) => {
     statusLabel: game.status.label,
     classification: typeof game.classification === 'string' ? game.classification : null,
     preseason: game.preseason,
-    targetableCounts: {
-      away: game.away_team.targetable_player_count,
-      home: game.home_team.targetable_player_count,
-    },
   };
 };
 
@@ -59,15 +95,23 @@ export const decodeSlate = (data) => {
     typeof data.slate_date !== 'string' ||
     !Array.isArray(data.games) ||
     !data.freshness ||
-    typeof data.freshness !== 'object'
+    !poolStatuses.has(data.pool_status)
   ) {
-    throw invalidSlate();
+    throw createInvalidSlateError();
+  }
+
+  const slateDate = new Date(`${data.slate_date}T12:00:00Z`);
+  if (
+    Number.isNaN(slateDate.getTime()) ||
+    slateDate.toISOString().slice(0, 10) !== data.slate_date
+  ) {
+    throw createInvalidSlateError();
   }
 
   return {
     slateDate: data.slate_date,
-    freshness: data.freshness,
-    poolStatus: typeof data.pool_status === 'string' ? data.pool_status : null,
+    freshness: decodeFreshness(data.freshness),
+    poolStatus: data.pool_status,
     games: data.games.map(decodeGame),
   };
 };

--- a/src/slateApi.js
+++ b/src/slateApi.js
@@ -1,4 +1,5 @@
 import { apiClient, getApiUrl } from './config';
+import { isCalendarDate } from './calendarDate';
 
 const createInvalidSlateError = () => new Error('The slate endpoint returned an invalid response.');
 
@@ -28,18 +29,28 @@ const decodeFreshness = (freshness) => {
   if (!freshness || typeof freshness !== 'object') throw createInvalidSlateError();
   const schedule = decodeFreshnessSurface(freshness.schedule, scheduleStatuses);
   const poolSurface = decodeFreshnessSurface(freshness.pool, poolStatuses);
+  const providerSurfaces = freshness.pool.providers;
   if (
-    !freshness.pool.providers ||
-    typeof freshness.pool.providers !== 'object' ||
-    Array.isArray(freshness.pool.providers)
+    providerSurfaces !== undefined &&
+    (typeof providerSurfaces !== 'object' ||
+      providerSurfaces === null ||
+      Array.isArray(providerSurfaces))
   ) {
     throw createInvalidSlateError();
   }
-  const providers = Object.entries(freshness.pool.providers).map(([name, surface]) => {
+  const providers = Object.entries(providerSurfaces || {}).map(([name, surface]) => {
     if (!name) throw createInvalidSlateError();
     return { name, ...decodeFreshnessSurface(surface, poolStatuses) };
   });
   return { schedule, pool: { ...poolSurface, providers } };
+};
+
+const derivePoolStatus = (aggregateStatus, pool) => {
+  if (['fresh', 'stale-served'].includes(pool.status)) return pool.status;
+  const providerStatuses = pool.providers.map(({ status }) => status);
+  if (providerStatuses.includes('fresh')) return 'fresh';
+  if (providerStatuses.includes('stale-served')) return 'stale-served';
+  return aggregateStatus || pool.status;
 };
 
 const decodeTeam = (team) => {
@@ -92,26 +103,20 @@ const decodeGame = (game) => {
 export const decodeSlate = (data) => {
   if (
     !data ||
-    typeof data.slate_date !== 'string' ||
+    !isCalendarDate(data.slate_date) ||
     !Array.isArray(data.games) ||
     !data.freshness ||
-    !poolStatuses.has(data.pool_status)
+    (data.pool_status !== undefined && !poolStatuses.has(data.pool_status))
   ) {
     throw createInvalidSlateError();
   }
 
-  const slateDate = new Date(`${data.slate_date}T12:00:00Z`);
-  if (
-    Number.isNaN(slateDate.getTime()) ||
-    slateDate.toISOString().slice(0, 10) !== data.slate_date
-  ) {
-    throw createInvalidSlateError();
-  }
+  const freshness = decodeFreshness(data.freshness);
 
   return {
     slateDate: data.slate_date,
-    freshness: decodeFreshness(data.freshness),
-    poolStatus: data.pool_status,
+    freshness,
+    poolStatus: derivePoolStatus(data.pool_status, freshness.pool),
     games: data.games.map(decodeGame),
   };
 };

--- a/src/slateApi.js
+++ b/src/slateApi.js
@@ -28,20 +28,20 @@ const decodeFreshnessSurface = (surface, surfaceName) => {
   return { status: surface.status, retrievedAt };
 };
 
+const decodeDerivedSchedule = (surface) => {
+  if (!surface || !('retrieved_at' in surface)) throw createInvalidSlateError();
+  const retrievedAt = decodeRetrievedAt(surface.retrieved_at);
+  if (!retrievedAt) throw createInvalidSlateError();
+  return { status: deriveScheduleStatus(retrievedAt), retrievedAt };
+};
+
 const decodeFreshness = (freshness) => {
   if (!freshness || typeof freshness !== 'object' || !freshness.pool) {
     throw createInvalidSlateError();
   }
-  if (!freshness.schedule || !('retrieved_at' in freshness.schedule)) {
-    throw createInvalidSlateError();
-  }
   const schedule =
-    freshness.schedule.status === undefined
-      ? (() => {
-          const retrievedAt = decodeRetrievedAt(freshness.schedule.retrieved_at);
-          if (!retrievedAt) throw createInvalidSlateError();
-          return { status: deriveScheduleStatus(retrievedAt), retrievedAt };
-        })()
+    freshness.schedule?.status === undefined
+      ? decodeDerivedSchedule(freshness.schedule)
       : decodeFreshnessSurface(freshness.schedule, 'schedule');
   const providerSurfaces = freshness.pool.providers;
   if (

--- a/src/slateApi.js
+++ b/src/slateApi.js
@@ -8,6 +8,7 @@ import {
 } from './slateStatus';
 
 const createInvalidSlateError = () => new Error('The slate endpoint returned an invalid response.');
+const isRecord = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
 
 const decodeRetrievedAt = (value) => {
   if (value === null) return null;
@@ -18,7 +19,11 @@ const decodeRetrievedAt = (value) => {
 };
 
 const decodeFreshnessSurface = (surface, surfaceName) => {
-  if (!surface || !isStatusAllowed(surface.status, surfaceName) || !('retrieved_at' in surface)) {
+  if (
+    !isRecord(surface) ||
+    !isStatusAllowed(surface.status, surfaceName) ||
+    !('retrieved_at' in surface)
+  ) {
     throw createInvalidSlateError();
   }
   const retrievedAt = decodeRetrievedAt(surface.retrieved_at);
@@ -29,14 +34,14 @@ const decodeFreshnessSurface = (surface, surfaceName) => {
 };
 
 const decodeDerivedSchedule = (surface) => {
-  if (!surface || !('retrieved_at' in surface)) throw createInvalidSlateError();
+  if (!isRecord(surface) || !('retrieved_at' in surface)) throw createInvalidSlateError();
   const retrievedAt = decodeRetrievedAt(surface.retrieved_at);
   if (!retrievedAt) throw createInvalidSlateError();
   return { status: deriveScheduleStatus(retrievedAt), retrievedAt };
 };
 
 const decodeFreshness = (freshness) => {
-  if (!freshness || typeof freshness !== 'object' || !freshness.pool) {
+  if (!isRecord(freshness) || !isRecord(freshness.pool)) {
     throw createInvalidSlateError();
   }
   const schedule =

--- a/src/slateApi.js
+++ b/src/slateApi.js
@@ -1,10 +1,8 @@
 import { apiClient, getApiUrl } from './config';
 import { isCalendarDate } from './calendarDate';
+import { derivePoolStatusFromProviders, poolStatuses, scheduleStatuses } from './slateStatus';
 
 const createInvalidSlateError = () => new Error('The slate endpoint returned an invalid response.');
-
-const scheduleStatuses = new Set(['fresh', 'stale', 'missing']);
-const poolStatuses = new Set(['fresh', 'stale-served', 'missing', 'unavailable']);
 
 const decodeRetrievedAt = (value) => {
   if (value === null) return null;
@@ -26,9 +24,10 @@ const decodeFreshnessSurface = (surface, statuses) => {
 };
 
 const decodeFreshness = (freshness) => {
-  if (!freshness || typeof freshness !== 'object') throw createInvalidSlateError();
+  if (!freshness || typeof freshness !== 'object' || !freshness.pool) {
+    throw createInvalidSlateError();
+  }
   const schedule = decodeFreshnessSurface(freshness.schedule, scheduleStatuses);
-  const poolSurface = decodeFreshnessSurface(freshness.pool, poolStatuses);
   const providerSurfaces = freshness.pool.providers;
   if (
     providerSurfaces !== undefined &&
@@ -42,15 +41,19 @@ const decodeFreshness = (freshness) => {
     if (!name) throw createInvalidSlateError();
     return { name, ...decodeFreshnessSurface(surface, poolStatuses) };
   });
+  let poolSurface;
+  if (freshness.pool.status !== undefined) {
+    poolSurface = decodeFreshnessSurface(freshness.pool, poolStatuses);
+  } else {
+    const status = derivePoolStatusFromProviders(providers);
+    if (!status || !('retrieved_at' in freshness.pool)) throw createInvalidSlateError();
+    const retrievedAt =
+      decodeRetrievedAt(freshness.pool.retrieved_at) ||
+      providers.find((provider) => provider.status === status)?.retrievedAt ||
+      null;
+    poolSurface = { status, retrievedAt };
+  }
   return { schedule, pool: { ...poolSurface, providers } };
-};
-
-const derivePoolStatus = (aggregateStatus, pool) => {
-  if (['fresh', 'stale-served'].includes(pool.status)) return pool.status;
-  const providerStatuses = pool.providers.map(({ status }) => status);
-  if (providerStatuses.includes('fresh')) return 'fresh';
-  if (providerStatuses.includes('stale-served')) return 'stale-served';
-  return aggregateStatus || pool.status;
 };
 
 const decodeTeam = (team) => {
@@ -116,7 +119,7 @@ export const decodeSlate = (data) => {
   return {
     slateDate: data.slate_date,
     freshness,
-    poolStatus: derivePoolStatus(data.pool_status, freshness.pool),
+    poolStatus: data.pool_status ?? freshness.pool.status,
     games: data.games.map(decodeGame),
   };
 };

--- a/src/slateApi.js
+++ b/src/slateApi.js
@@ -68,12 +68,8 @@ const decodeFreshness = (freshness) => {
       .map(({ retrievedAt }) => retrievedAt)
       .filter(Boolean)
       .sort()
-      .at(-1);
-    const retrievedAt =
-      poolRetrievedAt ||
-      providers.find((provider) => provider.status === status)?.retrievedAt ||
-      providerRetrievedAt ||
-      null;
+      .at(0);
+    const retrievedAt = poolRetrievedAt || providerRetrievedAt || null;
     poolSurface = { status, retrievedAt };
   }
   return { schedule, pool: { ...poolSurface, providers } };

--- a/src/slateApi.js
+++ b/src/slateApi.js
@@ -1,6 +1,11 @@
 import { apiClient, getApiUrl } from './config';
 import { isCalendarDate } from './calendarDate';
-import { derivePoolStatusFromProviders, poolStatuses, scheduleStatuses } from './slateStatus';
+import {
+  derivePoolStatusFromProviders,
+  deriveScheduleStatus,
+  isStatusAllowed,
+  statusAllowsNullRetrievedAt,
+} from './slateStatus';
 
 const createInvalidSlateError = () => new Error('The slate endpoint returned an invalid response.');
 
@@ -12,12 +17,12 @@ const decodeRetrievedAt = (value) => {
   return retrievedAt.toISOString();
 };
 
-const decodeFreshnessSurface = (surface, statuses) => {
-  if (!surface || !statuses.has(surface.status) || !('retrieved_at' in surface)) {
+const decodeFreshnessSurface = (surface, surfaceName) => {
+  if (!surface || !isStatusAllowed(surface.status, surfaceName) || !('retrieved_at' in surface)) {
     throw createInvalidSlateError();
   }
   const retrievedAt = decodeRetrievedAt(surface.retrieved_at);
-  if (!retrievedAt && !['missing', 'unavailable'].includes(surface.status)) {
+  if (!retrievedAt && !statusAllowsNullRetrievedAt(surface.status)) {
     throw createInvalidSlateError();
   }
   return { status: surface.status, retrievedAt };
@@ -27,7 +32,17 @@ const decodeFreshness = (freshness) => {
   if (!freshness || typeof freshness !== 'object' || !freshness.pool) {
     throw createInvalidSlateError();
   }
-  const schedule = decodeFreshnessSurface(freshness.schedule, scheduleStatuses);
+  if (!freshness.schedule || !('retrieved_at' in freshness.schedule)) {
+    throw createInvalidSlateError();
+  }
+  const schedule =
+    freshness.schedule.status === undefined
+      ? (() => {
+          const retrievedAt = decodeRetrievedAt(freshness.schedule.retrieved_at);
+          if (!retrievedAt) throw createInvalidSlateError();
+          return { status: deriveScheduleStatus(retrievedAt), retrievedAt };
+        })()
+      : decodeFreshnessSurface(freshness.schedule, 'schedule');
   const providerSurfaces = freshness.pool.providers;
   if (
     providerSurfaces !== undefined &&
@@ -39,11 +54,11 @@ const decodeFreshness = (freshness) => {
   }
   const providers = Object.entries(providerSurfaces || {}).map(([name, surface]) => {
     if (!name) throw createInvalidSlateError();
-    return { name, ...decodeFreshnessSurface(surface, poolStatuses) };
+    return { name, ...decodeFreshnessSurface(surface, 'pool') };
   });
   let poolSurface;
   if (freshness.pool.status !== undefined) {
-    poolSurface = decodeFreshnessSurface(freshness.pool, poolStatuses);
+    poolSurface = decodeFreshnessSurface(freshness.pool, 'pool');
   } else {
     const status = derivePoolStatusFromProviders(providers);
     if (!status || !('retrieved_at' in freshness.pool)) throw createInvalidSlateError();
@@ -82,7 +97,7 @@ const decodeGame = (game) => {
     typeof game.scheduled_at !== 'string' ||
     !game.status ||
     !['scheduled', 'postponed', 'final'].includes(game.status.state) ||
-    typeof game.status.label !== 'string' ||
+    (game.status.label !== undefined && typeof game.status.label !== 'string') ||
     typeof game.preseason !== 'boolean'
   ) {
     throw createInvalidSlateError();
@@ -97,7 +112,7 @@ const decodeGame = (game) => {
     home: decodeTeam(game.home_team),
     scheduledAt: scheduledAt.toISOString(),
     status: game.status.state,
-    statusLabel: game.status.label,
+    statusLabel: game.status.label || null,
     classification: typeof game.classification === 'string' ? game.classification : null,
     preseason: game.preseason,
   };
@@ -109,7 +124,7 @@ export const decodeSlate = (data) => {
     !isCalendarDate(data.slate_date) ||
     !Array.isArray(data.games) ||
     !data.freshness ||
-    (data.pool_status !== undefined && !poolStatuses.has(data.pool_status))
+    (data.pool_status !== undefined && !isStatusAllowed(data.pool_status, 'pool'))
   ) {
     throw createInvalidSlateError();
   }

--- a/src/slateApi.test.js
+++ b/src/slateApi.test.js
@@ -214,6 +214,23 @@ test('derives missing pool freshness status from provider evidence', () => {
   );
 });
 
+test.each([
+  ['2026-01-14T06:00:00Z', 'fresh'],
+  ['2026-01-14T05:59:59Z', 'stale'],
+])('derives missing schedule status from its 30h threshold at %s', (retrievedAt, expected) => {
+  jest.useFakeTimers().setSystemTime(new Date('2026-01-15T12:00:00Z'));
+  const candidate = {
+    ...payload,
+    freshness: {
+      ...payload.freshness,
+      schedule: { retrieved_at: retrievedAt },
+    },
+  };
+
+  expect(decodeSlate(candidate).freshness.schedule.status).toBe(expected);
+  jest.useRealTimers();
+});
+
 test('validates optional provider freshness when providers are present', () => {
   expect(() =>
     decodeSlate({

--- a/src/slateApi.test.js
+++ b/src/slateApi.test.js
@@ -1,0 +1,69 @@
+import { decodeSlate, fetchSlate } from './slateApi';
+import { apiClient, getApiUrl } from './config';
+
+jest.mock('./utils/axiosConfig', () => ({
+  __esModule: true,
+  default: { get: jest.fn() },
+}));
+
+const payload = {
+  slate_date: '2026-01-15',
+  freshness: {
+    schedule: { retrieved_at: '2026-01-15T10:00:00Z', status: 'fresh' },
+    pool: { status: 'unavailable', retrieved_at: null, providers: {} },
+  },
+  pool_status: 'unavailable',
+  games: [
+    {
+      game_id: '0022500584',
+      away_team: {
+        team_id: 1610612747,
+        tricode: 'LAL',
+        name: 'Los Angeles Lakers',
+        targetable_player_count: 5,
+      },
+      home_team: {
+        team_id: 1610612738,
+        tricode: 'BOS',
+        name: 'Boston Celtics',
+        targetable_player_count: 4,
+      },
+      scheduled_at: '2026-01-16T00:30:00Z',
+      status: { state: 'scheduled', label: '7:30 PM ET' },
+      classification: 'NBA Paris Game',
+      preseason: false,
+      targetable_counts: { away: 5, home: 4 },
+    },
+  ],
+};
+
+test('decodes the slate boundary including freshness and targetable counts', () => {
+  expect(decodeSlate(payload)).toEqual({
+    slateDate: '2026-01-15',
+    freshness: payload.freshness,
+    poolStatus: 'unavailable',
+    games: [
+      expect.objectContaining({
+        gameId: '0022500584',
+        scheduledAt: '2026-01-16T00:30:00.000Z',
+        targetableCounts: { away: 5, home: 4 },
+      }),
+    ],
+  });
+});
+
+test('rejects malformed slate payloads rather than inventing an empty slate', () => {
+  expect(() => decodeSlate({ slate_date: '2026-01-15' })).toThrow(
+    'The slate endpoint returned an invalid response.',
+  );
+});
+
+test('fetches a dated slate through the endpoint catalog and bearer transport', async () => {
+  apiClient.get.mockResolvedValue({ data: payload });
+
+  await expect(fetchSlate('2026-01-15')).resolves.toEqual(decodeSlate(payload));
+  expect(apiClient.get).toHaveBeenCalledWith(getApiUrl('SLATE'), {
+    params: { date: '2026-01-15' },
+    signal: undefined,
+  });
+});

--- a/src/slateApi.test.js
+++ b/src/slateApi.test.js
@@ -104,6 +104,17 @@ test.each([
     },
   ],
   ['unknown aggregate pool status', { ...payload, pool_status: 'old' }],
+  ['frontend-derived aggregate pool status', { ...payload, pool_status: 'partial' }],
+  [
+    'frontend-derived pool freshness status',
+    {
+      ...payload,
+      freshness: {
+        ...payload.freshness,
+        pool: { status: 'partial', retrieved_at: null, providers: {} },
+      },
+    },
+  ],
   ['invalid calendar slate date', { ...payload, slate_date: '2026-02-30' }],
 ])('rejects a %s', (_label, malformedPayload) => {
   expect(() => decodeSlate(malformedPayload)).toThrow(
@@ -265,6 +276,34 @@ test('accepts provider freshness without a pool-level retrieved_at', () => {
       freshness: expect.objectContaining({
         pool: expect.objectContaining({ status: 'partial' }),
       }),
+    }),
+  );
+});
+
+test.each([
+  [
+    {
+      prizepicks: { status: 'fresh', retrieved_at: '2026-01-15T11:50:00Z' },
+      underdog: { status: 'fresh', retrieved_at: '2026-01-15T11:30:00Z' },
+    },
+  ],
+  [
+    {
+      underdog: { status: 'fresh', retrieved_at: '2026-01-15T11:30:00Z' },
+      prizepicks: { status: 'fresh', retrieved_at: '2026-01-15T11:50:00Z' },
+    },
+  ],
+])('uses the oldest provider timestamp independent of key order', (providers) => {
+  const candidate = {
+    ...payload,
+    freshness: { ...payload.freshness, pool: { providers } },
+  };
+  delete candidate.pool_status;
+
+  expect(decodeSlate(candidate).freshness.pool).toEqual(
+    expect.objectContaining({
+      status: 'fresh',
+      retrievedAt: '2026-01-15T11:30:00.000Z',
     }),
   );
 });

--- a/src/slateApi.test.js
+++ b/src/slateApi.test.js
@@ -215,6 +215,36 @@ test('derives missing pool freshness status from provider evidence', () => {
 });
 
 test.each([
+  [['fresh', 'missing'], 'missing'],
+  [['fresh', 'stale-served'], 'stale-served'],
+  [['unavailable'], 'unavailable'],
+])('derives degraded pool status %s from mixed providers', (statuses, expected) => {
+  const candidate = {
+    ...payload,
+    freshness: {
+      ...payload.freshness,
+      pool: {
+        retrieved_at: null,
+        providers: Object.fromEntries(
+          statuses.map((status, index) => [
+            `provider-${index}`,
+            {
+              status,
+              retrieved_at: ['missing', 'unavailable'].includes(status)
+                ? null
+                : '2026-01-15T09:55:00Z',
+            },
+          ]),
+        ),
+      },
+    },
+  };
+  delete candidate.pool_status;
+
+  expect(decodeSlate(candidate).poolStatus).toBe(expected);
+});
+
+test.each([
   ['2026-01-14T06:00:00Z', 'fresh'],
   ['2026-01-14T05:59:59Z', 'stale'],
 ])('derives missing schedule status from its 30h threshold at %s', (retrievedAt, expected) => {

--- a/src/slateApi.test.js
+++ b/src/slateApi.test.js
@@ -215,10 +215,10 @@ test('derives missing pool freshness status from provider evidence', () => {
 });
 
 test.each([
-  [['fresh', 'missing'], 'missing'],
-  [['fresh', 'stale-served'], 'stale-served'],
+  [['fresh', 'missing'], 'partial'],
+  [['fresh', 'stale-served'], 'partial'],
   [['unavailable'], 'unavailable'],
-])('derives degraded pool status %s from mixed providers', (statuses, expected) => {
+])('preserves provider-aware pool status %s from providers', (statuses, expected) => {
   const candidate = {
     ...payload,
     freshness: {
@@ -242,6 +242,31 @@ test.each([
   delete candidate.pool_status;
 
   expect(decodeSlate(candidate).poolStatus).toBe(expected);
+});
+
+test('accepts provider freshness without a pool-level retrieved_at', () => {
+  const candidate = {
+    ...payload,
+    freshness: {
+      ...payload.freshness,
+      pool: {
+        providers: {
+          prizepicks: { status: 'fresh', retrieved_at: '2026-01-15T09:55:00Z' },
+          underdog: { status: 'missing', retrieved_at: null },
+        },
+      },
+    },
+  };
+  delete candidate.pool_status;
+
+  expect(decodeSlate(candidate)).toEqual(
+    expect.objectContaining({
+      poolStatus: 'partial',
+      freshness: expect.objectContaining({
+        pool: expect.objectContaining({ status: 'partial' }),
+      }),
+    }),
+  );
 });
 
 test.each([

--- a/src/slateApi.test.js
+++ b/src/slateApi.test.js
@@ -115,6 +115,14 @@ test.each([
       },
     },
   ],
+  ...['text', 7, null].map((schedule) => [
+    `primitive schedule surface ${String(schedule)}`,
+    { ...payload, freshness: { ...payload.freshness, schedule } },
+  ]),
+  ...['text', 7, null].map((pool) => [
+    `primitive pool surface ${String(pool)}`,
+    { ...payload, freshness: { ...payload.freshness, pool } },
+  ]),
   ['invalid calendar slate date', { ...payload, slate_date: '2026-02-30' }],
 ])('rejects a %s', (_label, malformedPayload) => {
   expect(() => decodeSlate(malformedPayload)).toThrow(

--- a/src/slateApi.test.js
+++ b/src/slateApi.test.js
@@ -10,9 +10,16 @@ const payload = {
   slate_date: '2026-01-15',
   freshness: {
     schedule: { retrieved_at: '2026-01-15T10:00:00Z', status: 'fresh' },
-    pool: { status: 'unavailable', retrieved_at: null, providers: {} },
+    pool: {
+      status: 'stale-served',
+      retrieved_at: '2026-01-15T09:55:00Z',
+      providers: {
+        prizepicks: { status: 'fresh', retrieved_at: '2026-01-15T09:55:00Z' },
+        underdog: { status: 'missing', retrieved_at: null },
+      },
+    },
   },
-  pool_status: 'unavailable',
+  pool_status: 'stale-served',
   games: [
     {
       game_id: '0022500584',
@@ -32,24 +39,97 @@ const payload = {
       status: { state: 'scheduled', label: '7:30 PM ET' },
       classification: 'NBA Paris Game',
       preseason: false,
-      targetable_counts: { away: 5, home: 4 },
     },
   ],
 };
 
-test('decodes the slate boundary including freshness and targetable counts', () => {
+test('decodes the complete slate freshness boundary and team counts', () => {
   expect(decodeSlate(payload)).toEqual({
     slateDate: '2026-01-15',
-    freshness: payload.freshness,
-    poolStatus: 'unavailable',
+    freshness: {
+      schedule: { retrievedAt: '2026-01-15T10:00:00.000Z', status: 'fresh' },
+      pool: {
+        status: 'stale-served',
+        retrievedAt: '2026-01-15T09:55:00.000Z',
+        providers: [
+          {
+            name: 'prizepicks',
+            status: 'fresh',
+            retrievedAt: '2026-01-15T09:55:00.000Z',
+          },
+          { name: 'underdog', status: 'missing', retrievedAt: null },
+        ],
+      },
+    },
+    poolStatus: 'stale-served',
     games: [
       expect.objectContaining({
         gameId: '0022500584',
         scheduledAt: '2026-01-16T00:30:00.000Z',
-        targetableCounts: { away: 5, home: 4 },
+        away: expect.objectContaining({ targetablePlayerCount: 5 }),
+        home: expect.objectContaining({ targetablePlayerCount: 4 }),
       }),
     ],
   });
+});
+
+test.each([
+  [
+    'missing freshness surface',
+    { ...payload, freshness: { schedule: payload.freshness.schedule } },
+  ],
+  [
+    'unknown schedule status',
+    {
+      ...payload,
+      freshness: {
+        ...payload.freshness,
+        schedule: { ...payload.freshness.schedule, status: 'old' },
+      },
+    },
+  ],
+  [
+    'invalid provider retrieval time',
+    {
+      ...payload,
+      freshness: {
+        ...payload.freshness,
+        pool: {
+          ...payload.freshness.pool,
+          providers: {
+            prizepicks: { status: 'fresh', retrieved_at: 'not-a-date' },
+          },
+        },
+      },
+    },
+  ],
+  ['unknown aggregate pool status', { ...payload, pool_status: 'old' }],
+  ['invalid calendar slate date', { ...payload, slate_date: '2026-02-30' }],
+])('rejects a %s', (_label, malformedPayload) => {
+  expect(() => decodeSlate(malformedPayload)).toThrow(
+    'The slate endpoint returned an invalid response.',
+  );
+});
+
+test('accepts schedule staleness and an unavailable aggregate pool from the backend contract', () => {
+  expect(
+    decodeSlate({
+      ...payload,
+      pool_status: 'unavailable',
+      freshness: {
+        schedule: { status: 'stale', retrieved_at: '2026-01-13T10:00:00Z' },
+        pool: { status: 'unavailable', retrieved_at: null, providers: {} },
+      },
+    }),
+  ).toEqual(
+    expect.objectContaining({
+      poolStatus: 'unavailable',
+      freshness: {
+        schedule: { status: 'stale', retrievedAt: '2026-01-13T10:00:00.000Z' },
+        pool: { status: 'unavailable', retrievedAt: null, providers: [] },
+      },
+    }),
+  );
 });
 
 test('rejects malformed slate payloads rather than inventing an empty slate', () => {

--- a/src/slateApi.test.js
+++ b/src/slateApi.test.js
@@ -149,26 +149,69 @@ test('derives the aggregate pool status when the optional top-level field is abs
   );
 });
 
-test('does not report the pool unavailable when freshness has served evidence', () => {
-  expect(
-    decodeSlate({
+test.each([
+  ['unavailable', 'stale-served', 'stale-served', 'unavailable'],
+  ['fresh', 'unavailable', 'missing', 'fresh'],
+  [undefined, 'stale-served', 'fresh', 'stale-served'],
+])(
+  'uses aggregate %s with pool freshness %s and provider freshness %s',
+  (aggregateStatus, poolFreshnessStatus, providerStatus, expected) => {
+    const candidate = {
       ...payload,
-      pool_status: 'unavailable',
       freshness: {
         ...payload.freshness,
         pool: {
-          status: 'unavailable',
-          retrieved_at: null,
+          status: poolFreshnessStatus,
+          retrieved_at: ['missing', 'unavailable'].includes(poolFreshnessStatus)
+            ? null
+            : '2026-01-15T09:55:00Z',
           providers: {
             prizepicks: {
-              status: 'stale-served',
-              retrieved_at: '2026-01-15T09:55:00Z',
+              status: providerStatus,
+              retrieved_at: ['missing', 'unavailable'].includes(providerStatus)
+                ? null
+                : '2026-01-15T09:55:00Z',
             },
           },
         },
       },
-    }).poolStatus,
-  ).toBe('stale-served');
+    };
+    if (aggregateStatus === undefined) delete candidate.pool_status;
+    else candidate.pool_status = aggregateStatus;
+
+    expect(decodeSlate(candidate).poolStatus).toBe(expected);
+  },
+);
+
+test('derives missing pool freshness status from provider evidence', () => {
+  const candidate = {
+    ...payload,
+    freshness: {
+      ...payload.freshness,
+      pool: {
+        retrieved_at: null,
+        providers: {
+          prizepicks: {
+            status: 'stale-served',
+            retrieved_at: '2026-01-15T09:55:00Z',
+          },
+        },
+      },
+    },
+  };
+  delete candidate.pool_status;
+
+  expect(decodeSlate(candidate)).toEqual(
+    expect.objectContaining({
+      poolStatus: 'stale-served',
+      freshness: expect.objectContaining({
+        pool: expect.objectContaining({
+          status: 'stale-served',
+          retrievedAt: '2026-01-15T09:55:00.000Z',
+        }),
+      }),
+    }),
+  );
 });
 
 test('validates optional provider freshness when providers are present', () => {

--- a/src/slateApi.test.js
+++ b/src/slateApi.test.js
@@ -1,9 +1,9 @@
 import { decodeSlate, fetchSlate } from './slateApi';
 import { apiClient, getApiUrl } from './config';
 
-jest.mock('./utils/axiosConfig', () => ({
-  __esModule: true,
-  default: { get: jest.fn() },
+jest.mock('./config', () => ({
+  apiClient: { get: jest.fn() },
+  getApiUrl: jest.fn(() => '/api/games/slate'),
 }));
 
 const payload = {
@@ -130,6 +130,57 @@ test('accepts schedule staleness and an unavailable aggregate pool from the back
       },
     }),
   );
+});
+
+test('derives the aggregate pool status when the optional top-level field is absent', () => {
+  const { pool_status: _poolStatus, ...minimumPayload } = payload;
+  minimumPayload.freshness = {
+    ...minimumPayload.freshness,
+    pool: { status: 'fresh', retrieved_at: '2026-01-15T09:55:00Z' },
+  };
+
+  expect(decodeSlate(minimumPayload)).toEqual(
+    expect.objectContaining({
+      poolStatus: 'fresh',
+      freshness: expect.objectContaining({
+        pool: expect.objectContaining({ status: 'fresh', providers: [] }),
+      }),
+    }),
+  );
+});
+
+test('does not report the pool unavailable when freshness has served evidence', () => {
+  expect(
+    decodeSlate({
+      ...payload,
+      pool_status: 'unavailable',
+      freshness: {
+        ...payload.freshness,
+        pool: {
+          status: 'unavailable',
+          retrieved_at: null,
+          providers: {
+            prizepicks: {
+              status: 'stale-served',
+              retrieved_at: '2026-01-15T09:55:00Z',
+            },
+          },
+        },
+      },
+    }).poolStatus,
+  ).toBe('stale-served');
+});
+
+test('validates optional provider freshness when providers are present', () => {
+  expect(() =>
+    decodeSlate({
+      ...payload,
+      freshness: {
+        ...payload.freshness,
+        pool: { ...payload.freshness.pool, providers: [] },
+      },
+    }),
+  ).toThrow('The slate endpoint returned an invalid response.');
 });
 
 test('rejects malformed slate payloads rather than inventing an empty slate', () => {

--- a/src/slateStatus.js
+++ b/src/slateStatus.js
@@ -2,7 +2,7 @@ const definitions = {
   fresh: {
     allowedSurfaces: ['schedule', 'pool'],
     allowsNullRetrievedAt: false,
-    providerRank: 4,
+    providerRank: 0,
     warning: false,
     currentPoolMessage: 'Targetable counts use the current player pool.',
     historicalPoolMessage:
@@ -17,7 +17,7 @@ const definitions = {
   'stale-served': {
     allowedSurfaces: ['pool'],
     allowsNullRetrievedAt: false,
-    providerRank: 3,
+    providerRank: 1,
     warning: true,
     currentPoolMessage:
       'Player pool is stale-served; targetable counts use the latest available snapshot.',
@@ -27,7 +27,7 @@ const definitions = {
   missing: {
     allowedSurfaces: ['schedule', 'pool'],
     allowsNullRetrievedAt: true,
-    providerRank: 1,
+    providerRank: 2,
     warning: true,
     currentPoolMessage: 'Player pool unavailable; no targetable players are currently available.',
     historicalPoolMessage:
@@ -36,7 +36,7 @@ const definitions = {
   unavailable: {
     allowedSurfaces: ['pool'],
     allowsNullRetrievedAt: true,
-    providerRank: 2,
+    providerRank: 3,
     warning: true,
     currentPoolMessage: 'Player pool unavailable; no targetable players are currently available.',
     historicalPoolMessage:
@@ -62,6 +62,29 @@ export const derivePoolStatusFromProviders = (providers) => {
 };
 
 export const SCHEDULE_STALE_AFTER_MS = 30 * 60 * 60 * 1000;
+export const POOL_STALE_AFTER_MS = 15 * 60 * 1000;
 
 export const deriveScheduleStatus = (retrievedAt, now = Date.now()) =>
   now - new Date(retrievedAt).getTime() <= SCHEDULE_STALE_AFTER_MS ? 'fresh' : 'stale';
+
+export const getSurfaceFreshnessPresentation = (surface, surfaceName, now = Date.now()) => {
+  let status = surface.status;
+  let warning = definitions[status].warning;
+  let thresholdNote = null;
+
+  if (status === 'fresh' && surface.retrievedAt) {
+    if (surfaceName === 'schedule' && deriveScheduleStatus(surface.retrievedAt, now) === 'stale') {
+      status = 'stale';
+      warning = true;
+    }
+    if (
+      surfaceName === 'pool' &&
+      now - new Date(surface.retrievedAt).getTime() > POOL_STALE_AFTER_MS
+    ) {
+      warning = true;
+      thresholdNote = 'older than 15m freshness bar';
+    }
+  }
+
+  return { status, warning, thresholdNote };
+};

--- a/src/slateStatus.js
+++ b/src/slateStatus.js
@@ -1,0 +1,59 @@
+const definitions = {
+  fresh: {
+    schedule: true,
+    pool: true,
+    warning: false,
+    currentPoolMessage: 'Targetable counts use the current player pool.',
+    historicalPoolMessage:
+      'Past slate — the current player pool is not displayed for historical dates. Final game cards retain the posted targetable counts returned for this slate.',
+  },
+  stale: { schedule: true, pool: false, warning: true },
+  'stale-served': {
+    schedule: false,
+    pool: true,
+    warning: true,
+    currentPoolMessage:
+      'Player pool is stale-served; targetable counts use the latest available snapshot.',
+    historicalPoolMessage:
+      'Past slate — the latest available snapshot is not displayed for historical dates. Final game cards retain the posted targetable counts returned for this slate.',
+  },
+  missing: {
+    schedule: true,
+    pool: true,
+    warning: true,
+    currentPoolMessage: 'Player pool unavailable; no targetable players are currently available.',
+    historicalPoolMessage:
+      'Past slate — the player pool is missing and no current pool is displayed. Game cards retain the targetable counts returned for this slate.',
+  },
+  unavailable: {
+    schedule: false,
+    pool: true,
+    warning: true,
+    currentPoolMessage: 'Player pool unavailable; no targetable players are currently available.',
+    historicalPoolMessage:
+      'Past slate — the player pool is unavailable and no current pool is displayed. Game cards retain the returned targetable counts for this slate.',
+  },
+};
+
+export const scheduleStatuses = new Set(
+  Object.entries(definitions)
+    .filter(([, definition]) => definition.schedule)
+    .map(([status]) => status),
+);
+
+export const poolStatuses = new Set(
+  Object.entries(definitions)
+    .filter(([, definition]) => definition.pool)
+    .map(([status]) => status),
+);
+
+export const getStatusPresentation = (status) => definitions[status];
+
+export const derivePoolStatusFromProviders = (providers) => {
+  const statuses = providers.map(({ status }) => status);
+  if (statuses.includes('fresh')) return 'fresh';
+  if (statuses.includes('stale-served')) return 'stale-served';
+  if (statuses.includes('unavailable')) return 'unavailable';
+  if (statuses.includes('missing')) return 'missing';
+  return null;
+};

--- a/src/slateStatus.js
+++ b/src/slateStatus.js
@@ -13,6 +13,9 @@ const definitions = {
     allowsNullRetrievedAt: false,
     providerRank: null,
     warning: true,
+    currentPoolMessage: 'Player pool snapshot is stale; targetable counts may be out of date.',
+    historicalPoolMessage:
+      'Past slate — the stale player pool snapshot is not displayed. Game cards retain the targetable counts returned for this slate.',
   },
   'stale-served': {
     allowedSurfaces: ['pool'],
@@ -29,7 +32,7 @@ const definitions = {
     allowsNullRetrievedAt: true,
     providerRank: 2,
     warning: true,
-    currentPoolMessage: 'Player pool unavailable; no targetable players are currently available.',
+    currentPoolMessage: 'Player pool is missing; no targetable players are currently available.',
     historicalPoolMessage:
       'Past slate — the player pool is missing and no current pool is displayed. Game cards retain the targetable counts returned for this slate.',
   },
@@ -38,9 +41,19 @@ const definitions = {
     allowsNullRetrievedAt: true,
     providerRank: 3,
     warning: true,
-    currentPoolMessage: 'Player pool unavailable; no targetable players are currently available.',
+    currentPoolMessage:
+      'Player pool is unavailable; no targetable players are currently available.',
     historicalPoolMessage:
       'Past slate — the player pool is unavailable and no current pool is displayed. Game cards retain the returned targetable counts for this slate.',
+  },
+  partial: {
+    allowedSurfaces: ['pool'],
+    allowsNullRetrievedAt: true,
+    providerRank: null,
+    warning: true,
+    currentPoolMessage: 'Player pool is partial; targetable counts reflect the available boards.',
+    historicalPoolMessage:
+      'Past slate — the partial player pool is not displayed. Final game cards retain the posted targetable counts returned for this slate.',
   },
 };
 
@@ -53,12 +66,10 @@ export const statusAllowsNullRetrievedAt = (status) =>
   Boolean(definitions[status]?.allowsNullRetrievedAt);
 
 export const derivePoolStatusFromProviders = (providers) => {
-  return providers.reduce((highest, provider) => {
-    const rank = definitions[provider.status]?.providerRank;
-    if (rank === null || rank === undefined) return highest;
-    if (!highest || rank > definitions[highest].providerRank) return provider.status;
-    return highest;
-  }, null);
+  const statuses = new Set(providers.map(({ status }) => status));
+  if (statuses.size === 0) return null;
+  if (statuses.size === 1) return statuses.values().next().value;
+  return 'partial';
 };
 
 export const SCHEDULE_STALE_AFTER_MS = 30 * 60 * 60 * 1000;
@@ -81,8 +92,9 @@ export const getSurfaceFreshnessPresentation = (surface, surfaceName, now = Date
       surfaceName === 'pool' &&
       now - new Date(surface.retrievedAt).getTime() > POOL_STALE_AFTER_MS
     ) {
+      status = 'stale';
       warning = true;
-      thresholdNote = 'older than 15m freshness bar';
+      thresholdNote = `older than ${POOL_STALE_AFTER_MS / 60000}m freshness bar`;
     }
   }
 

--- a/src/slateStatus.js
+++ b/src/slateStatus.js
@@ -1,16 +1,23 @@
 const definitions = {
   fresh: {
-    schedule: true,
-    pool: true,
+    allowedSurfaces: ['schedule', 'pool'],
+    allowsNullRetrievedAt: false,
+    providerRank: 4,
     warning: false,
     currentPoolMessage: 'Targetable counts use the current player pool.',
     historicalPoolMessage:
       'Past slate — the current player pool is not displayed for historical dates. Final game cards retain the posted targetable counts returned for this slate.',
   },
-  stale: { schedule: true, pool: false, warning: true },
+  stale: {
+    allowedSurfaces: ['schedule'],
+    allowsNullRetrievedAt: false,
+    providerRank: null,
+    warning: true,
+  },
   'stale-served': {
-    schedule: false,
-    pool: true,
+    allowedSurfaces: ['pool'],
+    allowsNullRetrievedAt: false,
+    providerRank: 3,
     warning: true,
     currentPoolMessage:
       'Player pool is stale-served; targetable counts use the latest available snapshot.',
@@ -18,16 +25,18 @@ const definitions = {
       'Past slate — the latest available snapshot is not displayed for historical dates. Final game cards retain the posted targetable counts returned for this slate.',
   },
   missing: {
-    schedule: true,
-    pool: true,
+    allowedSurfaces: ['schedule', 'pool'],
+    allowsNullRetrievedAt: true,
+    providerRank: 1,
     warning: true,
     currentPoolMessage: 'Player pool unavailable; no targetable players are currently available.',
     historicalPoolMessage:
       'Past slate — the player pool is missing and no current pool is displayed. Game cards retain the targetable counts returned for this slate.',
   },
   unavailable: {
-    schedule: false,
-    pool: true,
+    allowedSurfaces: ['pool'],
+    allowsNullRetrievedAt: true,
+    providerRank: 2,
     warning: true,
     currentPoolMessage: 'Player pool unavailable; no targetable players are currently available.',
     historicalPoolMessage:
@@ -35,25 +44,24 @@ const definitions = {
   },
 };
 
-export const scheduleStatuses = new Set(
-  Object.entries(definitions)
-    .filter(([, definition]) => definition.schedule)
-    .map(([status]) => status),
-);
-
-export const poolStatuses = new Set(
-  Object.entries(definitions)
-    .filter(([, definition]) => definition.pool)
-    .map(([status]) => status),
-);
-
 export const getStatusPresentation = (status) => definitions[status];
 
+export const isStatusAllowed = (status, surface) =>
+  Boolean(definitions[status]?.allowedSurfaces.includes(surface));
+
+export const statusAllowsNullRetrievedAt = (status) =>
+  Boolean(definitions[status]?.allowsNullRetrievedAt);
+
 export const derivePoolStatusFromProviders = (providers) => {
-  const statuses = providers.map(({ status }) => status);
-  if (statuses.includes('fresh')) return 'fresh';
-  if (statuses.includes('stale-served')) return 'stale-served';
-  if (statuses.includes('unavailable')) return 'unavailable';
-  if (statuses.includes('missing')) return 'missing';
-  return null;
+  return providers.reduce((highest, provider) => {
+    const rank = definitions[provider.status]?.providerRank;
+    if (rank === null || rank === undefined) return highest;
+    if (!highest || rank > definitions[highest].providerRank) return provider.status;
+    return highest;
+  }, null);
 };
+
+export const SCHEDULE_STALE_AFTER_MS = 30 * 60 * 60 * 1000;
+
+export const deriveScheduleStatus = (retrievedAt, now = Date.now()) =>
+  now - new Date(retrievedAt).getTime() <= SCHEDULE_STALE_AFTER_MS ? 'fresh' : 'stale';

--- a/src/slateStatus.js
+++ b/src/slateStatus.js
@@ -1,26 +1,23 @@
 const definitions = {
   fresh: {
-    allowedSurfaces: ['schedule', 'pool'],
+    inboundSurfaces: ['schedule', 'pool'],
     allowsNullRetrievedAt: false,
-    providerRank: 0,
     warning: false,
     currentPoolMessage: 'Targetable counts use the current player pool.',
     historicalPoolMessage:
       'Past slate — the current player pool is not displayed for historical dates. Final game cards retain the posted targetable counts returned for this slate.',
   },
   stale: {
-    allowedSurfaces: ['schedule'],
+    inboundSurfaces: ['schedule'],
     allowsNullRetrievedAt: false,
-    providerRank: null,
     warning: true,
     currentPoolMessage: 'Player pool snapshot is stale; targetable counts may be out of date.',
     historicalPoolMessage:
       'Past slate — the stale player pool snapshot is not displayed. Game cards retain the targetable counts returned for this slate.',
   },
   'stale-served': {
-    allowedSurfaces: ['pool'],
+    inboundSurfaces: ['pool'],
     allowsNullRetrievedAt: false,
-    providerRank: 1,
     warning: true,
     currentPoolMessage:
       'Player pool is stale-served; targetable counts use the latest available snapshot.',
@@ -28,18 +25,16 @@ const definitions = {
       'Past slate — the latest available snapshot is not displayed for historical dates. Final game cards retain the posted targetable counts returned for this slate.',
   },
   missing: {
-    allowedSurfaces: ['schedule', 'pool'],
+    inboundSurfaces: ['schedule', 'pool'],
     allowsNullRetrievedAt: true,
-    providerRank: 2,
     warning: true,
     currentPoolMessage: 'Player pool is missing; no targetable players are currently available.',
     historicalPoolMessage:
       'Past slate — the player pool is missing and no current pool is displayed. Game cards retain the targetable counts returned for this slate.',
   },
   unavailable: {
-    allowedSurfaces: ['pool'],
+    inboundSurfaces: ['pool'],
     allowsNullRetrievedAt: true,
-    providerRank: 3,
     warning: true,
     currentPoolMessage:
       'Player pool is unavailable; no targetable players are currently available.',
@@ -47,9 +42,8 @@ const definitions = {
       'Past slate — the player pool is unavailable and no current pool is displayed. Game cards retain the returned targetable counts for this slate.',
   },
   partial: {
-    allowedSurfaces: ['pool'],
+    inboundSurfaces: [],
     allowsNullRetrievedAt: true,
-    providerRank: null,
     warning: true,
     currentPoolMessage: 'Player pool is partial; targetable counts reflect the available boards.',
     historicalPoolMessage:
@@ -60,7 +54,7 @@ const definitions = {
 export const getStatusPresentation = (status) => definitions[status];
 
 export const isStatusAllowed = (status, surface) =>
-  Boolean(definitions[status]?.allowedSurfaces.includes(surface));
+  Boolean(definitions[status]?.inboundSurfaces.includes(surface));
 
 export const statusAllowsNullRetrievedAt = (status) =>
   Boolean(definitions[status]?.allowsNullRetrievedAt);

--- a/src/vercelConfig.test.js
+++ b/src/vercelConfig.test.js
@@ -1,0 +1,26 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const vercelConfig = JSON.parse(
+  fs.readFileSync(path.resolve(process.cwd(), 'vercel.json'), 'utf8'),
+);
+
+describe('Vercel deployment configuration', () => {
+  test('builds the Vite application into the configured deployment directory', () => {
+    expect(vercelConfig).toMatchObject({
+      framework: 'vite',
+      buildCommand: 'npm run build',
+      outputDirectory: 'build',
+    });
+  });
+
+  test('proxies API requests before applying the SPA fallback', () => {
+    expect(vercelConfig.rewrites).toEqual([
+      {
+        source: '/api/:path*',
+        destination: 'https://your-backend.example.com/api/:path*',
+      },
+      { source: '/:path*', destination: '/index.html' },
+    ]);
+  });
+});

--- a/src/vercelConfig.test.js
+++ b/src/vercelConfig.test.js
@@ -15,12 +15,8 @@ describe('Vercel deployment configuration', () => {
   });
 
   test('proxies API requests before applying the SPA fallback', () => {
-    expect(vercelConfig.rewrites).toEqual([
-      {
-        source: '/api/:path*',
-        destination: 'https://your-backend.example.com/api/:path*',
-      },
-      { source: '/:path*', destination: '/index.html' },
-    ]);
+    expect(vercelConfig.rewrites).toHaveLength(2);
+    expect(vercelConfig.rewrites[0]).toMatchObject({ source: '/api/:path*' });
+    expect(vercelConfig.rewrites[1]).toEqual({ source: '/:path*', destination: '/index.html' });
   });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "rewrites": [
-    { "source": "/api/:path*", "destination": "https://your-backend.example.com/api/:path*" }
+    { "source": "/api/:path*", "destination": "https://your-backend.example.com/api/:path*" },
+    { "source": "/:path*", "destination": "/index.html" }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,8 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "vite",
+  "buildCommand": "npm run build",
+  "outputDirectory": "build",
   "rewrites": [
     { "source": "/api/:path*", "destination": "https://your-backend.example.com/api/:path*" },
     { "source": "/:path*", "destination": "/index.html" }


### PR DESCRIPTION
Closes #6
Part of crf04/statsplus#14
Part of #5
Merge after: crf04/statsplus-backend#43

This PR intentionally targets the non-deploying `t3code/issue-5-matchups` packet branch. It completes the routing/shared-nav/slate slice while preserving the parent rollout rule; the final packet branch will merge to `master` only after backend #43.

Verification:
- lint and format:check: passed
- test:ci: 67 passed
- build: passed
- test:e2e: 15 passed
- Cross-repository contract check: passed
- Chromium desktop/narrow/keyboard/degraded-state QA: passed
- Final Opus 5 review: Standards CLEAR; Spec CLEAR