### PR TITLE
Build matchup detail spotting surface

### DIFF
--- a/e2e/fixtures/courtai.js
+++ b/e2e/fixtures/courtai.js
@@ -116,21 +116,98 @@ const defenseRow = (key, label, markets, season, last15) => ({
   last_15: last15,
 });
 
-const teamSheet = (team, rows) => ({
+const defensiveColumns = (offset = 0) => ({
+  OPP_TOV: {
+    season: { per_48: 14.2 + offset, percent_vs_league_average: 8 },
+    last_15: { per_48: 12.9 + offset, percent_vs_league_average: -3 },
+  },
+  OPP_STL: {
+    season: { per_48: 7.1 + offset, percent_vs_league_average: -5 },
+    last_15: { per_48: 7.8 + offset, percent_vs_league_average: 4 },
+  },
+  OPP_BLK: {
+    season: { per_48: 5.4 + offset, percent_vs_league_average: 11 },
+    last_15: { per_48: 4.7 + offset, percent_vs_league_average: -2 },
+  },
+});
+
+const teamSheet = (team, playTypes, offset = 0) => ({
   team_id: team.team_id,
   tricode: team.tricode,
   name: team.name,
-  defense_sheet: { play_types: rows },
+  defense_sheet: {
+    play_types: playTypes,
+    shot_zones: [
+      defenseRow(
+        'paint',
+        'Paint',
+        ['PTS', 'FGA'],
+        defenseValue(22 + offset, 10, 1.2, 25),
+        defenseValue(20 + offset, -7, -1.1, 7),
+      ),
+    ],
+    shot_types: [
+      defenseRow(
+        'catch-shoot',
+        'Catch and shoot',
+        ['PTS', 'FG3A'],
+        defenseValue(16 + offset, 9, 1.1, 23),
+        defenseValue(15 + offset, 8, 1.2, 22),
+      ),
+    ],
+    assist_locations: [
+      defenseRow(
+        'paint-assists',
+        'Paint assists',
+        ['AST'],
+        defenseValue(11 + offset, 13, 1.5, 28),
+        defenseValue(10 + offset, 9, 1.1, 24),
+      ),
+    ],
+    traditional: [
+      defenseRow(
+        'opponent-rebounds',
+        'Opponent rebounds',
+        ['REB'],
+        defenseValue(45 + offset, -8, -1.2, 4),
+        defenseValue(47 + offset, 6, 1.1, 21),
+      ),
+    ],
+  },
+  defensive_columns: defensiveColumns(offset),
 });
 
-const dietShare = (key, seasonShare, last15Share) => ({
+const dietShare = (key, seasonShare, last15Share, seasonVolume = 5.1, last15Volume = 5.4) => ({
   key,
-  season: { share: seasonShare, volume_per_game: 5.1 },
-  last_15: { share: last15Share, volume_per_game: 5.4 },
+  season: { share: seasonShare, volume_per_game: seasonVolume },
+  last_15: { share: last15Share, volume_per_game: last15Volume },
 });
+
+const scoreWindow = (value) => ({
+  components: {
+    play_types: { value: value - 0.01, thin: false },
+    shot_zones: { value, thin: false },
+  },
+  blend: { value, thin: false },
+});
+
+const scores = (markets, seasonValue, last15Value) =>
+  Object.fromEntries(
+    markets.map((market, index) => [
+      market,
+      {
+        season: scoreWindow(seasonValue + index / 100),
+        last_15: scoreWindow(last15Value + index / 100),
+      },
+    ]),
+  );
 
 export const matchupPayload = {
-  game: slateGame,
+  game: {
+    ...slateGame,
+    away_team: { ...slateGame.away_team, targetable_player_count: 2 },
+    home_team: { ...slateGame.home_team, targetable_player_count: 1 },
+  },
   teams: [
     teamSheet(slateGame.away_team, [
       defenseRow(
@@ -148,63 +225,88 @@ export const matchupPayload = {
         defenseValue(9, 5, 0.6, 19),
       ),
     ]),
-    teamSheet(slateGame.home_team, [
-      defenseRow(
-        'transition',
-        'Transition',
-        ['PTS', 'FGA'],
-        defenseValue(18.4, 12, 1.4, 27),
-        defenseValue(15.2, -8, -1.1, 5),
-      ),
-      defenseRow(
-        'above-break',
-        'Above-break three',
-        ['FG3A'],
-        defenseValue(10.2, -11, -1.3, 3),
-        defenseValue(11, -6, -0.7, 9),
-      ),
-      defenseRow(
-        'isolation',
-        'Isolation',
-        ['PTS'],
-        defenseValue(8.1, 2, 0.4, 16),
-        defenseValue(8.4, 4, 0.5, 18),
-      ),
-    ]),
+    teamSheet(
+      slateGame.home_team,
+      [
+        defenseRow(
+          'transition',
+          'Transition',
+          ['PTS', 'FGA'],
+          defenseValue(18.4, 12, 1.4, 27),
+          defenseValue(15.2, -8, -1.1, 5),
+        ),
+        defenseRow(
+          'above-break',
+          'Above-break three',
+          ['FG3A'],
+          defenseValue(10.2, -11, -1.3, 3),
+          defenseValue(11, -6, -0.7, 9),
+        ),
+        defenseRow(
+          'isolation',
+          'Isolation',
+          ['PTS'],
+          defenseValue(8.1, 2, 0.4, 16),
+          defenseValue(8.4, 4, 0.5, 18),
+        ),
+      ],
+      1,
+    ),
   ],
+  // The backend owns the Out override. Maxi Kleber represents a board-posted
+  // player removed from the returned Player Pool while remaining in injuries;
+  // the frontend renders this authoritative result and does not reimplement it.
   players: [
     {
       canonical_id: 'lebron-james',
       name: 'LeBron James',
       team_id: slateGame.away_team.team_id,
       tricode: 'LAL',
-      posted_markets: ['PTS', 'FGA'],
+      posted_markets: ['PTS', 'FGA', 'AST', 'REB', 'TOV'],
       season_scoring: 25.4,
       last_10_minutes: [35, 36, 38, 34, 37, 36, 35, 39, 36, 37],
-      diet_shares: { play_types: [dietShare('transition', 0.19, 0.2)] },
+      diet_shares: {
+        play_types: [dietShare('transition', 0.19, 0.2)],
+        shot_zones: [dietShare('paint', 0.27, 0.28)],
+        shot_types: [dietShare('catch-shoot', 0.36, 0.37, 4.2, 4.3)],
+        assist_locations: [dietShare('paint-assists', 0.31, 0.32, 1.1, 1.2)],
+      },
       injury_badge_ref: null,
+      scores: scores(['PTS', 'FGA', 'AST', 'REB', 'TOV'], 0.12, -0.02),
     },
     {
       canonical_id: 'austin-reaves',
       name: 'Austin Reaves',
       team_id: slateGame.away_team.team_id,
       tricode: 'LAL',
-      posted_markets: ['PTS', 'FG3A'],
+      posted_markets: ['PTS', 'FG3A', 'STL'],
       season_scoring: 20.1,
       last_10_minutes: [32, 35, 34, 33, 31, 35, 36, 34, 35, 33],
-      diet_shares: { play_types: [dietShare('transition', 0.14, 0.18)] },
+      diet_shares: {
+        play_types: [dietShare('transition', 0.14, 0.18)],
+        shot_zones: [dietShare('paint', 0.24, 0.26)],
+        shot_types: [dietShare('catch-shoot', 0.4, 0.41, 3.9, 3.8)],
+        assist_locations: [dietShare('paint-assists', 0.35, 0.36, 0.8, 0.9)],
+      },
       injury_badge_ref: 'injury-austin',
+      scores: scores(['PTS', 'FG3A', 'STL'], 0.24, 0.08),
     },
     {
       canonical_id: 'jayson-tatum',
       name: 'Jayson Tatum',
       team_id: slateGame.home_team.team_id,
       tricode: 'BOS',
-      posted_markets: ['PTS', 'FGA', 'FG3A'],
+      posted_markets: ['PTS', 'FGA', 'FG3A', 'REB', 'BLK'],
       season_scoring: 27.2,
       last_10_minutes: [36, 37, 35, 38, 34, 36, 39, 37, 36, 38],
-      diet_shares: { play_types: [dietShare('transition', 0.21, 0.23)] },
+      diet_shares: {
+        play_types: [dietShare('transition', 0.21, 0.23)],
+        shot_zones: [dietShare('paint', 0.29, 0.3)],
+        shot_types: [dietShare('catch-shoot', 0.39, 0.4, 4.8, 5)],
+        assist_locations: [dietShare('paint-assists', 0.33, 0.34, 1.2, 1.3)],
+      },
       injury_badge_ref: null,
+      scores: scores(['PTS', 'FGA', 'FG3A', 'REB', 'BLK'], 0.15, 0.11),
     },
   ],
   injuries: {
@@ -232,7 +334,7 @@ export const matchupPayload = {
           },
           {
             entry_id: 'injury-non-pool',
-            canonical_player_id: null,
+            canonical_player_id: 'maxi-kleber',
             source_player_name: 'Maxi Kleber',
             team_id: slateGame.away_team.team_id,
             tricode: 'LAL',

--- a/e2e/fixtures/courtai.js
+++ b/e2e/fixtures/courtai.js
@@ -101,6 +101,181 @@ export const slatePayload = (
   games,
 });
 
+const defenseValue = (allowed, relative, sigma, rank) => ({
+  allowed_per_48: allowed,
+  percent_vs_league_average: relative,
+  sigma_deviation: sigma,
+  rank,
+});
+
+const defenseRow = (key, label, markets, season, last15) => ({
+  key,
+  label,
+  markets,
+  season,
+  last_15: last15,
+});
+
+const teamSheet = (team, rows) => ({
+  team_id: team.team_id,
+  tricode: team.tricode,
+  name: team.name,
+  defense_sheet: { play_types: rows },
+});
+
+const dietShare = (key, seasonShare, last15Share) => ({
+  key,
+  season: { share: seasonShare, volume_per_game: 5.1 },
+  last_15: { share: last15Share, volume_per_game: 5.4 },
+});
+
+export const matchupPayload = {
+  game: slateGame,
+  teams: [
+    teamSheet(slateGame.away_team, [
+      defenseRow(
+        'transition',
+        'Transition',
+        ['PTS', 'FGA'],
+        defenseValue(17.1, 9, 1.2, 24),
+        defenseValue(14.8, -9, -1.1, 6),
+      ),
+      defenseRow(
+        'isolation',
+        'Isolation',
+        ['PTS'],
+        defenseValue(8.2, 2, 0.3, 16),
+        defenseValue(9, 5, 0.6, 19),
+      ),
+    ]),
+    teamSheet(slateGame.home_team, [
+      defenseRow(
+        'transition',
+        'Transition',
+        ['PTS', 'FGA'],
+        defenseValue(18.4, 12, 1.4, 27),
+        defenseValue(15.2, -8, -1.1, 5),
+      ),
+      defenseRow(
+        'above-break',
+        'Above-break three',
+        ['FG3A'],
+        defenseValue(10.2, -11, -1.3, 3),
+        defenseValue(11, -6, -0.7, 9),
+      ),
+      defenseRow(
+        'isolation',
+        'Isolation',
+        ['PTS'],
+        defenseValue(8.1, 2, 0.4, 16),
+        defenseValue(8.4, 4, 0.5, 18),
+      ),
+    ]),
+  ],
+  players: [
+    {
+      canonical_id: 'lebron-james',
+      name: 'LeBron James',
+      team_id: slateGame.away_team.team_id,
+      tricode: 'LAL',
+      posted_markets: ['PTS', 'FGA'],
+      season_scoring: 25.4,
+      last_10_minutes: [35, 36, 38, 34, 37, 36, 35, 39, 36, 37],
+      diet_shares: { play_types: [dietShare('transition', 0.19, 0.2)] },
+      injury_badge_ref: null,
+    },
+    {
+      canonical_id: 'austin-reaves',
+      name: 'Austin Reaves',
+      team_id: slateGame.away_team.team_id,
+      tricode: 'LAL',
+      posted_markets: ['PTS', 'FG3A'],
+      season_scoring: 20.1,
+      last_10_minutes: [32, 35, 34, 33, 31, 35, 36, 34, 35, 33],
+      diet_shares: { play_types: [dietShare('transition', 0.14, 0.18)] },
+      injury_badge_ref: 'injury-austin',
+    },
+    {
+      canonical_id: 'jayson-tatum',
+      name: 'Jayson Tatum',
+      team_id: slateGame.home_team.team_id,
+      tricode: 'BOS',
+      posted_markets: ['PTS', 'FGA', 'FG3A'],
+      season_scoring: 27.2,
+      last_10_minutes: [36, 37, 35, 38, 34, 36, 39, 37, 36, 38],
+      diet_shares: { play_types: [dietShare('transition', 0.21, 0.23)] },
+      injury_badge_ref: null,
+    },
+  ],
+  injuries: {
+    status: 'fresh',
+    unavailable_reason: null,
+    retrieved_at: '2026-01-15T11:55:00Z',
+    source: 'rotowire',
+    source_url: 'https://www.rotowire.com/basketball/injury-report.php',
+    teams: [
+      {
+        team_id: slateGame.away_team.team_id,
+        tricode: 'LAL',
+        submission_state: 'unknown',
+        entries: [
+          {
+            entry_id: 'injury-austin',
+            canonical_player_id: 'austin-reaves',
+            source_player_name: 'Austin Reaves',
+            team_id: slateGame.away_team.team_id,
+            tricode: 'LAL',
+            status: null,
+            raw_status: 'Game-time decision',
+            reason: 'Left calf soreness',
+            source_url: 'https://www.rotowire.com/basketball/player/austin-reaves-5440',
+          },
+          {
+            entry_id: 'injury-non-pool',
+            canonical_player_id: null,
+            source_player_name: 'Maxi Kleber',
+            team_id: slateGame.away_team.team_id,
+            tricode: 'LAL',
+            status: 'Out',
+            raw_status: 'Out',
+            reason: 'Right foot recovery',
+            source_url: 'https://www.rotowire.com/basketball/player/maxi-kleber-3929',
+          },
+          ...['Probable', 'Questionable', 'Doubtful'].map((status, index) => ({
+            entry_id: `injury-${status.toLowerCase()}`,
+            canonical_player_id: null,
+            source_player_name: ['Gabe Vincent', 'Jarred Vanderbilt', 'Jordan Goodwin'][index],
+            team_id: slateGame.away_team.team_id,
+            tricode: 'LAL',
+            status,
+            raw_status: status,
+            reason: ['Left knee soreness', 'Right shoulder soreness', 'Illness'][index],
+            source_url: 'https://www.rotowire.com/basketball/injury-report.php',
+          })),
+        ],
+      },
+      {
+        team_id: slateGame.home_team.team_id,
+        tricode: 'BOS',
+        submission_state: 'unknown',
+        entries: [],
+      },
+    ],
+  },
+  freshness: {
+    schedule: { status: 'fresh', retrieved_at: '2026-01-15T10:00:00Z' },
+    pool: {
+      status: 'fresh',
+      retrieved_at: '2026-01-15T11:50:00Z',
+      providers: {
+        prizepicks: { status: 'fresh', retrieved_at: '2026-01-15T11:50:00Z' },
+      },
+    },
+    stats: { status: 'fresh', retrieved_at: '2026-01-15T10:00:00Z' },
+    injuries: { status: 'fresh', retrieved_at: '2026-01-15T11:55:00Z' },
+  },
+};
+
 export const installApiContract = async (page, overrides = {}) => {
   await page.route('**/api/**', async (route) => {
     const request = route.request();
@@ -149,6 +324,11 @@ export const installApiContract = async (page, overrides = {}) => {
     if (url.pathname === '/api/games/slate') {
       const date = url.searchParams.get('date') || '2026-01-15';
       await route.fulfill({ json: slatePayload(date, [scheduleOnlySlateGame]) });
+      return;
+    }
+
+    if (url.pathname === '/api/games/matchup') {
+      await route.fulfill({ json: matchupPayload });
       return;
     }
 

--- a/e2e/fixtures/courtai.js
+++ b/e2e/fixtures/courtai.js
@@ -283,7 +283,9 @@ export const matchupPayload = {
       season_scoring: 20.1,
       last_10_minutes: [32, 35, 34, 33, 31, 35, 36, 34, 35, 33],
       diet_shares: {
-        play_types: [dietShare('transition', 0.14, 0.18)],
+        // Above the display gate but intentionally posted for PTS, not FGA,
+        // so market-tab chip scoping remains observable at the browser seam.
+        play_types: [dietShare('transition', 0.18, 0.18)],
         shot_zones: [dietShare('paint', 0.24, 0.26)],
         shot_types: [dietShare('catch-shoot', 0.4, 0.41, 3.9, 3.8)],
         assist_locations: [dietShare('paint-assists', 0.35, 0.36, 0.8, 0.9)],

--- a/e2e/specs/matchup-detail.spec.js
+++ b/e2e/specs/matchup-detail.spec.js
@@ -1,0 +1,129 @@
+import { expect, installApiContract, matchupPayload, test } from '../fixtures/courtai';
+
+test('@critical user opens a Defense Sheet and changes local spotting controls', async ({
+  authenticatedPage: page,
+}, testInfo) => {
+  await page.clock.setFixedTime(new Date('2026-01-15T12:00:00Z'));
+  const matchupRequests = [];
+  const consoleErrors = [];
+  const failedResponses = [];
+  page.on('console', (message) => {
+    if (message.type() === 'error') consoleErrors.push(message.text());
+  });
+  page.on('response', (response) => {
+    if (response.status() >= 400) failedResponses.push(`${response.status()} ${response.url()}`);
+  });
+  page.on('request', (request) => {
+    if (new URL(request.url()).pathname === '/api/games/matchup')
+      matchupRequests.push(request.url());
+  });
+
+  await page.goto('/matchups?date=2026-01-15');
+  await page.getByRole('link', { name: 'Open Team Sheets' }).click();
+  await expect(page).toHaveURL(/\/matchups\/0022500584$/);
+  await expect(page.getByRole('heading', { name: 'BOS Defense Sheet' })).toBeVisible();
+  await expect(page.getByText('Transition')).toBeVisible();
+  await expect(page.getByText('Above-break three')).toBeVisible();
+  await expect(page.getByText('Isolation')).toHaveCount(0);
+  await expect(page.getByText('1 row hidden near league average.')).toBeVisible();
+  await expect(page.getByText('+12% vs league')).toBeVisible();
+  await expect(page.getByText('-11% vs league')).toBeVisible();
+  await expect(page.getByText(/LeBron James · 19% poss/)).toBeVisible();
+  await expect(page.getByRole('article', { name: 'LeBron James player' })).toBeVisible();
+  await expect(page.getByText('Game-time decision')).toHaveCount(2);
+  await expect(page.getByText('Maxi Kleber')).toBeVisible();
+  await page.screenshot({
+    path: testInfo.outputPath('matchup-detail-desktop.png'),
+    fullPage: true,
+  });
+
+  await page.getByRole('button', { name: 'Last 15' }).click();
+  await expect(page.getByText('-8% vs league')).toBeVisible();
+  await expect(page.getByText(/LeBron James · 20% poss/)).toBeVisible();
+
+  await page.getByRole('button', { name: 'FGA' }).click();
+  await expect(page.getByText('Transition')).toBeVisible();
+  await expect(page.getByText('Above-break three')).toHaveCount(0);
+  await page.getByRole('button', { name: 'All deviations' }).click();
+  await expect(page.getByText('0 rows hidden near league average.')).toBeVisible();
+
+  await page.getByRole('button', { name: 'LAL defense' }).click();
+  await expect(page.getByRole('heading', { name: 'LAL Defense Sheet' })).toBeVisible();
+  await expect(page.getByRole('article', { name: 'Jayson Tatum player' })).toBeVisible();
+  expect(matchupRequests).toHaveLength(1);
+  expect(consoleErrors).toEqual([]);
+  expect(failedResponses).toEqual([]);
+});
+
+test('matchup renders stale and unavailable surfaces without inventing data', async ({
+  page,
+}, testInfo) => {
+  await page.clock.setFixedTime(new Date('2026-01-15T12:00:00Z'));
+  await page.addInitScript(() => localStorage.setItem('courtai:e2e-authenticated', 'true'));
+  await installApiContract(page, {
+    '/api/games/matchup': {
+      ...matchupPayload,
+      players: [],
+      injuries: {
+        ...matchupPayload.injuries,
+        status: 'unavailable',
+        unavailable_reason: 'permission_required',
+        retrieved_at: null,
+        teams: [],
+      },
+      freshness: {
+        ...matchupPayload.freshness,
+        pool: { status: 'unavailable', retrieved_at: null, providers: {} },
+        stats: { status: 'stale', retrieved_at: '2026-01-13T10:00:00Z' },
+        injuries: { status: 'missing', retrieved_at: null },
+      },
+    },
+  });
+
+  await page.goto('/matchups/0022500584');
+  await expect(page.getByText(/pool: unavailable.*pool data warning/i)).toBeVisible();
+  await expect(page.getByText(/stats: stale.*stats data warning/i)).toBeVisible();
+  await expect(page.getByText('No posted players are available for this market.')).toBeVisible();
+  await expect(page.getByText('Injury report unavailable: permission_required.')).toBeVisible();
+  await page.screenshot({
+    path: testInfo.outputPath('matchup-detail-degraded.png'),
+    fullPage: true,
+  });
+});
+
+test('matchup detail is usable at a narrow viewport with keyboard-only controls', async ({
+  authenticatedPage: page,
+}, testInfo) => {
+  await page.clock.setFixedTime(new Date('2026-01-15T12:00:00Z'));
+  await page.setViewportSize({ width: 393, height: 852 });
+  await page.goto('/matchups/0022500584');
+  await expect(page.getByRole('heading', { name: 'BOS Defense Sheet' })).toBeVisible();
+  await page.getByRole('button', { name: 'BOS defense' }).focus();
+  await page.keyboard.press('Tab');
+  await expect(page.getByRole('button', { name: 'All', exact: true })).toBeFocused();
+  await page.keyboard.press('Tab');
+  await expect(page.getByRole('button', { name: 'PTS' })).toBeFocused();
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(
+    true,
+  );
+  await page.screenshot({ path: testInfo.outputPath('matchup-detail-narrow.png'), fullPage: true });
+});
+
+test('matchup exposes a truthful loading state before the fixture resolves', async ({
+  page,
+}, testInfo) => {
+  await page.addInitScript(() => localStorage.setItem('courtai:e2e-authenticated', 'true'));
+  await installApiContract(page, {
+    '/api/games/matchup': async () => {
+      await new Promise((resolve) => setTimeout(resolve, 400));
+      return matchupPayload;
+    },
+  });
+  await page.goto('/matchups/0022500584', { waitUntil: 'commit' });
+  await expect(page.getByRole('status')).toHaveText('Loading matchup…');
+  await page.screenshot({
+    path: testInfo.outputPath('matchup-detail-loading.png'),
+    fullPage: true,
+  });
+  await expect(page.getByRole('heading', { name: 'BOS Defense Sheet' })).toBeVisible();
+});

--- a/e2e/specs/matchup-detail.spec.js
+++ b/e2e/specs/matchup-detail.spec.js
@@ -33,6 +33,7 @@ test('@critical user opens a Defense Sheet and changes local spotting controls',
   await expect(page.getByText('+12% vs league')).toBeVisible();
   await expect(page.getByText('-11% vs league')).toBeVisible();
   await expect(page.getByText(/LeBron James · 19% poss/)).toBeVisible();
+  await expect(page.getByText(/Austin Reaves · 18% poss/)).toBeVisible();
   await expect(page.getByText(/LeBron James · 27% FGA/)).toBeVisible();
   await expect(page.getByText(/LeBron James · 36% FGA/)).toBeVisible();
   await expect(page.getByText(/LeBron James · 31% ast/)).toBeVisible();
@@ -55,6 +56,7 @@ test('@critical user opens a Defense Sheet and changes local spotting controls',
 
   await page.getByRole('button', { name: 'PTS' }).click();
   await expect(page.getByRole('article', { name: 'LeBron James player' })).toBeVisible();
+  await expect(page.getByText(/Austin Reaves · 18% poss/)).toBeVisible();
   await page.getByRole('button', { name: 'Matchup Score' }).click();
   const sortedPlayers = page.getByRole('article', { name: /player$/ });
   await expect(sortedPlayers.first()).toHaveAccessibleName('Austin Reaves player');
@@ -66,6 +68,11 @@ test('@critical user opens a Defense Sheet and changes local spotting controls',
   await page.getByRole('button', { name: 'FGA' }).click();
   await expect(page.getByText('Transition')).toBeVisible();
   await expect(page.getByText('Above-break three')).toHaveCount(0);
+  await expect(page.getByText(/Austin Reaves · 18% poss/)).toHaveCount(0);
+  await page.screenshot({
+    path: testInfo.outputPath('matchup-detail-fga-market.png'),
+    fullPage: true,
+  });
   await page.getByRole('button', { name: 'All deviations' }).click();
   await expect(page.getByText('0 rows hidden near league average.')).toBeVisible();
 

--- a/e2e/specs/matchup-detail.spec.js
+++ b/e2e/specs/matchup-detail.spec.js
@@ -24,12 +24,24 @@ test('@critical user opens a Defense Sheet and changes local spotting controls',
   await expect(page.getByRole('heading', { name: 'BOS Defense Sheet' })).toBeVisible();
   await expect(page.getByText('Transition')).toBeVisible();
   await expect(page.getByText('Above-break three')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Shot zones' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Shot types' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Assist locations' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Traditional defense' })).toBeVisible();
   await expect(page.getByText('Isolation')).toHaveCount(0);
   await expect(page.getByText('1 row hidden near league average.')).toBeVisible();
   await expect(page.getByText('+12% vs league')).toBeVisible();
   await expect(page.getByText('-11% vs league')).toBeVisible();
   await expect(page.getByText(/LeBron James · 19% poss/)).toBeVisible();
+  await expect(page.getByText(/LeBron James · 27% FGA/)).toBeVisible();
+  await expect(page.getByText(/LeBron James · 36% FGA/)).toBeVisible();
+  await expect(page.getByText(/LeBron James · 31% ast/)).toBeVisible();
+  await expect(page.getByText(/Austin Reaves · 40% FGA/)).toHaveCount(0);
+  await expect(page.getByText(/Austin Reaves · 35% ast/)).toHaveCount(0);
+  await expect(page.getByText('15.2 per 48')).toBeVisible();
+  await expect(page.getByText('2 targetable returned')).toBeVisible();
   await expect(page.getByRole('article', { name: 'LeBron James player' })).toBeVisible();
+  await expect(page.getByRole('article', { name: 'Maxi Kleber player' })).toHaveCount(0);
   await expect(page.getByText('Game-time decision')).toHaveCount(2);
   await expect(page.getByText('Maxi Kleber')).toBeVisible();
   await page.screenshot({
@@ -40,6 +52,16 @@ test('@critical user opens a Defense Sheet and changes local spotting controls',
   await page.getByRole('button', { name: 'Last 15' }).click();
   await expect(page.getByText('-8% vs league')).toBeVisible();
   await expect(page.getByText(/LeBron James · 20% poss/)).toBeVisible();
+
+  await page.getByRole('button', { name: 'PTS' }).click();
+  await expect(page.getByRole('article', { name: 'LeBron James player' })).toBeVisible();
+  await page.getByRole('button', { name: 'Matchup Score' }).click();
+  const sortedPlayers = page.getByRole('article', { name: /player$/ });
+  await expect(sortedPlayers.first()).toHaveAccessibleName('Austin Reaves player');
+  await page.screenshot({
+    path: testInfo.outputPath('matchup-detail-score-sort.png'),
+    fullPage: true,
+  });
 
   await page.getByRole('button', { name: 'FGA' }).click();
   await expect(page.getByText('Transition')).toBeVisible();
@@ -115,7 +137,7 @@ test('matchup exposes a truthful loading state before the fixture resolves', asy
   await page.addInitScript(() => localStorage.setItem('courtai:e2e-authenticated', 'true'));
   await installApiContract(page, {
     '/api/games/matchup': async () => {
-      await new Promise((resolve) => setTimeout(resolve, 400));
+      await new Promise((resolve) => setTimeout(resolve, 2000));
       return matchupPayload;
     },
   });
@@ -126,4 +148,32 @@ test('matchup exposes a truthful loading state before the fixture resolves', asy
     fullPage: true,
   });
   await expect(page.getByRole('heading', { name: 'BOS Defense Sheet' })).toBeVisible();
+});
+
+test('matchup freshness ages cross named bars without refetching', async ({ page }) => {
+  await page.clock.install({ time: new Date('2026-01-15T12:00:00Z') });
+  await page.addInitScript(() => localStorage.setItem('courtai:e2e-authenticated', 'true'));
+  await installApiContract(page, {
+    '/api/games/matchup': {
+      ...matchupPayload,
+      freshness: {
+        ...matchupPayload.freshness,
+        schedule: { status: 'fresh', retrieved_at: '2026-01-14T06:01:00Z' },
+      },
+    },
+  });
+  let matchupRequests = 0;
+  page.on('request', (request) => {
+    if (new URL(request.url()).pathname === '/api/games/matchup') matchupRequests += 1;
+  });
+  await page.goto('/matchups/0022500584');
+  const freshness = page.getByRole('region', { name: 'Matchup data freshness' });
+  await expect(freshness.getByText(/^pool: fresh, as of 10m ago$/i)).toBeVisible();
+
+  await page.clock.runFor(6 * 60 * 1000);
+  await expect(
+    freshness.getByText(/pool: stale, as of 16m ago.*older than 15m freshness bar/i),
+  ).toBeVisible();
+  await expect(freshness.getByText(/schedule: stale.*schedule data warning/i)).toBeVisible();
+  expect(matchupRequests).toBe(1);
 });

--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import { BrowserRouter, Navigate, NavLink, Route, Routes } from 'react-router-do
 import LoginButton from './components/Auth/LoginButton';
 import UserProfile from './components/Auth/UserProfile';
 import SlatePage from './SlatePage';
+import MatchupDetailPage from './matchups/MatchupDetailPage';
 import './App.css';
 
 function AppNav() {
@@ -40,6 +41,7 @@ function App() {
             <Routes>
               <Route path="/" element={<GameLogFilter />} />
               <Route path="/matchups" element={<SlatePage />} />
+              <Route path="/matchups/:gameId" element={<MatchupDetailPage />} />
               <Route path="*" element={<Navigate to="/" replace />} />
             </Routes>
           </ProtectedRoute>

--- a/src/SlatePage.css
+++ b/src/SlatePage.css
@@ -171,6 +171,18 @@
   font-size: 0.72rem;
 }
 
+.open-matchup {
+  display: inline-block;
+  margin-top: 18px;
+  color: var(--ct-gold);
+  font-weight: 700;
+}
+
+.open-matchup:focus-visible {
+  outline: 2px solid var(--ct-gold);
+  outline-offset: 3px;
+}
+
 .empty-slate,
 .signed-out-slate {
   margin-top: 28px;

--- a/src/SlatePage.js
+++ b/src/SlatePage.js
@@ -10,6 +10,7 @@ import {
   shiftCalendarDate,
 } from './calendarDate';
 import { getStatusPresentation, getSurfaceFreshnessPresentation } from './slateStatus';
+import { formatAge, useMinuteNow } from './freshness';
 import './SlatePage.css';
 
 const formatTip = (date) =>
@@ -18,29 +19,10 @@ const formatTip = (date) =>
     minute: '2-digit',
   }).format(new Date(date));
 
-const formatAge = (retrievedAt) => {
-  const minutes = Math.max(0, Math.round((Date.now() - new Date(retrievedAt).getTime()) / 60000));
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.round(minutes / 60);
-  if (hours < 48) return `${hours}h ago`;
-  return `${Math.round(hours / 24)}d ago`;
-};
-
-const surfaceStatusText = (name, surface, presentation) => {
-  const age = surface.retrievedAt ? ` — as of ${formatAge(surface.retrievedAt)}` : '';
+const surfaceStatusText = (name, surface, presentation, now) => {
+  const age = surface.retrievedAt ? ` — as of ${formatAge(surface.retrievedAt, now)}` : '';
   const thresholdNote = presentation.thresholdNote ? ` (${presentation.thresholdNote})` : '';
   return `${name} is ${presentation.status}${age}${thresholdNote}`;
-};
-
-const useMinuteNow = (enabled) => {
-  const [now, setNow] = useState(() => Date.now());
-  useEffect(() => {
-    if (!enabled) return undefined;
-    setNow(Date.now());
-    const interval = setInterval(() => setNow(Date.now()), 60000);
-    return () => clearInterval(interval);
-  }, [enabled]);
-  return now;
 };
 
 function SurfaceFreshness({ name, surface, surfaceName, now, presentation }) {
@@ -48,7 +30,7 @@ function SurfaceFreshness({ name, surface, surfaceName, now, presentation }) {
     presentation || getSurfaceFreshnessPresentation(surface, surfaceName, now);
   return (
     <span className={effectivePresentation.warning ? 'freshness-warning' : undefined}>
-      {surfaceStatusText(name, surface, effectivePresentation)}
+      {surfaceStatusText(name, surface, effectivePresentation, now)}
     </span>
   );
 }

--- a/src/SlatePage.js
+++ b/src/SlatePage.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import { useAuth } from './contexts/AuthContext';
 import { fetchSlate } from './slateApi';
 import { getRequestErrorMessage, isRequestCancelled } from './gameLogsApi';
@@ -119,6 +119,9 @@ function GameCard({ game }) {
         {game.preseason && <span className="slate-badge">Preseason</span>}
         {game.status === 'postponed' && <span className="slate-badge">Postponed</span>}
       </div>
+      <Link className="open-matchup" to={`/matchups/${game.gameId}`}>
+        Open Team Sheets
+      </Link>
     </article>
   );
 }

--- a/src/config.js
+++ b/src/config.js
@@ -14,6 +14,7 @@ const config = {
     TEAMS: '/api/teams',
     GAME_LOGS: '/api/games/game_logs',
     SLATE: '/api/games/slate',
+    MATCHUP: '/api/games/matchup',
     PLAYER_PROFILE: '/api/players/profile',
     TEAM_STATS: '/api/teams/stats',
     NL_QUERY: '/api/nl-query',

--- a/src/freshness.js
+++ b/src/freshness.js
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+
+export const formatAge = (retrievedAt, now = Date.now()) => {
+  if (!retrievedAt) return 'age unavailable';
+  const minutes = Math.max(0, Math.round((now - new Date(retrievedAt).getTime()) / 60000));
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) return `${hours}h ago`;
+  return `${Math.round(hours / 24)}d ago`;
+};
+
+export const useMinuteNow = (enabled) => {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!enabled) return undefined;
+    setNow(Date.now());
+    const interval = setInterval(() => setNow(Date.now()), 60000);
+    return () => clearInterval(interval);
+  }, [enabled]);
+  return now;
+};

--- a/src/matchups/MatchupDetailPage.css
+++ b/src/matchups/MatchupDetailPage.css
@@ -1,0 +1,232 @@
+.matchup-page {
+  width: min(1220px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 42px 0 80px;
+  text-align: left;
+}
+.matchup-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: end;
+  gap: 24px;
+  border-bottom: 1px solid var(--ct-line);
+  padding-bottom: 22px;
+}
+.matchup-heading a {
+  color: var(--ct-dim);
+}
+.matchup-heading h1 {
+  margin: 8px 0 0;
+  font-size: clamp(2.5rem, 7vw, 5rem);
+  line-height: 0.9;
+}
+.matchup-eyebrow {
+  margin: 14px 0 6px;
+  color: var(--ct-gold);
+  font-family: var(--ct-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+.team-toggle,
+.segmented {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.team-toggle button,
+.segmented button {
+  border: 1px solid var(--ct-line-strong);
+  border-radius: 999px;
+  padding: 8px 12px;
+  background: var(--ct-surface-2);
+  color: var(--ct-dim);
+}
+.team-toggle button[aria-pressed='true'],
+.segmented button[aria-pressed='true'] {
+  border-color: var(--ct-gold);
+  background: color-mix(in srgb, var(--ct-gold) 15%, var(--ct-surface));
+  color: var(--ct-text);
+}
+.matchup-page button:focus-visible,
+.matchup-page a:focus-visible {
+  outline: 2px solid var(--ct-gold);
+  outline-offset: 2px;
+}
+.matchup-freshness {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 18px;
+  padding: 14px 0;
+  color: var(--ct-dim);
+  font-family: var(--ct-mono);
+  font-size: 0.7rem;
+  text-transform: capitalize;
+}
+.matchup-warning {
+  color: var(--ct-gold);
+}
+.detail-controls {
+  display: grid;
+  gap: 10px;
+  border: 1px solid var(--ct-line);
+  border-radius: var(--ct-radius-card);
+  padding: 14px;
+  background: var(--ct-surface);
+}
+.detail-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 310px;
+  gap: 18px;
+  margin-top: 18px;
+  align-items: start;
+}
+.defense-sheet,
+.player-rail,
+.injury-report {
+  border: 1px solid var(--ct-line);
+  border-radius: var(--ct-radius-card);
+  padding: 20px;
+  background: var(--ct-surface);
+}
+.section-heading h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+.hidden-count,
+.honest-empty,
+.no-lean {
+  color: var(--ct-dim);
+  font-size: 0.82rem;
+}
+.sheet-base {
+  margin-top: 22px;
+}
+.sheet-base > h3 {
+  border-bottom: 1px solid var(--ct-line);
+  padding-bottom: 8px;
+  font-size: 0.78rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.sheet-rows {
+  display: grid;
+  gap: 8px;
+}
+.sheet-row {
+  border: 1px solid var(--ct-line);
+  border-radius: var(--ct-radius-ctl);
+  padding: 14px;
+  background: var(--ct-surface-2);
+}
+.row-stat {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+}
+.row-stat h4 {
+  margin: 0 0 4px;
+}
+.row-stat span {
+  color: var(--ct-dim);
+  font-family: var(--ct-mono);
+  font-size: 0.72rem;
+}
+.relative-over,
+.relative-under {
+  display: grid;
+  justify-items: end;
+}
+.relative-over strong {
+  color: #ffb86c;
+  font-size: 1.5rem;
+}
+.relative-under strong {
+  color: #7ee7c4;
+  font-size: 1.5rem;
+}
+.diet-chips,
+.market-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 10px;
+}
+.diet-chips span,
+.market-chips span,
+.injury-badge {
+  border: 1px solid var(--ct-line-strong);
+  border-radius: 999px;
+  padding: 3px 7px;
+  color: var(--ct-dim);
+  font-family: var(--ct-mono);
+  font-size: 0.66rem;
+}
+.player-rail {
+  position: sticky;
+  top: 16px;
+}
+.player-list,
+.injury-list {
+  display: grid;
+  gap: 8px;
+  margin-top: 14px;
+}
+.player-card,
+.injury-list article {
+  border-top: 1px solid var(--ct-line);
+  padding: 12px 0;
+}
+.player-card h3,
+.player-card p,
+.injury-list p {
+  margin: 0;
+}
+.player-card p {
+  color: var(--ct-dim);
+  font-size: 0.75rem;
+}
+.minutes-sparkline {
+  width: 100%;
+  height: 34px;
+  margin-top: 8px;
+  color: var(--ct-gold);
+}
+.injury-report {
+  margin-top: 18px;
+}
+.injury-list {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+.injury-list article {
+  position: relative;
+}
+.injury-list a {
+  color: var(--ct-gold);
+  font-size: 0.75rem;
+}
+.signed-out-detail {
+  margin-top: 28px;
+}
+@media (max-width: 760px) {
+  .matchup-page {
+    width: min(100% - 20px, 1220px);
+    padding-top: 28px;
+  }
+  .matchup-heading {
+    align-items: stretch;
+    flex-direction: column;
+  }
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+  .player-rail {
+    position: static;
+  }
+  .injury-list {
+    grid-template-columns: 1fr;
+  }
+  .row-stat {
+    align-items: flex-start;
+  }
+}

--- a/src/matchups/MatchupDetailPage.css
+++ b/src/matchups/MatchupDetailPage.css
@@ -95,7 +95,8 @@
 }
 .hidden-count,
 .honest-empty,
-.no-lean {
+.no-lean,
+.rail-count {
   color: var(--ct-dim);
   font-size: 0.82rem;
 }
@@ -162,6 +163,61 @@
   font-family: var(--ct-mono);
   font-size: 0.66rem;
 }
+.rail-sort {
+  display: flex;
+  gap: 6px;
+  margin-top: 10px;
+}
+
+.rail-sort button {
+  border: 1px solid var(--ct-line-strong);
+  border-radius: 999px;
+  padding: 5px 8px;
+  background: transparent;
+  color: var(--ct-dim);
+  font-size: 0.68rem;
+}
+
+.rail-sort button[aria-pressed='true'] {
+  border-color: var(--ct-gold);
+  color: var(--ct-text);
+}
+
+.defensive-columns {
+  margin-top: 18px;
+}
+
+.defensive-columns > h3 {
+  font-size: 0.78rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.defensive-column-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.defensive-column-grid article {
+  display: grid;
+  gap: 4px;
+  border: 1px solid var(--ct-line);
+  border-radius: var(--ct-radius-ctl);
+  padding: 12px;
+  background: var(--ct-surface-2);
+}
+
+.defensive-column-grid h4 {
+  margin: 0;
+}
+
+.defensive-column-grid span,
+.injury-list small {
+  color: var(--ct-dim);
+  font-family: var(--ct-mono);
+  font-size: 0.68rem;
+}
 .player-rail {
   position: sticky;
   top: 16px;
@@ -202,8 +258,14 @@
   position: relative;
 }
 .injury-list a {
+  display: block;
   color: var(--ct-gold);
   font-size: 0.75rem;
+}
+
+.injury-list small {
+  display: block;
+  margin-top: 4px;
 }
 .signed-out-detail {
   margin-top: 28px;
@@ -224,6 +286,10 @@
     position: static;
   }
   .injury-list {
+    grid-template-columns: 1fr;
+  }
+
+  .defensive-column-grid {
     grid-template-columns: 1fr;
   }
   .row-stat {

--- a/src/matchups/MatchupDetailPage.js
+++ b/src/matchups/MatchupDetailPage.js
@@ -1,0 +1,415 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+import { getRequestErrorMessage, isRequestCancelled } from '../gameLogsApi';
+import { fetchMatchup } from './matchupApi';
+import { shouldDisplayDietShare } from './displayConfig';
+import './MatchupDetailPage.css';
+
+const WINDOWS = [
+  { key: 'season', label: 'Season' },
+  { key: 'last15', label: 'Last 15' },
+];
+const DEVIATIONS = [
+  { value: 0, label: 'All deviations' },
+  { value: 1, label: 'At least 1 sigma' },
+  { value: 2, label: 'At least 2 sigma' },
+];
+const BASE_LABELS = {
+  playTypes: 'Play types',
+  shotZones: 'Shot zones',
+  shotTypes: 'Shot types',
+  assistLocations: 'Assist locations',
+  traditional: 'Traditional defense',
+};
+const SHARE_LABELS = {
+  playTypes: 'poss',
+  shotZones: 'FGA',
+  shotTypes: 'FGA',
+  assistLocations: 'ast',
+};
+
+const ageText = (retrievedAt) => {
+  if (!retrievedAt) return 'age unavailable';
+  const minutes = Math.max(0, Math.round((Date.now() - new Date(retrievedAt).getTime()) / 60000));
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) return `${hours}h ago`;
+  return `${Math.round(hours / 24)}d ago`;
+};
+
+const isFreshnessWarning = (name, surface) => {
+  if (surface.status !== 'fresh') return true;
+  if (!surface.retrievedAt) return true;
+  const age = Date.now() - new Date(surface.retrievedAt).getTime();
+  if (name === 'pool') return age > 15 * 60 * 1000;
+  if (name === 'schedule') return age > 30 * 60 * 60 * 1000;
+  return false;
+};
+
+function Freshness({ freshness }) {
+  const surfaces = [
+    ['schedule', freshness.schedule],
+    ['pool', freshness.pool],
+    ['stats', freshness.stats],
+    ['injuries', freshness.injuries],
+  ];
+  return (
+    <section className="matchup-freshness" aria-label="Matchup data freshness">
+      {surfaces.map(([name, surface]) => {
+        const warning = isFreshnessWarning(name, surface);
+        return (
+          <span key={name} className={warning ? 'matchup-warning' : undefined}>
+            <strong>{name}</strong>: {surface.status}, as of {ageText(surface.retrievedAt)}
+            {warning ? ` — ${name} data warning` : ''}
+          </span>
+        );
+      })}
+      {freshness.pool.providers.map((provider) => (
+        <span
+          key={provider.name}
+          className={isFreshnessWarning('pool', provider) ? 'matchup-warning' : undefined}
+        >
+          <strong>{provider.name} pool</strong>: {provider.status}, as of{' '}
+          {ageText(provider.retrievedAt)}
+        </span>
+      ))}
+    </section>
+  );
+}
+
+function Sparkline({ values, playerName }) {
+  if (values.length === 0) return <span className="sparkline-empty">Minutes unavailable</span>;
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const span = max - min || 1;
+  const points = values
+    .map(
+      (value, index) =>
+        `${(index / Math.max(1, values.length - 1)) * 88 + 4},${24 - ((value - min) / span) * 18}`,
+    )
+    .join(' ');
+  return (
+    <svg
+      className="minutes-sparkline"
+      viewBox="0 0 96 30"
+      role="img"
+      aria-label={`${playerName} last 10 minutes: ${values.join(', ')}`}
+    >
+      <polyline points={points} fill="none" stroke="currentColor" strokeWidth="2" />
+    </svg>
+  );
+}
+
+function PlayerRail({ players, injuries, market }) {
+  const injuryById = new Map(
+    injuries.teams.flatMap((team) => team.entries).map((entry) => [entry.id, entry]),
+  );
+  const scoped = players
+    .filter((player) => market === 'All' || player.postedMarkets.includes(market))
+    .sort((a, b) => b.seasonScoring - a.seasonScoring || a.name.localeCompare(b.name));
+  return (
+    <aside className="player-rail" aria-labelledby="player-rail-heading">
+      <div className="section-heading">
+        <p className="matchup-eyebrow">Targetable players</p>
+        <h2 id="player-rail-heading">Season scoring order</h2>
+      </div>
+      {scoped.length === 0 ? (
+        <p className="honest-empty">No posted players are available for this market.</p>
+      ) : (
+        <div className="player-list">
+          {scoped.map((player) => {
+            const injury = injuryById.get(player.injuryBadgeRef);
+            return (
+              <article key={player.id} aria-label={`${player.name} player`} className="player-card">
+                <div>
+                  <h3>{player.name}</h3>
+                  <p>{player.seasonScoring.toFixed(1)} PPG</p>
+                </div>
+                {injury && (
+                  <span className="injury-badge">{injury.status || injury.rawStatus}</span>
+                )}
+                <div className="market-chips" aria-label={`${player.name} posted markets`}>
+                  {player.postedMarkets.map((postedMarket) => (
+                    <span key={postedMarket}>{postedMarket}</span>
+                  ))}
+                </div>
+                <Sparkline values={player.last10Minutes} playerName={player.name} />
+              </article>
+            );
+          })}
+        </div>
+      )}
+    </aside>
+  );
+}
+
+function DietShareChips({ players, base, rowKey, windowKey }) {
+  if (!SHARE_LABELS[base]) return null;
+  const chips = players.flatMap((player) => {
+    const share = player.dietShares[base]?.find((entry) => entry.key === rowKey)?.[windowKey];
+    if (!share || !shouldDisplayDietShare(base, share)) return [];
+    return [{ player, share }];
+  });
+  if (chips.length === 0)
+    return <p className="no-lean">No displayed Diet Shares meet the named threshold.</p>;
+  return (
+    <div className="diet-chips" aria-label="Players leaning on this slice">
+      {chips.map(({ player, share }) => (
+        <span key={player.id}>
+          {player.name} · {Math.round(share.share * 100)}% {SHARE_LABELS[base]}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function DefenseSheet({ team, players, market, windowKey, deviation }) {
+  let hidden = 0;
+  const sections = Object.entries(team.defenseSheet).map(([base, rows]) => {
+    const marketRows = rows.filter((row) => market === 'All' || row.markets.includes(market));
+    const visibleRows = marketRows.filter((row) => {
+      const shown = Math.abs(row[windowKey].sigmaDeviation) >= deviation;
+      if (!shown) hidden += 1;
+      return shown;
+    });
+    return { base, visibleRows };
+  });
+  const visibleCount = sections.reduce((total, section) => total + section.visibleRows.length, 0);
+  return (
+    <section className="defense-sheet" aria-labelledby="defense-sheet-heading">
+      <div className="section-heading">
+        <p className="matchup-eyebrow">Relative concessions · per 48</p>
+        <h2 id="defense-sheet-heading">{team.tricode} Defense Sheet</h2>
+      </div>
+      <p className="hidden-count">
+        {hidden} {hidden === 1 ? 'row' : 'rows'} hidden near league average.
+      </p>
+      {visibleCount === 0 && (
+        <p className="honest-empty">No Defense Sheet rows match these controls.</p>
+      )}
+      {sections.map(({ base, visibleRows }) =>
+        visibleRows.length ? (
+          <section className="sheet-base" key={base} aria-labelledby={`base-${base}`}>
+            <h3 id={`base-${base}`}>{BASE_LABELS[base] || base}</h3>
+            <div className="sheet-rows">
+              {visibleRows.map((row) => {
+                const stat = row[windowKey];
+                return (
+                  <article className="sheet-row" key={`${base}-${row.key}`}>
+                    <div className="row-stat">
+                      <div>
+                        <h4>{row.label}</h4>
+                        <span>Rank {stat.rank} of 30</span>
+                      </div>
+                      <div
+                        className={
+                          stat.percentVsLeagueAverage < 0 ? 'relative-under' : 'relative-over'
+                        }
+                      >
+                        <strong>{stat.allowedPer48.toFixed(1)}</strong>
+                        <span>
+                          {stat.percentVsLeagueAverage > 0 ? '+' : ''}
+                          {stat.percentVsLeagueAverage}% vs league
+                        </span>
+                        <span>
+                          {stat.sigmaDeviation > 0 ? '+' : ''}
+                          {stat.sigmaDeviation.toFixed(1)}σ
+                        </span>
+                      </div>
+                    </div>
+                    <DietShareChips
+                      players={players}
+                      base={base}
+                      rowKey={row.key}
+                      windowKey={windowKey}
+                    />
+                  </article>
+                );
+              })}
+            </div>
+          </section>
+        ) : null,
+      )}
+    </section>
+  );
+}
+
+function InjuryReport({ injuries }) {
+  if (injuries.status === 'unavailable') {
+    return (
+      <section className="injury-report" aria-labelledby="injury-heading">
+        <h2 id="injury-heading">Injury Report</h2>
+        <p className="honest-empty">
+          Injury report unavailable: {injuries.unavailableReason || 'unknown reason'}.
+        </p>
+      </section>
+    );
+  }
+  const entries = injuries.teams.flatMap((team) => team.entries);
+  return (
+    <section className="injury-report" aria-labelledby="injury-heading">
+      <div className="section-heading">
+        <p className="matchup-eyebrow">
+          {injuries.status} · as of {ageText(injuries.retrievedAt)}
+        </p>
+        <h2 id="injury-heading">Injury Report</h2>
+      </div>
+      {entries.length === 0 ? (
+        <p className="honest-empty">No non-Available injury entries were reported.</p>
+      ) : (
+        <div className="injury-list">
+          {entries.map((entry) => (
+            <article key={entry.id}>
+              <div>
+                <strong>{entry.playerName}</strong> <span>{entry.tricode}</span>
+              </div>
+              <span className="injury-badge">
+                {entry.status || entry.rawStatus || 'Unknown status'}
+              </span>
+              <p>{entry.reason}</p>
+              <a href={entry.sourceUrl} target="_blank" rel="noreferrer">
+                Source
+              </a>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function Detail({ matchup }) {
+  const homeTricode = matchup.game.home_team?.tricode;
+  const initialTeam =
+    matchup.teams.find((team) => team.tricode === homeTricode) || matchup.teams[0];
+  const [teamId, setTeamId] = useState(initialTeam.teamId);
+  const [market, setMarket] = useState('All');
+  const [windowKey, setWindowKey] = useState('season');
+  const [deviation, setDeviation] = useState(1);
+  const defenseTeam = matchup.teams.find((team) => team.teamId === teamId) || initialTeam;
+  const opposingTeam = matchup.teams.find((team) => team.teamId !== defenseTeam.teamId);
+  const opposingPlayers = matchup.players.filter(
+    (player) => player.teamId === opposingTeam?.teamId,
+  );
+  const markets = useMemo(
+    () => ['All', ...new Set(matchup.players.flatMap((player) => player.postedMarkets))],
+    [matchup.players],
+  );
+  return (
+    <>
+      <header className="matchup-heading">
+        <div>
+          <Link to="/matchups">← Back to slate</Link>
+          <p className="matchup-eyebrow">Open Team Sheets</p>
+          <h1>
+            {matchup.game.away_team.tricode} @ {matchup.game.home_team.tricode}
+          </h1>
+        </div>
+        <div className="team-toggle" role="group" aria-label="Defense team">
+          {matchup.teams.map((team) => (
+            <button
+              type="button"
+              aria-pressed={team.teamId === defenseTeam.teamId}
+              key={team.teamId}
+              onClick={() => setTeamId(team.teamId)}
+            >
+              {team.tricode} defense
+            </button>
+          ))}
+        </div>
+      </header>
+      <Freshness freshness={matchup.freshness} />
+      <section className="detail-controls" aria-label="Defense Sheet controls">
+        <div className="segmented" role="group" aria-label="Market">
+          {markets.map((item) => (
+            <button
+              type="button"
+              aria-pressed={market === item}
+              key={item}
+              onClick={() => setMarket(item)}
+            >
+              {item}
+            </button>
+          ))}
+        </div>
+        <div className="segmented" role="group" aria-label="Stat window">
+          {WINDOWS.map((item) => (
+            <button
+              type="button"
+              aria-pressed={windowKey === item.key}
+              key={item.key}
+              onClick={() => setWindowKey(item.key)}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+        <div className="segmented" role="group" aria-label="Deviation filter">
+          {DEVIATIONS.map((item) => (
+            <button
+              type="button"
+              aria-pressed={deviation === item.value}
+              key={item.value}
+              onClick={() => setDeviation(item.value)}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      </section>
+      <div className="detail-grid">
+        <DefenseSheet
+          team={defenseTeam}
+          players={opposingPlayers}
+          market={market}
+          windowKey={windowKey}
+          deviation={deviation}
+        />
+        <PlayerRail players={opposingPlayers} injuries={matchup.injuries} market={market} />
+      </div>
+      <InjuryReport injuries={matchup.injuries} />
+    </>
+  );
+}
+
+export default function MatchupDetailPage() {
+  const { gameId } = useParams();
+  const { isAuthenticated, loading: authLoading } = useAuth();
+  const [state, setState] = useState({ status: 'idle', matchup: null, error: null });
+  useEffect(() => {
+    if (authLoading || !isAuthenticated) {
+      setState({ status: 'idle', matchup: null, error: null });
+      return undefined;
+    }
+    const controller = new AbortController();
+    setState({ status: 'loading', matchup: null, error: null });
+    fetchMatchup(gameId, { signal: controller.signal })
+      .then((matchup) => setState({ status: 'ready', matchup, error: null }))
+      .catch((error) => {
+        if (!isRequestCancelled(error))
+          setState({
+            status: 'error',
+            matchup: null,
+            error: getRequestErrorMessage(error, 'Unable to load this matchup. Please try again.'),
+          });
+      });
+    return () => controller.abort();
+  }, [authLoading, gameId, isAuthenticated]);
+
+  if (!authLoading && !isAuthenticated) {
+    return (
+      <main className="matchup-page signed-out-detail">
+        <h1>Sign in to view this matchup</h1>
+        <p>Use the sign-in control in the navigation to load Defense Sheets and player data.</p>
+      </main>
+    );
+  }
+  return (
+    <main className="matchup-page">
+      {state.status === 'loading' && <p role="status">Loading matchup…</p>}
+      {state.status === 'error' && <p role="alert">{state.error}</p>}
+      {state.status === 'ready' && <Detail matchup={state.matchup} />}
+    </main>
+  );
+}

--- a/src/matchups/MatchupDetailPage.js
+++ b/src/matchups/MatchupDetailPage.js
@@ -171,13 +171,15 @@ function PlayerRail({ players, injuries, market, windowKey, targetableCount }) {
   );
 }
 
-function DietShareChips({ players, base, rowKey, windowKey }) {
+function DietShareChips({ players, base, rowKey, windowKey, market }) {
   if (!SHARE_LABELS[base]) return null;
-  const chips = players.flatMap((player) => {
-    const share = player.dietShares[base]?.find((entry) => entry.key === rowKey)?.[windowKey];
-    if (!share || !shouldDisplayDietShare(base, share)) return [];
-    return [{ player, share }];
-  });
+  const chips = players
+    .filter((player) => market === 'All' || player.postedMarkets.includes(market))
+    .flatMap((player) => {
+      const share = player.dietShares[base]?.find((entry) => entry.key === rowKey)?.[windowKey];
+      if (!share || !shouldDisplayDietShare(base, share)) return [];
+      return [{ player, share }];
+    });
   if (chips.length === 0)
     return <p className="no-lean">No displayed Diet Shares meet the named threshold.</p>;
   return (
@@ -251,6 +253,7 @@ function DefenseSheet({ team, players, market, windowKey, deviation }) {
                       base={base}
                       rowKey={row.key}
                       windowKey={windowKey}
+                      market={market}
                     />
                   </article>
                 );

--- a/src/matchups/MatchupDetailPage.js
+++ b/src/matchups/MatchupDetailPage.js
@@ -2,6 +2,8 @@ import { useEffect, useMemo, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { getRequestErrorMessage, isRequestCancelled } from '../gameLogsApi';
+import { formatAge, useMinuteNow } from '../freshness';
+import { getSurfaceFreshnessPresentation } from '../slateStatus';
 import { fetchMatchup } from './matchupApi';
 import { shouldDisplayDietShare } from './displayConfig';
 import './MatchupDetailPage.css';
@@ -29,25 +31,7 @@ const SHARE_LABELS = {
   assistLocations: 'ast',
 };
 
-const ageText = (retrievedAt) => {
-  if (!retrievedAt) return 'age unavailable';
-  const minutes = Math.max(0, Math.round((Date.now() - new Date(retrievedAt).getTime()) / 60000));
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.round(minutes / 60);
-  if (hours < 48) return `${hours}h ago`;
-  return `${Math.round(hours / 24)}d ago`;
-};
-
-const isFreshnessWarning = (name, surface) => {
-  if (surface.status !== 'fresh') return true;
-  if (!surface.retrievedAt) return true;
-  const age = Date.now() - new Date(surface.retrievedAt).getTime();
-  if (name === 'pool') return age > 15 * 60 * 1000;
-  if (name === 'schedule') return age > 30 * 60 * 60 * 1000;
-  return false;
-};
-
-function Freshness({ freshness }) {
+function Freshness({ freshness, now }) {
   const surfaces = [
     ['schedule', freshness.schedule],
     ['pool', freshness.pool],
@@ -57,23 +41,28 @@ function Freshness({ freshness }) {
   return (
     <section className="matchup-freshness" aria-label="Matchup data freshness">
       {surfaces.map(([name, surface]) => {
-        const warning = isFreshnessWarning(name, surface);
+        const presentation = getSurfaceFreshnessPresentation(surface, name, now);
         return (
-          <span key={name} className={warning ? 'matchup-warning' : undefined}>
-            <strong>{name}</strong>: {surface.status}, as of {ageText(surface.retrievedAt)}
-            {warning ? ` — ${name} data warning` : ''}
+          <span key={name} className={presentation.warning ? 'matchup-warning' : undefined}>
+            <strong>{name}</strong>: {presentation.status}, as of{' '}
+            {formatAge(surface.retrievedAt, now)}
+            {presentation.warning ? ` — ${name} data warning` : ''}
+            {presentation.thresholdNote ? ` (${presentation.thresholdNote})` : ''}
           </span>
         );
       })}
-      {freshness.pool.providers.map((provider) => (
-        <span
-          key={provider.name}
-          className={isFreshnessWarning('pool', provider) ? 'matchup-warning' : undefined}
-        >
-          <strong>{provider.name} pool</strong>: {provider.status}, as of{' '}
-          {ageText(provider.retrievedAt)}
-        </span>
-      ))}
+      {freshness.pool.providers.map((provider) => {
+        const presentation = getSurfaceFreshnessPresentation(provider, 'pool', now);
+        return (
+          <span
+            key={provider.name}
+            className={presentation.warning ? 'matchup-warning' : undefined}
+          >
+            <strong>{provider.name} pool</strong>: {presentation.status}, as of{' '}
+            {formatAge(provider.retrievedAt, now)}
+          </span>
+        );
+      })}
     </section>
   );
 }
@@ -101,18 +90,52 @@ function Sparkline({ values, playerName }) {
   );
 }
 
-function PlayerRail({ players, injuries, market }) {
+function PlayerRail({ players, injuries, market, windowKey, targetableCount }) {
+  const [sortMode, setSortMode] = useState('season');
+  useEffect(() => {
+    if (market === 'All') setSortMode('season');
+  }, [market]);
   const injuryById = new Map(
     injuries.teams.flatMap((team) => team.entries).map((entry) => [entry.id, entry]),
   );
-  const scoped = players
-    .filter((player) => market === 'All' || player.postedMarkets.includes(market))
-    .sort((a, b) => b.seasonScoring - a.seasonScoring || a.name.localeCompare(b.name));
+  const scoreFor = (player) => player.scores[market]?.[windowKey].blend.value ?? -Infinity;
+  const scoped = players.filter(
+    (player) => market === 'All' || player.postedMarkets.includes(market),
+  );
+  scoped.sort((a, b) =>
+    sortMode === 'score' && market !== 'All'
+      ? scoreFor(b) - scoreFor(a) || b.seasonScoring - a.seasonScoring
+      : b.seasonScoring - a.seasonScoring || a.name.localeCompare(b.name),
+  );
   return (
     <aside className="player-rail" aria-labelledby="player-rail-heading">
       <div className="section-heading">
         <p className="matchup-eyebrow">Targetable players</p>
-        <h2 id="player-rail-heading">Season scoring order</h2>
+        <h2 id="player-rail-heading">
+          {sortMode === 'score' && market !== 'All'
+            ? `${market} Matchup Score order`
+            : 'Season scoring order'}
+        </h2>
+        {targetableCount !== null && (
+          <p className="rail-count">{targetableCount} targetable returned</p>
+        )}
+        <div className="rail-sort" role="group" aria-label="Player rail sort">
+          <button
+            type="button"
+            aria-pressed={sortMode === 'season'}
+            onClick={() => setSortMode('season')}
+          >
+            Season scoring
+          </button>
+          <button
+            type="button"
+            aria-pressed={sortMode === 'score'}
+            disabled={market === 'All'}
+            onClick={() => setSortMode('score')}
+          >
+            Matchup Score
+          </button>
+        </div>
       </div>
       {scoped.length === 0 ? (
         <p className="honest-empty">No posted players are available for this market.</p>
@@ -129,7 +152,11 @@ function PlayerRail({ players, injuries, market }) {
                 {injury && (
                   <span className="injury-badge">{injury.status || injury.rawStatus}</span>
                 )}
-                <div className="market-chips" aria-label={`${player.name} posted markets`}>
+                <div
+                  className="market-chips"
+                  role="group"
+                  aria-label={`${player.name} posted markets`}
+                >
                   {player.postedMarkets.map((postedMarket) => (
                     <span key={postedMarket}>{postedMarket}</span>
                   ))}
@@ -154,7 +181,7 @@ function DietShareChips({ players, base, rowKey, windowKey }) {
   if (chips.length === 0)
     return <p className="no-lean">No displayed Diet Shares meet the named threshold.</p>;
   return (
-    <div className="diet-chips" aria-label="Players leaning on this slice">
+    <div className="diet-chips" role="group" aria-label="Players leaning on this slice">
       {chips.map(({ player, share }) => (
         <span key={player.id}>
           {player.name} · {Math.round(share.share * 100)}% {SHARE_LABELS[base]}
@@ -185,6 +212,7 @@ function DefenseSheet({ team, players, market, windowKey, deviation }) {
       <p className="hidden-count">
         {hidden} {hidden === 1 ? 'row' : 'rows'} hidden near league average.
       </p>
+      <DefensiveColumns columns={team.defensiveColumns} market={market} windowKey={windowKey} />
       {visibleCount === 0 && (
         <p className="honest-empty">No Defense Sheet rows match these controls.</p>
       )}
@@ -235,7 +263,36 @@ function DefenseSheet({ team, players, market, windowKey, deviation }) {
   );
 }
 
-function InjuryReport({ injuries }) {
+const DEFENSIVE_COLUMN_MARKETS = { OPP_TOV: 'TOV', OPP_STL: 'STL', OPP_BLK: 'BLK' };
+
+function DefensiveColumns({ columns, market, windowKey }) {
+  const visible = Object.entries(columns).filter(
+    ([key]) => market === 'All' || DEFENSIVE_COLUMN_MARKETS[key] === market,
+  );
+  if (visible.length === 0) return null;
+  return (
+    <section className="defensive-columns" aria-labelledby="defensive-columns-heading">
+      <h3 id="defensive-columns-heading">Traditional defensive columns</h3>
+      <div className="defensive-column-grid">
+        {visible.map(([key, windows]) => {
+          const value = windows[windowKey];
+          return (
+            <article key={key}>
+              <h4>{key}</h4>
+              <strong>{value.per48.toFixed(1)} per 48</strong>
+              <span>
+                {value.percentVsLeagueAverage > 0 ? '+' : ''}
+                {value.percentVsLeagueAverage}% vs league
+              </span>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function InjuryReport({ injuries, now }) {
   if (injuries.status === 'unavailable') {
     return (
       <section className="injury-report" aria-labelledby="injury-heading">
@@ -243,6 +300,9 @@ function InjuryReport({ injuries }) {
         <p className="honest-empty">
           Injury report unavailable: {injuries.unavailableReason || 'unknown reason'}.
         </p>
+        <a href={injuries.sourceUrl} target="_blank" rel="noreferrer">
+          Data source: {injuries.source}
+        </a>
       </section>
     );
   }
@@ -251,28 +311,36 @@ function InjuryReport({ injuries }) {
     <section className="injury-report" aria-labelledby="injury-heading">
       <div className="section-heading">
         <p className="matchup-eyebrow">
-          {injuries.status} · as of {ageText(injuries.retrievedAt)}
+          {injuries.status} · as of {formatAge(injuries.retrievedAt, now)}
         </p>
         <h2 id="injury-heading">Injury Report</h2>
+        <a href={injuries.sourceUrl} target="_blank" rel="noreferrer">
+          Data source: {injuries.source}
+        </a>
       </div>
       {entries.length === 0 ? (
         <p className="honest-empty">No non-Available injury entries were reported.</p>
       ) : (
         <div className="injury-list">
-          {entries.map((entry) => (
-            <article key={entry.id}>
-              <div>
-                <strong>{entry.playerName}</strong> <span>{entry.tricode}</span>
-              </div>
-              <span className="injury-badge">
-                {entry.status || entry.rawStatus || 'Unknown status'}
-              </span>
-              <p>{entry.reason}</p>
-              <a href={entry.sourceUrl} target="_blank" rel="noreferrer">
-                Source
-              </a>
-            </article>
-          ))}
+          {injuries.teams.flatMap((team) =>
+            team.entries.map((entry) => (
+              <article key={entry.id}>
+                <div>
+                  <strong>{entry.playerName}</strong> <span>{entry.tricode}</span>
+                </div>
+                <span className="injury-badge">
+                  {entry.status || entry.rawStatus || 'Unknown status'}
+                </span>
+                <p>{entry.reason}</p>
+                <a href={entry.sourceUrl} target="_blank" rel="noreferrer">
+                  Source
+                </a>
+                <small>
+                  {team.tricode} submission: {team.submissionState || 'unknown'}
+                </small>
+              </article>
+            )),
+          )}
         </div>
       )}
     </section>
@@ -280,7 +348,8 @@ function InjuryReport({ injuries }) {
 }
 
 function Detail({ matchup }) {
-  const homeTricode = matchup.game.home_team?.tricode;
+  const now = useMinuteNow(true);
+  const homeTricode = matchup.game.home.tricode;
   const initialTeam =
     matchup.teams.find((team) => team.tricode === homeTricode) || matchup.teams[0];
   const [teamId, setTeamId] = useState(initialTeam.teamId);
@@ -289,13 +358,23 @@ function Detail({ matchup }) {
   const [deviation, setDeviation] = useState(1);
   const defenseTeam = matchup.teams.find((team) => team.teamId === teamId) || initialTeam;
   const opposingTeam = matchup.teams.find((team) => team.teamId !== defenseTeam.teamId);
-  const opposingPlayers = matchup.players.filter(
-    (player) => player.teamId === opposingTeam?.teamId,
+  const opposingTeamId = opposingTeam?.teamId;
+  const poolAvailable = !['missing', 'unavailable'].includes(matchup.freshness.pool.status);
+  const opposingPlayers = useMemo(
+    () =>
+      poolAvailable ? matchup.players.filter((player) => player.teamId === opposingTeamId) : [],
+    [matchup.players, opposingTeamId, poolAvailable],
+  );
+  const opposingGameTeam = [matchup.game.away, matchup.game.home].find(
+    (team) => team.teamId === opposingTeamId,
   );
   const markets = useMemo(
-    () => ['All', ...new Set(matchup.players.flatMap((player) => player.postedMarkets))],
-    [matchup.players],
+    () => ['All', ...new Set(opposingPlayers.flatMap((player) => player.postedMarkets))],
+    [opposingPlayers],
   );
+  useEffect(() => {
+    if (!markets.includes(market)) setMarket('All');
+  }, [market, markets]);
   return (
     <>
       <header className="matchup-heading">
@@ -303,7 +382,7 @@ function Detail({ matchup }) {
           <Link to="/matchups">← Back to slate</Link>
           <p className="matchup-eyebrow">Open Team Sheets</p>
           <h1>
-            {matchup.game.away_team.tricode} @ {matchup.game.home_team.tricode}
+            {matchup.game.away.tricode} @ {matchup.game.home.tricode}
           </h1>
         </div>
         <div className="team-toggle" role="group" aria-label="Defense team">
@@ -319,7 +398,7 @@ function Detail({ matchup }) {
           ))}
         </div>
       </header>
-      <Freshness freshness={matchup.freshness} />
+      <Freshness freshness={matchup.freshness} now={now} />
       <section className="detail-controls" aria-label="Defense Sheet controls">
         <div className="segmented" role="group" aria-label="Market">
           {markets.map((item) => (
@@ -359,16 +438,29 @@ function Detail({ matchup }) {
         </div>
       </section>
       <div className="detail-grid">
-        <DefenseSheet
-          team={defenseTeam}
+        {matchup.freshness.stats.status === 'missing' ? (
+          <section className="defense-sheet" aria-labelledby="defense-sheet-heading">
+            <h2 id="defense-sheet-heading">{defenseTeam.tricode} Defense Sheet</h2>
+            <p className="honest-empty">Defense Sheet unavailable because stats are missing.</p>
+          </section>
+        ) : (
+          <DefenseSheet
+            team={defenseTeam}
+            players={opposingPlayers}
+            market={market}
+            windowKey={windowKey}
+            deviation={deviation}
+          />
+        )}
+        <PlayerRail
           players={opposingPlayers}
+          injuries={matchup.injuries}
           market={market}
           windowKey={windowKey}
-          deviation={deviation}
+          targetableCount={poolAvailable ? (opposingGameTeam?.targetablePlayerCount ?? null) : null}
         />
-        <PlayerRail players={opposingPlayers} injuries={matchup.injuries} market={market} />
       </div>
-      <InjuryReport injuries={matchup.injuries} />
+      <InjuryReport injuries={matchup.injuries} now={now} />
     </>
   );
 }

--- a/src/matchups/MatchupDetailPage.test.js
+++ b/src/matchups/MatchupDetailPage.test.js
@@ -93,7 +93,7 @@ const matchup = {
         playTypes: [
           {
             key: 'transition',
-            season: { share: 0.14, volumePerGame: 4 },
+            season: { share: 0.18, volumePerGame: 4 },
             last15: { share: 0.18, volumePerGame: 5 },
           },
         ],
@@ -185,6 +185,7 @@ test('toggles delivered windows and applies a two-sided sigma filter without ref
   expect(screen.getByText('+12% vs league')).toBeVisible();
   expect(screen.getByText('14.2 per 48')).toBeVisible();
   expect(screen.getByText(/19% poss/)).toBeVisible();
+  expect(screen.getByText(/Austin Reaves · 18% poss/)).toBeVisible();
   expect(screen.getAllByRole('article', { name: /player/i })[0]).toHaveTextContent('LeBron James');
 
   await userEvent.click(screen.getByRole('button', { name: 'Last 15' }));
@@ -195,6 +196,10 @@ test('toggles delivered windows and applies a two-sided sigma filter without ref
   await userEvent.click(screen.getByRole('button', { name: 'FGA' }));
   expect(screen.getByText('Transition')).toBeVisible();
   expect(screen.queryByText('Above-break three')).not.toBeInTheDocument();
+  expect(screen.queryByText(/Austin Reaves · 18% poss/)).not.toBeInTheDocument();
+
+  await userEvent.click(screen.getByRole('button', { name: 'PTS' }));
+  expect(screen.getByText(/Austin Reaves · 18% poss/)).toBeVisible();
 
   await userEvent.click(screen.getByRole('button', { name: 'All' }));
   await userEvent.click(screen.getByRole('button', { name: 'All deviations' }));

--- a/src/matchups/MatchupDetailPage.test.js
+++ b/src/matchups/MatchupDetailPage.test.js
@@ -14,15 +14,38 @@ const value = (allowedPer48, percentVsLeagueAverage, sigmaDeviation, rank) => ({
   sigmaDeviation,
   rank,
 });
+const defensiveColumns = {
+  OPP_TOV: {
+    season: { per48: 14.2, percentVsLeagueAverage: 8 },
+    last15: { per48: 12.9, percentVsLeagueAverage: -3 },
+  },
+  OPP_STL: {
+    season: { per48: 7.1, percentVsLeagueAverage: -5 },
+    last15: { per48: 7.8, percentVsLeagueAverage: 4 },
+  },
+  OPP_BLK: {
+    season: { per48: 5.4, percentVsLeagueAverage: 11 },
+    last15: { per48: 4.7, percentVsLeagueAverage: -2 },
+  },
+};
+const score = (season, last15 = season) => ({
+  season: { components: {}, blend: { value: season, thin: false } },
+  last15: { components: {}, blend: { value: last15, thin: false } },
+});
 
 const matchup = {
-  game: { game_id: 'game-1', away_team: { tricode: 'LAL' }, home_team: { tricode: 'BOS' } },
+  game: {
+    gameId: 'game-1',
+    away: { tricode: 'LAL' },
+    home: { tricode: 'BOS' },
+  },
   teams: [
     {
       teamId: 1,
       tricode: 'LAL',
       name: 'Los Angeles Lakers',
       defenseSheet: { playTypes: [] },
+      defensiveColumns,
     },
     {
       teamId: 2,
@@ -53,6 +76,7 @@ const matchup = {
           },
         ],
       },
+      defensiveColumns,
     },
   ],
   players: [
@@ -74,6 +98,7 @@ const matchup = {
           },
         ],
       },
+      scores: { PTS: score(0.21, 0.03), FG3A: score(0.07, 0.02) },
     },
     {
       id: 'player-one',
@@ -93,6 +118,19 @@ const matchup = {
           },
         ],
       },
+      scores: { PTS: score(0.12, -0.01), FGA: score(0.04, 0.02) },
+    },
+    {
+      id: 'player-three',
+      name: 'Jayson Tatum',
+      teamId: 2,
+      tricode: 'BOS',
+      postedMarkets: ['REB'],
+      seasonScoring: 27.2,
+      last10Minutes: [36, 37, 38],
+      injuryBadgeRef: null,
+      dietShares: { playTypes: [] },
+      scores: { REB: score(0.08) },
     },
   ],
   injuries: {
@@ -145,6 +183,7 @@ test('toggles delivered windows and applies a two-sided sigma filter without ref
   expect(screen.queryByText('Isolation')).not.toBeInTheDocument();
   expect(screen.getByText('1 row hidden near league average.')).toBeVisible();
   expect(screen.getByText('+12% vs league')).toBeVisible();
+  expect(screen.getByText('14.2 per 48')).toBeVisible();
   expect(screen.getByText(/19% poss/)).toBeVisible();
   expect(screen.getAllByRole('article', { name: /player/i })[0]).toHaveTextContent('LeBron James');
 
@@ -161,6 +200,32 @@ test('toggles delivered windows and applies a two-sided sigma filter without ref
   await userEvent.click(screen.getByRole('button', { name: 'All deviations' }));
   expect(screen.getByText('Isolation')).toBeVisible();
   expect(fetchMatchup).toHaveBeenCalledTimes(1);
+});
+
+test('sorts the active market by delivered Matchup Score and scopes tabs to the displayed side', async () => {
+  render(
+    <MemoryRouter initialEntries={['/matchups/game-1']}>
+      <Routes>
+        <Route path="/matchups/:gameId" element={<MatchupDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+  await screen.findByRole('heading', { name: 'BOS Defense Sheet' });
+  expect(screen.queryByRole('button', { name: 'REB' })).not.toBeInTheDocument();
+  await userEvent.click(screen.getByRole('button', { name: 'PTS' }));
+  expect(screen.getAllByRole('article', { name: /player/i })[0]).toHaveTextContent('LeBron James');
+  await userEvent.click(screen.getByRole('button', { name: 'Matchup Score' }));
+  expect(screen.getAllByRole('article', { name: /player/i })[0]).toHaveTextContent('Austin Reaves');
+
+  await userEvent.click(screen.getByRole('button', { name: 'LAL defense' }));
+  expect(await screen.findByRole('button', { name: 'REB' })).toBeVisible();
+  expect(screen.queryByRole('button', { name: 'FGA' })).not.toBeInTheDocument();
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: 'All', exact: true })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    ),
+  );
 });
 
 test('renders raw injury statuses and keeps the signed-out shell honest', async () => {

--- a/src/matchups/MatchupDetailPage.test.js
+++ b/src/matchups/MatchupDetailPage.test.js
@@ -1,0 +1,189 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+import { fetchMatchup } from './matchupApi';
+import MatchupDetailPage from './MatchupDetailPage';
+
+jest.mock('../contexts/AuthContext');
+jest.mock('./matchupApi');
+
+const value = (allowedPer48, percentVsLeagueAverage, sigmaDeviation, rank) => ({
+  allowedPer48,
+  percentVsLeagueAverage,
+  sigmaDeviation,
+  rank,
+});
+
+const matchup = {
+  game: { game_id: 'game-1', away_team: { tricode: 'LAL' }, home_team: { tricode: 'BOS' } },
+  teams: [
+    {
+      teamId: 1,
+      tricode: 'LAL',
+      name: 'Los Angeles Lakers',
+      defenseSheet: { playTypes: [] },
+    },
+    {
+      teamId: 2,
+      tricode: 'BOS',
+      name: 'Boston Celtics',
+      defenseSheet: {
+        playTypes: [
+          {
+            key: 'transition',
+            label: 'Transition',
+            markets: ['PTS', 'FGA'],
+            season: value(18.4, 12, 1.4, 27),
+            last15: value(15.2, -8, -1.1, 5),
+          },
+          {
+            key: 'isolation',
+            label: 'Isolation',
+            markets: ['PTS'],
+            season: value(8.1, 2, 0.4, 16),
+            last15: value(8.4, 4, 0.5, 18),
+          },
+          {
+            key: 'above-break',
+            label: 'Above-break three',
+            markets: ['FG3A'],
+            season: value(10.2, -11, -1.3, 3),
+            last15: value(11, -6, -0.7, 9),
+          },
+        ],
+      },
+    },
+  ],
+  players: [
+    {
+      id: 'player-two',
+      name: 'Austin Reaves',
+      teamId: 1,
+      tricode: 'LAL',
+      postedMarkets: ['PTS', 'FG3A'],
+      seasonScoring: 20.1,
+      last10Minutes: [32, 35, 34],
+      injuryBadgeRef: 'injury-1',
+      dietShares: {
+        playTypes: [
+          {
+            key: 'transition',
+            season: { share: 0.14, volumePerGame: 4 },
+            last15: { share: 0.18, volumePerGame: 5 },
+          },
+        ],
+      },
+    },
+    {
+      id: 'player-one',
+      name: 'LeBron James',
+      teamId: 1,
+      tricode: 'LAL',
+      postedMarkets: ['PTS', 'FGA'],
+      seasonScoring: 25.4,
+      last10Minutes: [35, 36, 38],
+      injuryBadgeRef: null,
+      dietShares: {
+        playTypes: [
+          {
+            key: 'transition',
+            season: { share: 0.19, volumePerGame: 5 },
+            last15: { share: 0.2, volumePerGame: 5.2 },
+          },
+        ],
+      },
+    },
+  ],
+  injuries: {
+    status: 'fresh',
+    unavailableReason: null,
+    retrievedAt: '2026-01-15T11:55:00Z',
+    source: 'rotowire',
+    sourceUrl: 'https://example.com/injuries',
+    teams: [
+      {
+        tricode: 'LAL',
+        entries: [
+          {
+            id: 'injury-1',
+            playerName: 'Austin Reaves',
+            status: null,
+            rawStatus: 'Game-time decision',
+            reason: 'Left calf soreness',
+            sourceUrl: 'https://example.com/austin',
+          },
+        ],
+      },
+    ],
+  },
+  freshness: {
+    schedule: { status: 'fresh', retrievedAt: '2026-01-15T10:00:00Z' },
+    pool: { status: 'fresh', retrievedAt: '2026-01-15T11:50:00Z', providers: [] },
+    stats: { status: 'fresh', retrievedAt: '2026-01-15T10:00:00Z' },
+    injuries: { status: 'fresh', retrievedAt: '2026-01-15T11:55:00Z' },
+  },
+};
+
+beforeEach(() => {
+  useAuth.mockReturnValue({ isAuthenticated: true, loading: false });
+  fetchMatchup.mockResolvedValue(matchup);
+});
+
+test('toggles delivered windows and applies a two-sided sigma filter without refetching', async () => {
+  render(
+    <MemoryRouter initialEntries={['/matchups/game-1']}>
+      <Routes>
+        <Route path="/matchups/:gameId" element={<MatchupDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+  expect(await screen.findByRole('heading', { name: 'BOS Defense Sheet' })).toBeVisible();
+  expect(screen.getByText('Transition')).toBeVisible();
+  expect(screen.getByText('Above-break three')).toBeVisible();
+  expect(screen.queryByText('Isolation')).not.toBeInTheDocument();
+  expect(screen.getByText('1 row hidden near league average.')).toBeVisible();
+  expect(screen.getByText('+12% vs league')).toBeVisible();
+  expect(screen.getByText(/19% poss/)).toBeVisible();
+  expect(screen.getAllByRole('article', { name: /player/i })[0]).toHaveTextContent('LeBron James');
+
+  await userEvent.click(screen.getByRole('button', { name: 'Last 15' }));
+  expect(screen.getByText('-8% vs league')).toBeVisible();
+  expect(screen.getByText(/20% poss/)).toBeVisible();
+  expect(fetchMatchup).toHaveBeenCalledTimes(1);
+
+  await userEvent.click(screen.getByRole('button', { name: 'FGA' }));
+  expect(screen.getByText('Transition')).toBeVisible();
+  expect(screen.queryByText('Above-break three')).not.toBeInTheDocument();
+
+  await userEvent.click(screen.getByRole('button', { name: 'All' }));
+  await userEvent.click(screen.getByRole('button', { name: 'All deviations' }));
+  expect(screen.getByText('Isolation')).toBeVisible();
+  expect(fetchMatchup).toHaveBeenCalledTimes(1);
+});
+
+test('renders raw injury statuses and keeps the signed-out shell honest', async () => {
+  const { unmount } = render(
+    <MemoryRouter initialEntries={['/matchups/game-1']}>
+      <Routes>
+        <Route path="/matchups/:gameId" element={<MatchupDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+  expect((await screen.findAllByText('Game-time decision')).length).toBeGreaterThan(0);
+  expect(screen.getByText('Left calf soreness')).toBeVisible();
+
+  unmount();
+  useAuth.mockReturnValue({ isAuthenticated: false, loading: false });
+  fetchMatchup.mockClear();
+  render(
+    <MemoryRouter initialEntries={['/matchups/game-1']}>
+      <Routes>
+        <Route path="/matchups/:gameId" element={<MatchupDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+  expect(screen.getByRole('heading', { name: 'Sign in to view this matchup' })).toBeVisible();
+  await waitFor(() => expect(fetchMatchup).not.toHaveBeenCalled());
+});

--- a/src/matchups/displayConfig.js
+++ b/src/matchups/displayConfig.js
@@ -1,0 +1,15 @@
+export const DIET_SHARE_DISPLAY_THRESHOLDS = Object.freeze({
+  playTypes: Object.freeze({ minimumShare: 0.15, minimumVolumePerGame: 0 }),
+  shotZones: Object.freeze({ minimumShare: 0.25, minimumVolumePerGame: 0 }),
+  shotTypes: Object.freeze({ minimumShare: 0.35, minimumVolumePerGame: 4 }),
+  assistLocations: Object.freeze({ minimumShare: 0.3, minimumVolumePerGame: 1 }),
+});
+
+export const shouldDisplayDietShare = (base, value) => {
+  const threshold = DIET_SHARE_DISPLAY_THRESHOLDS[base];
+  return (
+    Boolean(threshold) &&
+    value.share >= threshold.minimumShare &&
+    value.volumePerGame >= threshold.minimumVolumePerGame
+  );
+};

--- a/src/matchups/displayConfig.test.js
+++ b/src/matchups/displayConfig.test.js
@@ -1,0 +1,14 @@
+import { shouldDisplayDietShare } from './displayConfig';
+
+test.each([
+  ['playTypes', { share: 0.15, volumePerGame: 0 }, true],
+  ['playTypes', { share: 0.149, volumePerGame: 9 }, false],
+  ['shotZones', { share: 0.25, volumePerGame: 0 }, true],
+  ['shotZones', { share: 0.249, volumePerGame: 9 }, false],
+  ['shotTypes', { share: 0.35, volumePerGame: 4 }, true],
+  ['shotTypes', { share: 0.4, volumePerGame: 3.99 }, false],
+  ['assistLocations', { share: 0.3, volumePerGame: 1 }, true],
+  ['assistLocations', { share: 0.35, volumePerGame: 0.99 }, false],
+])('%s gating returns %s for the named share and volume floors', (base, value, expected) => {
+  expect(shouldDisplayDietShare(base, value)).toBe(expected);
+});

--- a/src/matchups/matchupApi.js
+++ b/src/matchups/matchupApi.js
@@ -1,0 +1,205 @@
+import { apiClient, getApiUrl } from '../config';
+
+const invalid = () => new Error('The matchup endpoint returned an invalid response.');
+const isRecord = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
+const requireString = (value) => {
+  if (typeof value !== 'string' || !value) throw invalid();
+  return value;
+};
+const requireNumber = (value) => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) throw invalid();
+  return value;
+};
+const requireStringList = (value) => {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) throw invalid();
+  return value;
+};
+const camelKey = (key) => key.replace(/_([a-z0-9])/g, (_match, letter) => letter.toUpperCase());
+
+const decodeWindowValue = (value) => {
+  if (!isRecord(value)) throw invalid();
+  return {
+    allowedPer48: requireNumber(value.allowed_per_48),
+    percentVsLeagueAverage: requireNumber(value.percent_vs_league_average),
+    sigmaDeviation: requireNumber(value.sigma_deviation),
+    rank: requireNumber(value.rank),
+  };
+};
+
+const decodeSheetRow = (row) => {
+  if (!isRecord(row)) throw invalid();
+  return {
+    key: requireString(row.key),
+    label: requireString(row.label),
+    markets: requireStringList(row.markets),
+    season: decodeWindowValue(row.season),
+    last15: decodeWindowValue(row.last_15),
+  };
+};
+
+const decodeDefenseSheet = (sheet) => {
+  if (!isRecord(sheet) || Object.keys(sheet).length === 0) throw invalid();
+  return Object.fromEntries(
+    Object.entries(sheet).map(([base, rows]) => {
+      if (!Array.isArray(rows)) throw invalid();
+      return [camelKey(base), rows.map(decodeSheetRow)];
+    }),
+  );
+};
+
+const decodeTeam = (team) => {
+  if (!isRecord(team) || !Number.isInteger(team.team_id)) throw invalid();
+  return {
+    teamId: team.team_id,
+    tricode: requireString(team.tricode),
+    name: requireString(team.name),
+    defenseSheet: decodeDefenseSheet(team.defense_sheet),
+  };
+};
+
+const decodeDietShares = (dietShares) => {
+  if (!isRecord(dietShares)) throw invalid();
+  return Object.fromEntries(
+    Object.entries(dietShares).map(([base, entries]) => {
+      if (!Array.isArray(entries)) throw invalid();
+      return [
+        camelKey(base),
+        entries.map((entry) => {
+          if (!isRecord(entry) || !isRecord(entry.season) || !isRecord(entry.last_15)) {
+            throw invalid();
+          }
+          const decodeShare = (share) => ({
+            share: requireNumber(share.share),
+            volumePerGame: requireNumber(share.volume_per_game),
+          });
+          return {
+            key: requireString(entry.key),
+            season: decodeShare(entry.season),
+            last15: decodeShare(entry.last_15),
+          };
+        }),
+      ];
+    }),
+  );
+};
+
+const decodePlayer = (player) => {
+  if (!isRecord(player) || !Number.isInteger(player.team_id)) throw invalid();
+  if (!Array.isArray(player.last_10_minutes)) throw invalid();
+  return {
+    id: requireString(player.canonical_id),
+    name: requireString(player.name),
+    teamId: player.team_id,
+    tricode: requireString(player.tricode),
+    postedMarkets: requireStringList(player.posted_markets),
+    seasonScoring: requireNumber(player.season_scoring),
+    last10Minutes: player.last_10_minutes.map(requireNumber),
+    dietShares: decodeDietShares(player.diet_shares),
+    injuryBadgeRef:
+      player.injury_badge_ref === null ? null : requireString(player.injury_badge_ref),
+  };
+};
+
+const decodeRetrievedAt = (value) => {
+  if (value === null) return null;
+  const date = new Date(requireString(value));
+  if (Number.isNaN(date.getTime())) throw invalid();
+  return date.toISOString();
+};
+
+const decodeFreshnessSurface = (surface) => {
+  if (!isRecord(surface) || !('retrieved_at' in surface)) throw invalid();
+  return {
+    status: requireString(surface.status),
+    retrievedAt: decodeRetrievedAt(surface.retrieved_at),
+  };
+};
+
+const decodeFreshness = (freshness) => {
+  if (!isRecord(freshness)) throw invalid();
+  const result = {};
+  for (const name of ['schedule', 'pool', 'stats', 'injuries']) {
+    result[name] = decodeFreshnessSurface(freshness[name]);
+  }
+  if (!isRecord(freshness.pool.providers)) throw invalid();
+  result.pool.providers = Object.entries(freshness.pool.providers).map(([name, surface]) => ({
+    name,
+    ...decodeFreshnessSurface(surface),
+  }));
+  return result;
+};
+
+const decodeInjuryEntry = (entry) => {
+  if (!isRecord(entry)) throw invalid();
+  if (
+    entry.status !== null &&
+    entry.status !== undefined &&
+    !['Probable', 'Questionable', 'Doubtful', 'Out'].includes(entry.status)
+  ) {
+    throw invalid();
+  }
+  return {
+    id: requireString(entry.entry_id),
+    playerId: entry.canonical_player_id,
+    playerName: requireString(entry.source_player_name),
+    teamId: entry.team_id,
+    tricode: requireString(entry.tricode),
+    status: entry.status || null,
+    rawStatus: entry.raw_status || null,
+    reason: requireString(entry.reason),
+    sourceUrl: requireString(entry.source_url),
+  };
+};
+
+const decodeInjuries = (injuries) => {
+  if (!isRecord(injuries) || !['fresh', 'stale', 'unavailable'].includes(injuries.status)) {
+    throw invalid();
+  }
+  if (!Array.isArray(injuries.teams)) throw invalid();
+  return {
+    status: injuries.status,
+    unavailableReason: injuries.unavailable_reason || null,
+    retrievedAt: decodeRetrievedAt(injuries.retrieved_at),
+    source: requireString(injuries.source),
+    sourceUrl: requireString(injuries.source_url),
+    teams: injuries.teams.map((team) => {
+      if (!isRecord(team) || !Array.isArray(team.entries)) throw invalid();
+      return {
+        teamId: team.team_id,
+        tricode: requireString(team.tricode),
+        submissionState: team.submission_state || null,
+        entries: team.entries.map(decodeInjuryEntry),
+      };
+    }),
+  };
+};
+
+export const decodeMatchup = (data) => {
+  if (
+    !isRecord(data) ||
+    !isRecord(data.game) ||
+    !Array.isArray(data.teams) ||
+    data.teams.length !== 2
+  ) {
+    throw invalid();
+  }
+  return {
+    game: data.game,
+    teams: data.teams.map(decodeTeam),
+    players: Array.isArray(data.players)
+      ? data.players.map(decodePlayer)
+      : (() => {
+          throw invalid();
+        })(),
+    injuries: decodeInjuries(data.injuries),
+    freshness: decodeFreshness(data.freshness),
+  };
+};
+
+export const fetchMatchup = async (gameId, { signal } = {}) => {
+  const response = await apiClient.get(getApiUrl('MATCHUP'), {
+    params: { game_id: gameId },
+    signal,
+  });
+  return decodeMatchup(response.data);
+};

--- a/src/matchups/matchupApi.js
+++ b/src/matchups/matchupApi.js
@@ -1,4 +1,10 @@
 import { apiClient, getApiUrl } from '../config';
+import {
+  derivePoolStatusFromProviders,
+  deriveScheduleStatus,
+  isStatusAllowed,
+  statusAllowsNullRetrievedAt,
+} from '../slateStatus';
 
 const invalid = () => new Error('The matchup endpoint returned an invalid response.');
 const isRecord = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
@@ -54,8 +60,34 @@ const decodeTeam = (team) => {
     tricode: requireString(team.tricode),
     name: requireString(team.name),
     defenseSheet: decodeDefenseSheet(team.defense_sheet),
+    defensiveColumns: decodeDefensiveColumns(team.defensive_columns),
   };
 };
+
+const DEFENSIVE_COLUMN_KEYS = ['OPP_TOV', 'OPP_STL', 'OPP_BLK'];
+
+const decodeDefensiveColumnWindow = (value) => {
+  if (!isRecord(value)) throw invalid();
+  return {
+    per48: requireNumber(value.per_48),
+    percentVsLeagueAverage: requireNumber(value.percent_vs_league_average),
+  };
+};
+
+function decodeDefensiveColumns(columns) {
+  if (!isRecord(columns) || DEFENSIVE_COLUMN_KEYS.some((key) => !isRecord(columns[key]))) {
+    throw invalid();
+  }
+  return Object.fromEntries(
+    DEFENSIVE_COLUMN_KEYS.map((key) => [
+      key,
+      {
+        season: decodeDefensiveColumnWindow(columns[key].season),
+        last15: decodeDefensiveColumnWindow(columns[key].last_15),
+      },
+    ]),
+  );
+}
 
 const decodeDietShares = (dietShares) => {
   if (!isRecord(dietShares)) throw invalid();
@@ -97,8 +129,42 @@ const decodePlayer = (player) => {
     dietShares: decodeDietShares(player.diet_shares),
     injuryBadgeRef:
       player.injury_badge_ref === null ? null : requireString(player.injury_badge_ref),
+    scores: decodeScores(player.scores, player.posted_markets),
   };
 };
+
+const decodeScoreCell = (cell) => {
+  if (!isRecord(cell) || typeof cell.thin !== 'boolean') throw invalid();
+  return { value: requireNumber(cell.value), thin: cell.thin };
+};
+
+const decodeScoreWindow = (window) => {
+  if (!isRecord(window) || !isRecord(window.components)) throw invalid();
+  return {
+    components: Object.fromEntries(
+      Object.entries(window.components).map(([base, cell]) => [
+        camelKey(base),
+        decodeScoreCell(cell),
+      ]),
+    ),
+    blend: decodeScoreCell(window.blend),
+  };
+};
+
+function decodeScores(scores, postedMarkets) {
+  if (!isRecord(scores) || postedMarkets.some((market) => !isRecord(scores[market]))) {
+    throw invalid();
+  }
+  return Object.fromEntries(
+    postedMarkets.map((market) => [
+      market,
+      {
+        season: decodeScoreWindow(scores[market].season),
+        last15: decodeScoreWindow(scores[market].last_15),
+      },
+    ]),
+  );
+}
 
 const decodeRetrievedAt = (value) => {
   if (value === null) return null;
@@ -107,26 +173,93 @@ const decodeRetrievedAt = (value) => {
   return date.toISOString();
 };
 
-const decodeFreshnessSurface = (surface) => {
-  if (!isRecord(surface) || !('retrieved_at' in surface)) throw invalid();
+const decodeFreshnessSurface = (surface, surfaceName) => {
+  if (!isRecord(surface) || !isStatusAllowed(surface.status, surfaceName)) throw invalid();
+  const retrievedAt = decodeRetrievedAt(surface.retrieved_at ?? null);
+  if (!retrievedAt && !statusAllowsNullRetrievedAt(surface.status)) throw invalid();
   return {
-    status: requireString(surface.status),
-    retrievedAt: decodeRetrievedAt(surface.retrieved_at),
+    status: surface.status,
+    retrievedAt,
   };
 };
 
 const decodeFreshness = (freshness) => {
-  if (!isRecord(freshness)) throw invalid();
-  const result = {};
-  for (const name of ['schedule', 'pool', 'stats', 'injuries']) {
-    result[name] = decodeFreshnessSurface(freshness[name]);
+  if (!isRecord(freshness) || !isRecord(freshness.schedule) || !isRecord(freshness.pool)) {
+    throw invalid();
+  }
+  const scheduleRetrievedAt = decodeRetrievedAt(freshness.schedule.retrieved_at ?? null);
+  let schedule;
+  if (freshness.schedule.status === undefined) {
+    if (!scheduleRetrievedAt) throw invalid();
+    schedule = {
+      status: deriveScheduleStatus(scheduleRetrievedAt),
+      retrievedAt: scheduleRetrievedAt,
+    };
+  } else {
+    schedule = decodeFreshnessSurface(freshness.schedule, 'schedule');
   }
   if (!isRecord(freshness.pool.providers)) throw invalid();
-  result.pool.providers = Object.entries(freshness.pool.providers).map(([name, surface]) => ({
-    name,
-    ...decodeFreshnessSurface(surface),
+  const providers = Object.entries(freshness.pool.providers).map(([name, surface]) => ({
+    name: requireString(name),
+    ...decodeFreshnessSurface(surface, 'pool'),
   }));
-  return result;
+  let pool;
+  if (freshness.pool.status === undefined) {
+    const status = derivePoolStatusFromProviders(providers);
+    if (!status) throw invalid();
+    const retrievedAt =
+      decodeRetrievedAt(freshness.pool.retrieved_at ?? null) ||
+      providers
+        .map((provider) => provider.retrievedAt)
+        .filter(Boolean)
+        .sort()
+        .at(0) ||
+      null;
+    pool = { status, retrievedAt, providers };
+  } else {
+    pool = { ...decodeFreshnessSurface(freshness.pool, 'pool'), providers };
+  }
+  return {
+    schedule,
+    pool,
+    stats: decodeFreshnessSurface(freshness.stats, 'stats'),
+    injuries: decodeFreshnessSurface(freshness.injuries, 'injuries'),
+  };
+};
+
+const decodeGameTeam = (team) => {
+  if (!isRecord(team) || !Number.isInteger(team.team_id)) throw invalid();
+  const targetablePlayerCount = team.targetable_player_count ?? null;
+  if (targetablePlayerCount !== null && !Number.isInteger(targetablePlayerCount)) throw invalid();
+  return {
+    teamId: team.team_id,
+    tricode: requireString(team.tricode),
+    name: requireString(team.name),
+    targetablePlayerCount,
+  };
+};
+
+const decodeGame = (game) => {
+  if (
+    !isRecord(game) ||
+    !isRecord(game.status) ||
+    !['scheduled', 'postponed', 'final'].includes(game.status.state) ||
+    typeof game.preseason !== 'boolean'
+  ) {
+    throw invalid();
+  }
+  const scheduledAt = new Date(requireString(game.scheduled_at));
+  if (Number.isNaN(scheduledAt.getTime())) throw invalid();
+  return {
+    gameId: requireString(game.game_id),
+    away: decodeGameTeam(game.away_team),
+    home: decodeGameTeam(game.home_team),
+    scheduledAt: scheduledAt.toISOString(),
+    status: game.status.state,
+    statusLabel: game.status.label ? requireString(game.status.label) : null,
+    classification: game.classification ? requireString(game.classification) : null,
+    preseason: game.preseason,
+  };
 };
 
 const decodeInjuryEntry = (entry) => {
@@ -179,18 +312,15 @@ export const decodeMatchup = (data) => {
     !isRecord(data) ||
     !isRecord(data.game) ||
     !Array.isArray(data.teams) ||
-    data.teams.length !== 2
+    data.teams.length !== 2 ||
+    !Array.isArray(data.players)
   ) {
     throw invalid();
   }
   return {
-    game: data.game,
+    game: decodeGame(data.game),
     teams: data.teams.map(decodeTeam),
-    players: Array.isArray(data.players)
-      ? data.players.map(decodePlayer)
-      : (() => {
-          throw invalid();
-        })(),
+    players: data.players.map(decodePlayer),
     injuries: decodeInjuries(data.injuries),
     freshness: decodeFreshness(data.freshness),
   };

--- a/src/matchups/matchupApi.test.js
+++ b/src/matchups/matchupApi.test.js
@@ -35,12 +35,40 @@ const payload = {
           },
         ],
       },
+      defensive_columns: {
+        OPP_TOV: {
+          season: { per_48: 14.2, percent_vs_league_average: 8 },
+          last_15: { per_48: 12.9, percent_vs_league_average: -3 },
+        },
+        OPP_STL: {
+          season: { per_48: 7.1, percent_vs_league_average: -5 },
+          last_15: { per_48: 7.8, percent_vs_league_average: 4 },
+        },
+        OPP_BLK: {
+          season: { per_48: 5.4, percent_vs_league_average: 11 },
+          last_15: { per_48: 4.7, percent_vs_league_average: -2 },
+        },
+      },
     },
     {
       team_id: 2,
       tricode: 'BOS',
       name: 'Boston Celtics',
       defense_sheet: { play_types: [] },
+      defensive_columns: {
+        OPP_TOV: {
+          season: { per_48: 12, percent_vs_league_average: -4 },
+          last_15: { per_48: 13, percent_vs_league_average: 2 },
+        },
+        OPP_STL: {
+          season: { per_48: 8, percent_vs_league_average: 5 },
+          last_15: { per_48: 8.2, percent_vs_league_average: 7 },
+        },
+        OPP_BLK: {
+          season: { per_48: 4.8, percent_vs_league_average: -2 },
+          last_15: { per_48: 5, percent_vs_league_average: 1 },
+        },
+      },
     },
   ],
   players: [
@@ -62,6 +90,28 @@ const payload = {
         ],
       },
       injury_badge_ref: null,
+      scores: {
+        PTS: {
+          season: {
+            components: { play_types: { value: 0.08, thin: false } },
+            blend: { value: 0.12, thin: false },
+          },
+          last_15: {
+            components: { play_types: { value: -0.03, thin: false } },
+            blend: { value: -0.01, thin: false },
+          },
+        },
+        FGA: {
+          season: {
+            components: { play_types: { value: 0.04, thin: false } },
+            blend: { value: 0.04, thin: false },
+          },
+          last_15: {
+            components: { play_types: { value: 0.02, thin: false } },
+            blend: { value: 0.02, thin: false },
+          },
+        },
+      },
     },
   ],
   injuries: {
@@ -91,7 +141,48 @@ test('decodes both delivered windows and preserves relative values', () => {
     }),
   );
   expect(matchup.players[0]).toEqual(
-    expect.objectContaining({ id: 'lebron-james', postedMarkets: ['PTS', 'FGA'] }),
+    expect.objectContaining({
+      id: 'lebron-james',
+      postedMarkets: ['PTS', 'FGA'],
+      scores: expect.objectContaining({
+        PTS: expect.objectContaining({
+          season: expect.objectContaining({ blend: { value: 0.12, thin: false } }),
+        }),
+      }),
+    }),
+  );
+  expect(matchup.game).toEqual(
+    expect.objectContaining({
+      gameId: '0022500584',
+      away: expect.objectContaining({ tricode: 'LAL' }),
+    }),
+  );
+  expect(matchup.teams[0].defensiveColumns.OPP_TOV.season).toEqual({
+    per48: 14.2,
+    percentVsLeagueAverage: 8,
+  });
+});
+
+test('accepts clarified freshness with derived schedule and provider-only pool timestamps', () => {
+  const candidate = {
+    ...payload,
+    freshness: {
+      ...payload.freshness,
+      schedule: { retrieved_at: '2026-01-15T10:00:00Z' },
+      pool: {
+        providers: {
+          prizepicks: { status: 'fresh', retrieved_at: '2026-01-15T11:50:00Z' },
+          underdog: { status: 'missing', retrieved_at: null },
+        },
+      },
+    },
+  };
+
+  expect(decodeMatchup(candidate).freshness).toEqual(
+    expect.objectContaining({
+      schedule: expect.objectContaining({ status: expect.stringMatching(/fresh|stale/) }),
+      pool: expect.objectContaining({ status: 'partial', retrievedAt: '2026-01-15T11:50:00.000Z' }),
+    }),
   );
 });
 
@@ -104,6 +195,14 @@ test.each([
       injuries: { ...payload.injuries, status: 'fresh-ish' },
     },
   ],
+  [
+    'invalid freshness status',
+    {
+      ...payload,
+      freshness: { ...payload.freshness, stats: { status: 'fresh-ish', retrieved_at: null } },
+    },
+  ],
+  ['invalid game', { ...payload, game: { ...payload.game, scheduled_at: 'not-a-date' } }],
 ])('rejects %s at the response boundary', (_name, candidate) => {
   expect(() => decodeMatchup(candidate)).toThrow('invalid response');
 });

--- a/src/matchups/matchupApi.test.js
+++ b/src/matchups/matchupApi.test.js
@@ -1,0 +1,109 @@
+import { decodeMatchup } from './matchupApi';
+
+const payload = {
+  game: {
+    game_id: '0022500584',
+    away_team: { team_id: 1, tricode: 'LAL', name: 'Los Angeles Lakers' },
+    home_team: { team_id: 2, tricode: 'BOS', name: 'Boston Celtics' },
+    scheduled_at: '2026-01-16T00:30:00Z',
+    status: { state: 'scheduled', label: 'Scheduled' },
+    preseason: false,
+  },
+  teams: [
+    {
+      team_id: 1,
+      tricode: 'LAL',
+      name: 'Los Angeles Lakers',
+      defense_sheet: {
+        play_types: [
+          {
+            key: 'transition',
+            label: 'Transition',
+            markets: ['PTS', 'FGA'],
+            season: {
+              allowed_per_48: 18.4,
+              percent_vs_league_average: 12,
+              sigma_deviation: 1.4,
+              rank: 27,
+            },
+            last_15: {
+              allowed_per_48: 15.2,
+              percent_vs_league_average: -8,
+              sigma_deviation: -1.1,
+              rank: 5,
+            },
+          },
+        ],
+      },
+    },
+    {
+      team_id: 2,
+      tricode: 'BOS',
+      name: 'Boston Celtics',
+      defense_sheet: { play_types: [] },
+    },
+  ],
+  players: [
+    {
+      canonical_id: 'lebron-james',
+      name: 'LeBron James',
+      team_id: 1,
+      tricode: 'LAL',
+      posted_markets: ['PTS', 'FGA'],
+      season_scoring: 25.4,
+      last_10_minutes: [35, 36],
+      diet_shares: {
+        play_types: [
+          {
+            key: 'transition',
+            season: { share: 0.19, volume_per_game: 5.1 },
+            last_15: { share: 0.2, volume_per_game: 5.3 },
+          },
+        ],
+      },
+      injury_badge_ref: null,
+    },
+  ],
+  injuries: {
+    status: 'unavailable',
+    unavailable_reason: 'permission_required',
+    retrieved_at: null,
+    source: 'rotowire',
+    source_url: 'https://example.com/injuries',
+    teams: [],
+  },
+  freshness: {
+    schedule: { status: 'fresh', retrieved_at: '2026-01-15T10:00:00Z' },
+    pool: { status: 'fresh', retrieved_at: '2026-01-15T11:50:00Z', providers: {} },
+    stats: { status: 'fresh', retrieved_at: '2026-01-15T10:00:00Z' },
+    injuries: { status: 'missing', retrieved_at: null },
+  },
+};
+
+test('decodes both delivered windows and preserves relative values', () => {
+  const matchup = decodeMatchup(payload);
+
+  expect(matchup.teams[0].defenseSheet.playTypes[0]).toEqual(
+    expect.objectContaining({
+      markets: ['PTS', 'FGA'],
+      season: expect.objectContaining({ allowedPer48: 18.4, sigmaDeviation: 1.4 }),
+      last15: expect.objectContaining({ percentVsLeagueAverage: -8 }),
+    }),
+  );
+  expect(matchup.players[0]).toEqual(
+    expect.objectContaining({ id: 'lebron-james', postedMarkets: ['PTS', 'FGA'] }),
+  );
+});
+
+test.each([
+  ['missing windows', { ...payload, teams: [{ ...payload.teams[0], defense_sheet: {} }] }],
+  [
+    'invented injury status',
+    {
+      ...payload,
+      injuries: { ...payload.injuries, status: 'fresh-ish' },
+    },
+  ],
+])('rejects %s at the response boundary', (_name, candidate) => {
+  expect(() => decodeMatchup(candidate)).toThrow('invalid response');
+});

--- a/src/slateStatus.js
+++ b/src/slateStatus.js
@@ -1,6 +1,6 @@
 const definitions = {
   fresh: {
-    inboundSurfaces: ['schedule', 'pool'],
+    inboundSurfaces: ['schedule', 'pool', 'stats', 'injuries'],
     allowsNullRetrievedAt: false,
     warning: false,
     currentPoolMessage: 'Targetable counts use the current player pool.',
@@ -8,7 +8,7 @@ const definitions = {
       'Past slate — the current player pool is not displayed for historical dates. Final game cards retain the posted targetable counts returned for this slate.',
   },
   stale: {
-    inboundSurfaces: ['schedule'],
+    inboundSurfaces: ['schedule', 'stats', 'injuries'],
     allowsNullRetrievedAt: false,
     warning: true,
     currentPoolMessage: 'Player pool snapshot is stale; targetable counts may be out of date.',
@@ -25,7 +25,7 @@ const definitions = {
       'Past slate — the latest available snapshot is not displayed for historical dates. Final game cards retain the posted targetable counts returned for this slate.',
   },
   missing: {
-    inboundSurfaces: ['schedule', 'pool'],
+    inboundSurfaces: ['schedule', 'pool', 'stats', 'injuries'],
     allowsNullRetrievedAt: true,
     warning: true,
     currentPoolMessage: 'Player pool is missing; no targetable players are currently available.',


### PR DESCRIPTION
Part of #5 and crf04/statsplus#14.

Merge after: crf04/statsplus-backend#43. This PR targets the non-deploying packet integration branch.

Implements `/matchups/:gameId`, Team Defense Sheets across five bases and two windows, market/window/team controls, Matchup Score sorting, scoped Diet Share chips, player rail, injuries/provenance, freshness/degraded behavior, strict decoder, and deterministic visual coverage.

Verification: lint/format/build; Jest 86/86; Chromium 20/20; desktop/narrow/loading/degraded visual QA with no console/network/page errors.

Review: Opus 5 Standards CLEAR; Opus 5 Spec CLEAR after correction loops.