### PR TITLE
Add matchup selection card and log tables

### DIFF
--- a/e2e/fixtures/courtai.js
+++ b/e2e/fixtures/courtai.js
@@ -190,7 +190,9 @@ const scoreWindow = (value, market) => ({
         play_types: { value: value - 0.01, thin: market === 'AST' },
         shot_zones: { value, thin: false },
       },
-  blend: { value, thin: false },
+  ...(!['TOV', 'STL', 'BLK', 'STKS'].includes(market) && {
+    blend: { value, thin: false },
+  }),
 });
 
 const scores = (markets, seasonValue, last15Value) =>
@@ -251,6 +253,13 @@ export const matchupPayload = {
           defenseValue(8.1, 2, 0.4, 16),
           defenseValue(8.4, 4, 0.5, 18),
         ),
+        defenseRow(
+          'post-up',
+          'Post up',
+          ['PTS'],
+          defenseValue(12.1, 10, 1.2, 25),
+          defenseValue(12.8, 11, 1.3, 26),
+        ),
       ],
       1,
     ),
@@ -264,17 +273,17 @@ export const matchupPayload = {
       name: 'LeBron James',
       team_id: slateGame.away_team.team_id,
       tricode: 'LAL',
-      posted_markets: ['PTS', 'FGA', 'AST', 'REB', 'TOV'],
+      posted_markets: ['PTS', 'FGA', 'AST', 'REB', 'PRA', 'TOV'],
       season_scoring: 25.4,
       last_10_minutes: [35, 36, 38, 34, 37, 36, 35, 39, 36, 37],
       diet_shares: {
-        play_types: [dietShare('transition', 0.19, 0.2)],
+        play_types: [dietShare('transition', 0.19, 0.2), dietShare('post-up', 0.02, 0.16)],
         shot_zones: [dietShare('paint', 0.27, 0.28)],
         shot_types: [dietShare('catch-shoot', 0.36, 0.37, 4.2, 4.3)],
         assist_locations: [dietShare('paint-assists', 0.31, 0.32, 1.1, 1.2)],
       },
       injury_badge_ref: null,
-      scores: scores(['PTS', 'FGA', 'AST', 'REB', 'TOV'], 0.12, -0.02),
+      scores: scores(['PTS', 'FGA', 'AST', 'REB', 'PRA', 'TOV'], 0.12, -0.02),
     },
     {
       canonical_id: 'austin-reaves',
@@ -382,33 +391,74 @@ export const matchupPayload = {
   },
 };
 
-const selectionLine = (date, matchup, minutes, pts, ast, ptsDelta, astDelta) => ({
+const selectionLine = (date, matchup, minutes, values, deltas) => ({
   game_date: date,
   matchup,
   minutes,
-  stats: { PTS: pts, FGA: 19, AST: ast, REB: 8, TOV: 3 },
-  deltas: { PTS: ptsDelta, FGA: 0.018, AST: astDelta, REB: -0.012, TOV: 0.006 },
+  stats: values,
+  deltas,
 });
 
 export const selectionPayload = {
   player_id: 'lebron-james',
   h2h: {
-    status: 'ready',
-    rows: [selectionLine('2025-12-25', 'LAL vs. BOS', 36, 31, 9, 0.083, 0.031)],
-    average: {
-      minutes: 36,
-      stats: { PTS: 31, FGA: 19, AST: 9, REB: 8, TOV: 3 },
-      deltas: { PTS: 0.083, FGA: 0.018, AST: 0.031, REB: -0.012, TOV: 0.006 },
-    },
+    rows: [
+      selectionLine(
+        '2025-12-25',
+        'LAL vs. BOS',
+        36,
+        { PTS: 31, FGA: 19, AST: 9, REB: 8, PRA: 48, TOV: 3 },
+        { PTS: 0.083, FGA: 0.018, AST: 0.031, REB: -0.012, PRA: 0.102, TOV: 0.006 },
+      ),
+      selectionLine(
+        null,
+        'AVG',
+        36,
+        { PTS: 31, FGA: 19, AST: 9, REB: 8, PRA: 48, TOV: 3 },
+        { PTS: 0.083, FGA: 0.018, AST: 0.031, REB: -0.012, PRA: 0.102, TOV: 0.006 },
+      ),
+    ],
   },
   archetype: {
-    status: 'thin',
-    rows: [selectionLine('2025-12-20', 'DAL @ BOS', 34, 28, 7, 0.041, -0.009)],
-    average: {
-      minutes: 34,
-      stats: { PTS: 28, FGA: 19, AST: 7, REB: 8, TOV: 3 },
-      deltas: { PTS: 0.041, FGA: 0.018, AST: -0.009, REB: -0.012, TOV: 0.006 },
-    },
+    rows: [
+      selectionLine(
+        '2025-12-20',
+        'DAL @ BOS',
+        34,
+        { PTS: 28, FGA: 18, AST: 7, REB: 8, PRA: 43, TOV: 3 },
+        { PTS: 0.041, FGA: 0.015, AST: -0.009, REB: -0.012, PRA: 0.02, TOV: 0.006 },
+      ),
+      selectionLine(
+        null,
+        'AVG',
+        34,
+        { PTS: 28, FGA: 18, AST: 7, REB: 8, PRA: 43, TOV: 3 },
+        { PTS: 0.041, FGA: 0.015, AST: -0.009, REB: -0.012, PRA: 0.02, TOV: 0.006 },
+      ),
+    ],
+  },
+};
+
+export const austinSelectionPayload = {
+  player_id: 'austin-reaves',
+  h2h: { rows: [] },
+  archetype: {
+    rows: [
+      selectionLine(
+        '2025-12-18',
+        'MIA @ BOS',
+        33,
+        { PTS: 22, FG3A: 7, STL: 1 },
+        { PTS: 0.022, FG3A: 0.013, STL: -0.004 },
+      ),
+      selectionLine(
+        null,
+        'AVG',
+        33,
+        { PTS: 22, FG3A: 7, STL: 1 },
+        { PTS: 0.022, FG3A: 0.013, STL: -0.004 },
+      ),
+    ],
   },
 };
 
@@ -469,7 +519,17 @@ export const installApiContract = async (page, overrides = {}) => {
     }
 
     if (url.pathname === '/api/games/matchup/selection') {
-      await route.fulfill({ json: selectionPayload });
+      const gameId = url.searchParams.get('game_id');
+      const playerId = url.searchParams.get('player_id');
+      const payloads = {
+        'lebron-james': selectionPayload,
+        'austin-reaves': austinSelectionPayload,
+      };
+      if (gameId !== matchupPayload.game.game_id || !payloads[playerId]) {
+        await route.fulfill({ status: 404, json: { error: { code: 'resource_not_found' } } });
+        return;
+      }
+      await route.fulfill({ json: payloads[playerId] });
       return;
     }
 

--- a/e2e/fixtures/courtai.js
+++ b/e2e/fixtures/courtai.js
@@ -183,11 +183,13 @@ const dietShare = (key, seasonShare, last15Share, seasonVolume = 5.1, last15Volu
   last_15: { share: last15Share, volume_per_game: last15Volume },
 });
 
-const scoreWindow = (value) => ({
-  components: {
-    play_types: { value: value - 0.01, thin: false },
-    shot_zones: { value, thin: false },
-  },
+const scoreWindow = (value, market) => ({
+  components: ['TOV', 'STL', 'BLK', 'STKS'].includes(market)
+    ? { traditional: { value, thin: false } }
+    : {
+        play_types: { value: value - 0.01, thin: market === 'AST' },
+        shot_zones: { value, thin: false },
+      },
   blend: { value, thin: false },
 });
 
@@ -196,8 +198,8 @@ const scores = (markets, seasonValue, last15Value) =>
     markets.map((market, index) => [
       market,
       {
-        season: scoreWindow(seasonValue + index / 100),
-        last_15: scoreWindow(last15Value + index / 100),
+        season: scoreWindow(seasonValue + index / 100, market),
+        last_15: scoreWindow(last15Value + index / 100, market),
       },
     ]),
   );
@@ -380,6 +382,36 @@ export const matchupPayload = {
   },
 };
 
+const selectionLine = (date, matchup, minutes, pts, ast, ptsDelta, astDelta) => ({
+  game_date: date,
+  matchup,
+  minutes,
+  stats: { PTS: pts, FGA: 19, AST: ast, REB: 8, TOV: 3 },
+  deltas: { PTS: ptsDelta, FGA: 0.018, AST: astDelta, REB: -0.012, TOV: 0.006 },
+});
+
+export const selectionPayload = {
+  player_id: 'lebron-james',
+  h2h: {
+    status: 'ready',
+    rows: [selectionLine('2025-12-25', 'LAL vs. BOS', 36, 31, 9, 0.083, 0.031)],
+    average: {
+      minutes: 36,
+      stats: { PTS: 31, FGA: 19, AST: 9, REB: 8, TOV: 3 },
+      deltas: { PTS: 0.083, FGA: 0.018, AST: 0.031, REB: -0.012, TOV: 0.006 },
+    },
+  },
+  archetype: {
+    status: 'thin',
+    rows: [selectionLine('2025-12-20', 'DAL @ BOS', 34, 28, 7, 0.041, -0.009)],
+    average: {
+      minutes: 34,
+      stats: { PTS: 28, FGA: 19, AST: 7, REB: 8, TOV: 3 },
+      deltas: { PTS: 0.041, FGA: 0.018, AST: -0.009, REB: -0.012, TOV: 0.006 },
+    },
+  },
+};
+
 export const installApiContract = async (page, overrides = {}) => {
   await page.route('**/api/**', async (route) => {
     const request = route.request();
@@ -433,6 +465,11 @@ export const installApiContract = async (page, overrides = {}) => {
 
     if (url.pathname === '/api/games/matchup') {
       await route.fulfill({ json: matchupPayload });
+      return;
+    }
+
+    if (url.pathname === '/api/games/matchup/selection') {
+      await route.fulfill({ json: selectionPayload });
       return;
     }
 

--- a/e2e/fixtures/courtai.js
+++ b/e2e/fixtures/courtai.js
@@ -392,8 +392,9 @@ export const matchupPayload = {
 };
 
 const selectionLine = (date, matchup, minutes, values, deltas) => ({
+  row_type: date === null ? 'average' : 'game',
   game_date: date,
-  matchup,
+  matchup: date === null ? null : matchup,
   minutes,
   stats: values,
   deltas,
@@ -402,6 +403,7 @@ const selectionLine = (date, matchup, minutes, values, deltas) => ({
 export const selectionPayload = {
   player_id: 'lebron-james',
   h2h: {
+    thin: false,
     rows: [
       selectionLine(
         '2025-12-25',
@@ -420,6 +422,7 @@ export const selectionPayload = {
     ],
   },
   archetype: {
+    thin: true,
     rows: [
       selectionLine(
         '2025-12-20',
@@ -441,8 +444,9 @@ export const selectionPayload = {
 
 export const austinSelectionPayload = {
   player_id: 'austin-reaves',
-  h2h: { rows: [] },
+  h2h: { thin: false, rows: [] },
   archetype: {
+    thin: true,
     rows: [
       selectionLine(
         '2025-12-18',

--- a/e2e/specs/matchup-detail.spec.js
+++ b/e2e/specs/matchup-detail.spec.js
@@ -50,7 +50,7 @@ test('@critical user opens a Defense Sheet and changes local spotting controls',
     fullPage: true,
   });
 
-  await page.getByRole('button', { name: 'Last 15' }).click();
+  await page.getByRole('button', { name: 'Last 15', exact: true }).click();
   await expect(page.getByText('-8% vs league')).toBeVisible();
   await expect(page.getByText(/LeBron James · 20% poss/)).toBeVisible();
 
@@ -201,26 +201,61 @@ test('@critical selection card supports selection, deep links, and tab flips wit
   page.on('request', (request) => {
     if (new URL(request.url()).pathname === '/api/games/matchup/selection') selectionRequests += 1;
   });
-  await page.goto('/matchups/0022500584');
+  await page.goto('/matchups/0022500584?context=kept');
   await page
     .getByRole('article', { name: 'LeBron James player' })
     .getByRole('button', { name: 'Open selection card' })
     .click();
-  await expect(page).toHaveURL(/player=lebron-james/);
+  await expect(page).toHaveURL(
+    /context=kept.*player=lebron-james|player=lebron-james.*context=kept/,
+  );
+  await expect(page.getByRole('button', { name: 'All', exact: true })).toHaveAttribute(
+    'aria-pressed',
+    'true',
+  );
   await expect(page.getByRole('heading', { name: 'LeBron James', level: 2 })).toBeVisible();
+  await page
+    .getByRole('article', { name: 'LeBron James player' })
+    .getByRole('button', { name: 'Selected' })
+    .click();
   const matrix = page.getByRole('table', { name: 'LeBron James Score Matrix' });
   await expect(matrix).toContainText('+12%');
   await expect(matrix).toContainText('thin');
-  await expect(page.getByText('Thin sample — interpret cautiously.')).toBeVisible();
+  await expect(page.getByText('Thin sample — interpret cautiously.').first()).toBeVisible();
   await expect(page.getByRole('rowheader', { name: 'AVG' }).first()).toBeVisible();
-  await page.getByRole('button', { name: 'AST', exact: true }).click();
-  await expect(page.getByRole('columnheader', { name: 'AST' }).first()).toBeVisible();
+  const postUpRow = page.locator('article.sheet-row').filter({ hasText: 'Post up' });
+  await expect(postUpRow).not.toHaveClass(/selection-why/);
+  await page.getByRole('button', { name: 'Last 15', exact: true }).click();
+  await expect(postUpRow).toHaveClass(/selection-why/);
+  await expect(page.getByRole('button', { name: 'All', exact: true })).toHaveAttribute(
+    'aria-pressed',
+    'true',
+  );
+  await page
+    .getByRole('group', { name: 'Selection log stat' })
+    .getByRole('button', { name: 'PRA' })
+    .click();
+  await expect(page.getByRole('columnheader', { name: 'PRA' }).first()).toBeVisible();
+  await expect(page.getByText('+0.102').first()).toBeVisible();
   expect(selectionRequests).toBe(1);
   await page.screenshot({
     path: testInfo.outputPath('selection-card-desktop.png'),
     fullPage: true,
   });
 
+  await page.goBack();
+  await expect(page.getByRole('heading', { name: 'LeBron James', level: 2 })).toHaveCount(0);
+  await page.goForward();
+  await expect(page.getByRole('heading', { name: 'LeBron James', level: 2 })).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(page.getByRole('heading', { name: 'LeBron James', level: 2 })).toHaveCount(0);
+  await expect(
+    page.getByRole('article', { name: 'LeBron James player' }).getByRole('button'),
+  ).toBeFocused();
+
+  await page.goto('/matchups/0022500584?player=austin-reaves');
+  await expect(page.getByRole('heading', { name: 'Austin Reaves', level: 2 })).toBeVisible();
+  await expect(page.getByText('No games vs this opponent data is available.')).toBeVisible();
   await page.goto('/matchups/0022500584?player=lebron-james');
   await expect(page.getByRole('heading', { name: 'LeBron James', level: 2 })).toBeVisible();
   await page.setViewportSize({ width: 393, height: 852 });

--- a/e2e/specs/matchup-detail.spec.js
+++ b/e2e/specs/matchup-detail.spec.js
@@ -270,7 +270,12 @@ test('@critical selection card supports selection, deep links, and tab flips wit
 test('selection clamps on an in-app player switch and leaves the team toggle operative', async ({
   authenticatedPage: page,
 }, testInfo) => {
+  let selectionRequests = 0;
+  page.on('request', (request) => {
+    if (new URL(request.url()).pathname === '/api/games/matchup/selection') selectionRequests += 1;
+  });
   await page.goto('/matchups/0022500584');
+  await page.getByRole('group', { name: 'Market' }).getByRole('button', { name: 'PTS' }).click();
   await page
     .getByRole('article', { name: 'LeBron James player' })
     .getByRole('button', { name: 'Open selection card' })
@@ -279,6 +284,18 @@ test('selection clamps on an in-app player switch and leaves the team toggle ope
     .getByRole('group', { name: 'Selection log stat' })
     .getByRole('button', { name: 'PRA' })
     .click();
+  await expect(
+    page.getByRole('group', { name: 'Selection log stat' }).getByRole('button', { name: 'PRA' }),
+  ).toHaveAttribute('aria-pressed', 'true');
+  await expect(
+    page.getByRole('group', { name: 'Market' }).getByRole('button', { name: 'PTS' }),
+  ).toHaveAttribute('aria-pressed', 'true');
+  await expect(page.getByRole('columnheader', { name: 'PRA' }).first()).toBeVisible();
+  expect(selectionRequests).toBe(1);
+  await page.screenshot({
+    path: testInfo.outputPath('selection-sheet-pts-card-pra.png'),
+    fullPage: true,
+  });
   await page
     .getByRole('article', { name: 'Austin Reaves player' })
     .getByRole('button', { name: 'Open selection card' })

--- a/e2e/specs/matchup-detail.spec.js
+++ b/e2e/specs/matchup-detail.spec.js
@@ -266,3 +266,54 @@ test('@critical selection card supports selection, deep links, and tab flips wit
   expect(failedResponses).toEqual([]);
   await page.screenshot({ path: testInfo.outputPath('selection-card-narrow.png'), fullPage: true });
 });
+
+test('selection clamps on an in-app player switch and leaves the team toggle operative', async ({
+  authenticatedPage: page,
+}, testInfo) => {
+  await page.goto('/matchups/0022500584');
+  await page
+    .getByRole('article', { name: 'LeBron James player' })
+    .getByRole('button', { name: 'Open selection card' })
+    .click();
+  await page
+    .getByRole('group', { name: 'Selection log stat' })
+    .getByRole('button', { name: 'PRA' })
+    .click();
+  await page
+    .getByRole('article', { name: 'Austin Reaves player' })
+    .getByRole('button', { name: 'Open selection card' })
+    .click();
+  await expect(page.getByRole('heading', { name: 'Austin Reaves', level: 2 })).toBeVisible();
+  await expect(
+    page.getByRole('group', { name: 'Selection log stat' }).getByRole('button', { name: 'PTS' }),
+  ).toHaveAttribute('aria-pressed', 'true');
+  await page.getByRole('button', { name: 'LAL defense' }).click();
+  await expect(page.getByRole('button', { name: 'LAL defense' })).toHaveAttribute(
+    'aria-pressed',
+    'true',
+  );
+  await expect(page.getByText(/not opposing the viewed Defense Sheet/)).toBeVisible();
+  await page.screenshot({
+    path: testInfo.outputPath('selection-player-switch-team-toggle.png'),
+    fullPage: true,
+  });
+});
+
+test('selection request failure renders an honest handled error', async ({ page }, testInfo) => {
+  await page.addInitScript(() => localStorage.setItem('courtai:e2e-authenticated', 'true'));
+  await installApiContract(page, {
+    '/api/games/matchup/selection': {
+      status: 500,
+      body: { error: { code: 'provider_unavailable' } },
+    },
+  });
+  const failedResponses = [];
+  page.on('response', (response) => {
+    if (response.status() >= 400) failedResponses.push(`${response.status()} ${response.url()}`);
+  });
+  await page.goto('/matchups/0022500584?player=lebron-james');
+  await expect(page.getByRole('alert')).toContainText('Unable to load selection logs');
+  await expect(page.getByText('Loading selection logs…')).toHaveCount(0);
+  expect(failedResponses).toHaveLength(1);
+  await page.screenshot({ path: testInfo.outputPath('selection-error.png'), fullPage: true });
+});

--- a/e2e/specs/matchup-detail.spec.js
+++ b/e2e/specs/matchup-detail.spec.js
@@ -184,3 +184,50 @@ test('matchup freshness ages cross named bars without refetching', async ({ page
   await expect(freshness.getByText(/schedule: stale.*schedule data warning/i)).toBeVisible();
   expect(matchupRequests).toBe(1);
 });
+
+test('@critical selection card supports selection, deep links, and tab flips without refetching', async ({
+  authenticatedPage: page,
+}, testInfo) => {
+  await page.clock.setFixedTime(new Date('2026-01-15T12:00:00Z'));
+  let selectionRequests = 0;
+  const consoleErrors = [];
+  const failedResponses = [];
+  page.on('console', (message) => {
+    if (message.type() === 'error') consoleErrors.push(message.text());
+  });
+  page.on('response', (response) => {
+    if (response.status() >= 400) failedResponses.push(`${response.status()} ${response.url()}`);
+  });
+  page.on('request', (request) => {
+    if (new URL(request.url()).pathname === '/api/games/matchup/selection') selectionRequests += 1;
+  });
+  await page.goto('/matchups/0022500584');
+  await page
+    .getByRole('article', { name: 'LeBron James player' })
+    .getByRole('button', { name: 'Open selection card' })
+    .click();
+  await expect(page).toHaveURL(/player=lebron-james/);
+  await expect(page.getByRole('heading', { name: 'LeBron James', level: 2 })).toBeVisible();
+  const matrix = page.getByRole('table', { name: 'LeBron James Score Matrix' });
+  await expect(matrix).toContainText('+12%');
+  await expect(matrix).toContainText('thin');
+  await expect(page.getByText('Thin sample — interpret cautiously.')).toBeVisible();
+  await expect(page.getByRole('rowheader', { name: 'AVG' }).first()).toBeVisible();
+  await page.getByRole('button', { name: 'AST', exact: true }).click();
+  await expect(page.getByRole('columnheader', { name: 'AST' }).first()).toBeVisible();
+  expect(selectionRequests).toBe(1);
+  await page.screenshot({
+    path: testInfo.outputPath('selection-card-desktop.png'),
+    fullPage: true,
+  });
+
+  await page.goto('/matchups/0022500584?player=lebron-james');
+  await expect(page.getByRole('heading', { name: 'LeBron James', level: 2 })).toBeVisible();
+  await page.setViewportSize({ width: 393, height: 852 });
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(
+    true,
+  );
+  expect(consoleErrors).toEqual([]);
+  expect(failedResponses).toEqual([]);
+  await page.screenshot({ path: testInfo.outputPath('selection-card-narrow.png'), fullPage: true });
+});

--- a/src/config.js
+++ b/src/config.js
@@ -15,6 +15,7 @@ const config = {
     GAME_LOGS: '/api/games/game_logs',
     SLATE: '/api/games/slate',
     MATCHUP: '/api/games/matchup',
+    MATCHUP_SELECTION: '/api/games/matchup/selection',
     PLAYER_PROFILE: '/api/players/profile',
     TEAM_STATS: '/api/teams/stats',
     NL_QUERY: '/api/nl-query',

--- a/src/matchups/MatchupDetailPage.css
+++ b/src/matchups/MatchupDetailPage.css
@@ -120,6 +120,10 @@
   padding: 14px;
   background: var(--ct-surface-2);
 }
+.sheet-row.selection-why {
+  border-color: var(--ct-gold);
+  box-shadow: inset 3px 0 var(--ct-gold);
+}
 .row-stat {
   display: flex;
   justify-content: space-between;
@@ -238,6 +242,79 @@
 .injury-list p {
   margin: 0;
 }
+.player-card.selected {
+  border-color: var(--ct-gold);
+}
+.select-player,
+.selection-card-heading button {
+  margin-top: 10px;
+  border: 1px solid var(--ct-line-strong);
+  border-radius: 999px;
+  padding: 7px 10px;
+  background: transparent;
+  color: var(--ct-text);
+}
+.selection-card {
+  margin-top: 18px;
+  border: 1px solid var(--ct-gold);
+  border-radius: var(--ct-radius-card);
+  padding: 20px;
+  background: var(--ct-surface);
+}
+.selection-card-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: start;
+}
+.selection-card-heading h2 {
+  margin: 0;
+}
+.selection-explainer,
+.thin-note {
+  color: var(--ct-dim);
+  font-size: 0.82rem;
+}
+.selection-table-wrap {
+  overflow-x: auto;
+}
+.selection-table-wrap table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 560px;
+}
+.selection-table-wrap th,
+.selection-table-wrap td {
+  border-bottom: 1px solid var(--ct-line);
+  padding: 10px;
+  text-align: right;
+  white-space: nowrap;
+}
+.selection-table-wrap th:first-child {
+  text-align: left;
+}
+.selection-table-wrap .active-market-row {
+  background: color-mix(in srgb, var(--ct-gold) 12%, transparent);
+}
+.thin-flag {
+  display: block;
+  color: var(--ct-gold);
+  font-family: var(--ct-mono);
+  font-size: 0.62rem;
+  text-transform: uppercase;
+}
+.selection-logs {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  margin-top: 22px;
+}
+.selection-log {
+  min-width: 0;
+}
+.average-row {
+  font-weight: 700;
+}
 .player-card p {
   color: var(--ct-dim);
   font-size: 0.75rem;
@@ -290,6 +367,9 @@
   }
 
   .defensive-column-grid {
+    grid-template-columns: 1fr;
+  }
+  .selection-logs {
     grid-template-columns: 1fr;
   }
   .row-stat {

--- a/src/matchups/MatchupDetailPage.css
+++ b/src/matchups/MatchupDetailPage.css
@@ -246,12 +246,29 @@
   border-color: var(--ct-gold);
 }
 .select-player,
-.selection-card-heading button {
+.selection-close {
   margin-top: 10px;
   border: 1px solid var(--ct-line-strong);
   border-radius: 999px;
   padding: 7px 10px;
   background: transparent;
+  color: var(--ct-text);
+}
+.selection-stat-control {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 14px 0;
+}
+.selection-stat-control button {
+  border: 1px solid var(--ct-line-strong);
+  border-radius: 999px;
+  padding: 6px 9px;
+  background: transparent;
+  color: var(--ct-dim);
+}
+.selection-stat-control button[aria-pressed='true'] {
+  border-color: var(--ct-gold);
   color: var(--ct-text);
 }
 .selection-card {

--- a/src/matchups/MatchupDetailPage.js
+++ b/src/matchups/MatchupDetailPage.js
@@ -1,10 +1,10 @@
-import { useEffect, useMemo, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Link, useParams, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { getRequestErrorMessage, isRequestCancelled } from '../gameLogsApi';
 import { formatAge, useMinuteNow } from '../freshness';
 import { getSurfaceFreshnessPresentation } from '../slateStatus';
-import { fetchMatchup } from './matchupApi';
+import { fetchMatchup, fetchMatchupSelection } from './matchupApi';
 import { shouldDisplayDietShare } from './displayConfig';
 import './MatchupDetailPage.css';
 
@@ -90,7 +90,15 @@ function Sparkline({ values, playerName }) {
   );
 }
 
-function PlayerRail({ players, injuries, market, windowKey, targetableCount }) {
+function PlayerRail({
+  players,
+  injuries,
+  market,
+  windowKey,
+  targetableCount,
+  selectedId,
+  onSelect,
+}) {
   const [sortMode, setSortMode] = useState('season');
   useEffect(() => {
     if (market === 'All') setSortMode('season');
@@ -144,7 +152,11 @@ function PlayerRail({ players, injuries, market, windowKey, targetableCount }) {
           {scoped.map((player) => {
             const injury = injuryById.get(player.injuryBadgeRef);
             return (
-              <article key={player.id} aria-label={`${player.name} player`} className="player-card">
+              <article
+                key={player.id}
+                aria-label={`${player.name} player`}
+                className={`player-card${selectedId === player.id ? ' selected' : ''}`}
+              >
                 <div>
                   <h3>{player.name}</h3>
                   <p>{player.seasonScoring.toFixed(1)} PPG</p>
@@ -162,6 +174,9 @@ function PlayerRail({ players, injuries, market, windowKey, targetableCount }) {
                   ))}
                 </div>
                 <Sparkline values={player.last10Minutes} playerName={player.name} />
+                <button type="button" className="select-player" onClick={() => onSelect(player)}>
+                  {selectedId === player.id ? 'Selected' : 'Open selection card'}
+                </button>
               </article>
             );
           })}
@@ -193,7 +208,7 @@ function DietShareChips({ players, base, rowKey, windowKey, market }) {
   );
 }
 
-function DefenseSheet({ team, players, market, windowKey, deviation }) {
+function DefenseSheet({ team, players, market, windowKey, deviation, selectedPlayer }) {
   let hidden = 0;
   const sections = Object.entries(team.defenseSheet).map(([base, rows]) => {
     const marketRows = rows.filter((row) => market === 'All' || row.markets.includes(market));
@@ -226,7 +241,14 @@ function DefenseSheet({ team, players, market, windowKey, deviation }) {
               {visibleRows.map((row) => {
                 const stat = row[windowKey];
                 return (
-                  <article className="sheet-row" key={`${base}-${row.key}`}>
+                  <article
+                    className={`sheet-row${
+                      selectedPlayer?.dietShares[base]?.some((entry) => entry.key === row.key)
+                        ? ' selection-why'
+                        : ''
+                    }`}
+                    key={`${base}-${row.key}`}
+                  >
                     <div className="row-stat">
                       <div>
                         <h4>{row.label}</h4>
@@ -261,6 +283,146 @@ function DefenseSheet({ team, players, market, windowKey, deviation }) {
             </div>
           </section>
         ) : null,
+      )}
+    </section>
+  );
+}
+
+const SCORE_BASE_LABELS = {
+  playTypes: 'Play types',
+  shotZones: 'Shot zones',
+  shotTypes: 'Shot types',
+  assistLocations: 'Assist locations',
+  traditional: 'Traditional',
+};
+const formatPercent = (value) => `${value >= 0 ? '+' : ''}${Math.round(value * 100)}%`;
+
+function LogTable({ title, table, market }) {
+  return (
+    <section className="selection-log" aria-labelledby={`${title.replaceAll(' ', '-')}-heading`}>
+      <h3 id={`${title.replaceAll(' ', '-')}-heading`}>{title}</h3>
+      {table.status === 'thin' && <p className="thin-note">Thin sample — interpret cautiously.</p>}
+      {table.status === 'empty' ? (
+        <p className="honest-empty">No {title.toLowerCase()} data is available.</p>
+      ) : (
+        <div className="selection-table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Game</th>
+                <th scope="col">MIN</th>
+                <th scope="col">{market}</th>
+                <th scope="col">±STAT/MIN</th>
+              </tr>
+            </thead>
+            <tbody>
+              {[...table.rows, ...(table.average ? [table.average] : [])].map((row, index) => (
+                <tr
+                  key={row.date || `average-${index}`}
+                  className={row.matchup === 'AVG' ? 'average-row' : undefined}
+                >
+                  <th scope="row">
+                    {row.matchup === 'AVG' ? 'AVG' : `${row.date} · ${row.matchup}`}
+                  </th>
+                  <td>{row.minutes.toFixed(1)}</td>
+                  <td>{row.stats[market].toFixed(1)}</td>
+                  <td>
+                    {row.deltas[market] >= 0 ? '+' : ''}
+                    {row.deltas[market].toFixed(3)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function SelectionCard({ player, selection, status, error, windowKey, market, onClose }) {
+  const panelRef = useRef(null);
+  useEffect(() => panelRef.current?.focus(), [player.id]);
+  const rows = player.postedMarkets.map((postedMarket) => ({
+    market: postedMarket,
+    score: player.scores[postedMarket][windowKey],
+  }));
+  const bases = [...new Set(rows.flatMap(({ score }) => Object.keys(score.components)))];
+  const defensiveMarkets = new Set(['TOV', 'STL', 'BLK', 'STKS']);
+  return (
+    <section
+      ref={panelRef}
+      className="selection-card"
+      aria-labelledby="selection-heading"
+      tabIndex="-1"
+    >
+      <div className="selection-card-heading">
+        <div>
+          <p className="matchup-eyebrow">Selection card</p>
+          <h2 id="selection-heading">{player.name}</h2>
+        </div>
+        <button type="button" onClick={onClose}>
+          Close selection card
+        </button>
+      </div>
+      <p className="selection-explainer">
+        Highlighted Defense Sheet rows show the inputs this player leans on. Scores and deltas are
+        delivered by the API.
+      </p>
+      <div className="selection-table-wrap">
+        <table aria-label={`${player.name} Score Matrix`}>
+          <thead>
+            <tr>
+              <th scope="col">Market</th>
+              {bases.map((base) => (
+                <th scope="col" key={base}>
+                  {SCORE_BASE_LABELS[base] || base}
+                </th>
+              ))}
+              <th scope="col">Blend</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(({ market: rowMarket, score }) => (
+              <tr
+                key={rowMarket}
+                className={rowMarket === market ? 'active-market-row' : undefined}
+              >
+                <th scope="row">{rowMarket}</th>
+                {bases.map((base) => (
+                  <td key={base}>
+                    {score.components[base] ? (
+                      <>
+                        {formatPercent(score.components[base].value)}
+                        {score.components[base].thin && <span className="thin-flag">thin</span>}
+                      </>
+                    ) : (
+                      '—'
+                    )}
+                  </td>
+                ))}
+                <td>
+                  {defensiveMarkets.has(rowMarket) ? (
+                    '—'
+                  ) : (
+                    <>
+                      {formatPercent(score.blend.value)}
+                      {score.blend.thin && <span className="thin-flag">thin</span>}
+                    </>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {status === 'loading' && <p role="status">Loading selection logs…</p>}
+      {status === 'error' && <p role="alert">{error}</p>}
+      {status === 'ready' && (
+        <div className="selection-logs">
+          <LogTable title="Games vs this opponent" table={selection.h2h} market={market} />
+          <LogTable title="Archetype sample" table={selection.archetype} market={market} />
+        </div>
       )}
     </section>
   );
@@ -350,7 +512,8 @@ function InjuryReport({ injuries, now }) {
   );
 }
 
-function Detail({ matchup }) {
+function Detail({ matchup, gameId }) {
+  const [searchParams, setSearchParams] = useSearchParams();
   const now = useMinuteNow(true);
   const homeTricode = matchup.game.home.tricode;
   const initialTeam =
@@ -359,6 +522,9 @@ function Detail({ matchup }) {
   const [market, setMarket] = useState('All');
   const [windowKey, setWindowKey] = useState('season');
   const [deviation, setDeviation] = useState(1);
+  const selectedId = searchParams.get('player');
+  const selectedPlayer = matchup.players.find((player) => player.id === selectedId) || null;
+  const [selectionState, setSelectionState] = useState({ status: 'idle', data: null, error: null });
   const defenseTeam = matchup.teams.find((team) => team.teamId === teamId) || initialTeam;
   const opposingTeam = matchup.teams.find((team) => team.teamId !== defenseTeam.teamId);
   const opposingTeamId = opposingTeam?.teamId;
@@ -378,6 +544,35 @@ function Detail({ matchup }) {
   useEffect(() => {
     if (!markets.includes(market)) setMarket('All');
   }, [market, markets]);
+  useEffect(() => {
+    if (!selectedPlayer) {
+      setSelectionState({ status: 'idle', data: null, error: null });
+      return undefined;
+    }
+    const selectedDefense = matchup.teams.find((team) => team.teamId !== selectedPlayer.teamId);
+    if (selectedDefense) setTeamId(selectedDefense.teamId);
+    const controller = new AbortController();
+    setSelectionState({ status: 'loading', data: null, error: null });
+    fetchMatchupSelection(gameId, selectedPlayer.id, selectedPlayer.postedMarkets, {
+      signal: controller.signal,
+    })
+      .then((data) => setSelectionState({ status: 'ready', data, error: null }))
+      .catch((error) => {
+        if (!isRequestCancelled(error))
+          setSelectionState({
+            status: 'error',
+            data: null,
+            error: getRequestErrorMessage(error, 'Unable to load selection logs.'),
+          });
+      });
+    return () => controller.abort();
+  }, [gameId, matchup.teams, selectedPlayer]);
+  useEffect(() => {
+    if (selectedPlayer && (market === 'All' || !selectedPlayer.postedMarkets.includes(market))) {
+      setMarket(selectedPlayer.postedMarkets[0]);
+    }
+  }, [market, selectedPlayer]); // Market and window flips deliberately do not refetch.
+  const selectPlayer = (player) => setSearchParams({ player: player.id });
   return (
     <>
       <header className="matchup-heading">
@@ -453,6 +648,7 @@ function Detail({ matchup }) {
             market={market}
             windowKey={windowKey}
             deviation={deviation}
+            selectedPlayer={selectedPlayer}
           />
         )}
         <PlayerRail
@@ -461,8 +657,26 @@ function Detail({ matchup }) {
           market={market}
           windowKey={windowKey}
           targetableCount={poolAvailable ? (opposingGameTeam?.targetablePlayerCount ?? null) : null}
+          selectedId={selectedId}
+          onSelect={selectPlayer}
         />
       </div>
+      {selectedId && !selectedPlayer && (
+        <p role="alert" className="selection-card">
+          That player is not available in this matchup.
+        </p>
+      )}
+      {selectedPlayer && market !== 'All' && (
+        <SelectionCard
+          player={selectedPlayer}
+          selection={selectionState.data}
+          status={selectionState.status}
+          error={selectionState.error}
+          windowKey={windowKey}
+          market={market}
+          onClose={() => setSearchParams({})}
+        />
+      )}
       <InjuryReport injuries={matchup.injuries} now={now} />
     </>
   );
@@ -504,7 +718,7 @@ export default function MatchupDetailPage() {
     <main className="matchup-page">
       {state.status === 'loading' && <p role="status">Loading matchup…</p>}
       {state.status === 'error' && <p role="alert">{state.error}</p>}
-      {state.status === 'ready' && <Detail matchup={state.matchup} />}
+      {state.status === 'ready' && <Detail matchup={state.matchup} gameId={gameId} />}
     </main>
   );
 }

--- a/src/matchups/MatchupDetailPage.js
+++ b/src/matchups/MatchupDetailPage.js
@@ -5,7 +5,8 @@ import { getRequestErrorMessage, isRequestCancelled } from '../gameLogsApi';
 import { formatAge, useMinuteNow } from '../freshness';
 import { getSurfaceFreshnessPresentation } from '../slateStatus';
 import { fetchMatchup, fetchMatchupSelection } from './matchupApi';
-import { shouldDisplayDietShare } from './displayConfig';
+import { getDisplayableDietShare } from './displayConfig';
+import SelectionCard from './SelectionCard';
 import './MatchupDetailPage.css';
 
 const WINDOWS = [
@@ -98,6 +99,7 @@ function PlayerRail({
   targetableCount,
   selectedId,
   onSelect,
+  registerTrigger,
 }) {
   const [sortMode, setSortMode] = useState('season');
   useEffect(() => {
@@ -106,7 +108,11 @@ function PlayerRail({
   const injuryById = new Map(
     injuries.teams.flatMap((team) => team.entries).map((entry) => [entry.id, entry]),
   );
-  const scoreFor = (player) => player.scores[market]?.[windowKey].blend.value ?? -Infinity;
+  const scoreFor = (player) => {
+    const score = player.scores[market]?.[windowKey];
+    if (!score) return -Infinity;
+    return score.blend?.value ?? Object.values(score.components)[0]?.value ?? -Infinity;
+  };
   const scoped = players.filter(
     (player) => market === 'All' || player.postedMarkets.includes(market),
   );
@@ -174,7 +180,14 @@ function PlayerRail({
                   ))}
                 </div>
                 <Sparkline values={player.last10Minutes} playerName={player.name} />
-                <button type="button" className="select-player" onClick={() => onSelect(player)}>
+                <button
+                  ref={(node) => registerTrigger(player.id, node)}
+                  type="button"
+                  className="select-player"
+                  aria-expanded={selectedId === player.id}
+                  aria-controls="matchup-selection-card"
+                  onClick={() => onSelect(player)}
+                >
                   {selectedId === player.id ? 'Selected' : 'Open selection card'}
                 </button>
               </article>
@@ -191,8 +204,8 @@ function DietShareChips({ players, base, rowKey, windowKey, market }) {
   const chips = players
     .filter((player) => market === 'All' || player.postedMarkets.includes(market))
     .flatMap((player) => {
-      const share = player.dietShares[base]?.find((entry) => entry.key === rowKey)?.[windowKey];
-      if (!share || !shouldDisplayDietShare(base, share)) return [];
+      const share = getDisplayableDietShare(player, base, rowKey, windowKey);
+      if (!share) return [];
       return [{ player, share }];
     });
   if (chips.length === 0)
@@ -243,7 +256,8 @@ function DefenseSheet({ team, players, market, windowKey, deviation, selectedPla
                 return (
                   <article
                     className={`sheet-row${
-                      selectedPlayer?.dietShares[base]?.some((entry) => entry.key === row.key)
+                      selectedPlayer &&
+                      getDisplayableDietShare(selectedPlayer, base, row.key, windowKey)
                         ? ' selection-why'
                         : ''
                     }`}
@@ -283,146 +297,6 @@ function DefenseSheet({ team, players, market, windowKey, deviation, selectedPla
             </div>
           </section>
         ) : null,
-      )}
-    </section>
-  );
-}
-
-const SCORE_BASE_LABELS = {
-  playTypes: 'Play types',
-  shotZones: 'Shot zones',
-  shotTypes: 'Shot types',
-  assistLocations: 'Assist locations',
-  traditional: 'Traditional',
-};
-const formatPercent = (value) => `${value >= 0 ? '+' : ''}${Math.round(value * 100)}%`;
-
-function LogTable({ title, table, market }) {
-  return (
-    <section className="selection-log" aria-labelledby={`${title.replaceAll(' ', '-')}-heading`}>
-      <h3 id={`${title.replaceAll(' ', '-')}-heading`}>{title}</h3>
-      {table.status === 'thin' && <p className="thin-note">Thin sample — interpret cautiously.</p>}
-      {table.status === 'empty' ? (
-        <p className="honest-empty">No {title.toLowerCase()} data is available.</p>
-      ) : (
-        <div className="selection-table-wrap">
-          <table>
-            <thead>
-              <tr>
-                <th scope="col">Game</th>
-                <th scope="col">MIN</th>
-                <th scope="col">{market}</th>
-                <th scope="col">±STAT/MIN</th>
-              </tr>
-            </thead>
-            <tbody>
-              {[...table.rows, ...(table.average ? [table.average] : [])].map((row, index) => (
-                <tr
-                  key={row.date || `average-${index}`}
-                  className={row.matchup === 'AVG' ? 'average-row' : undefined}
-                >
-                  <th scope="row">
-                    {row.matchup === 'AVG' ? 'AVG' : `${row.date} · ${row.matchup}`}
-                  </th>
-                  <td>{row.minutes.toFixed(1)}</td>
-                  <td>{row.stats[market].toFixed(1)}</td>
-                  <td>
-                    {row.deltas[market] >= 0 ? '+' : ''}
-                    {row.deltas[market].toFixed(3)}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-    </section>
-  );
-}
-
-function SelectionCard({ player, selection, status, error, windowKey, market, onClose }) {
-  const panelRef = useRef(null);
-  useEffect(() => panelRef.current?.focus(), [player.id]);
-  const rows = player.postedMarkets.map((postedMarket) => ({
-    market: postedMarket,
-    score: player.scores[postedMarket][windowKey],
-  }));
-  const bases = [...new Set(rows.flatMap(({ score }) => Object.keys(score.components)))];
-  const defensiveMarkets = new Set(['TOV', 'STL', 'BLK', 'STKS']);
-  return (
-    <section
-      ref={panelRef}
-      className="selection-card"
-      aria-labelledby="selection-heading"
-      tabIndex="-1"
-    >
-      <div className="selection-card-heading">
-        <div>
-          <p className="matchup-eyebrow">Selection card</p>
-          <h2 id="selection-heading">{player.name}</h2>
-        </div>
-        <button type="button" onClick={onClose}>
-          Close selection card
-        </button>
-      </div>
-      <p className="selection-explainer">
-        Highlighted Defense Sheet rows show the inputs this player leans on. Scores and deltas are
-        delivered by the API.
-      </p>
-      <div className="selection-table-wrap">
-        <table aria-label={`${player.name} Score Matrix`}>
-          <thead>
-            <tr>
-              <th scope="col">Market</th>
-              {bases.map((base) => (
-                <th scope="col" key={base}>
-                  {SCORE_BASE_LABELS[base] || base}
-                </th>
-              ))}
-              <th scope="col">Blend</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map(({ market: rowMarket, score }) => (
-              <tr
-                key={rowMarket}
-                className={rowMarket === market ? 'active-market-row' : undefined}
-              >
-                <th scope="row">{rowMarket}</th>
-                {bases.map((base) => (
-                  <td key={base}>
-                    {score.components[base] ? (
-                      <>
-                        {formatPercent(score.components[base].value)}
-                        {score.components[base].thin && <span className="thin-flag">thin</span>}
-                      </>
-                    ) : (
-                      '—'
-                    )}
-                  </td>
-                ))}
-                <td>
-                  {defensiveMarkets.has(rowMarket) ? (
-                    '—'
-                  ) : (
-                    <>
-                      {formatPercent(score.blend.value)}
-                      {score.blend.thin && <span className="thin-flag">thin</span>}
-                    </>
-                  )}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-      {status === 'loading' && <p role="status">Loading selection logs…</p>}
-      {status === 'error' && <p role="alert">{error}</p>}
-      {status === 'ready' && (
-        <div className="selection-logs">
-          <LogTable title="Games vs this opponent" table={selection.h2h} market={market} />
-          <LogTable title="Archetype sample" table={selection.archetype} market={market} />
-        </div>
       )}
     </section>
   );
@@ -524,6 +398,8 @@ function Detail({ matchup, gameId }) {
   const [deviation, setDeviation] = useState(1);
   const selectedId = searchParams.get('player');
   const selectedPlayer = matchup.players.find((player) => player.id === selectedId) || null;
+  const selectionTriggers = useRef(new Map());
+  const previousSelectedId = useRef(null);
   const [selectionState, setSelectionState] = useState({ status: 'idle', data: null, error: null });
   const defenseTeam = matchup.teams.find((team) => team.teamId === teamId) || initialTeam;
   const opposingTeam = matchup.teams.find((team) => team.teamId !== defenseTeam.teamId);
@@ -549,30 +425,50 @@ function Detail({ matchup, gameId }) {
       setSelectionState({ status: 'idle', data: null, error: null });
       return undefined;
     }
-    const selectedDefense = matchup.teams.find((team) => team.teamId !== selectedPlayer.teamId);
-    if (selectedDefense) setTeamId(selectedDefense.teamId);
     const controller = new AbortController();
+    let current = true;
     setSelectionState({ status: 'loading', data: null, error: null });
     fetchMatchupSelection(gameId, selectedPlayer.id, selectedPlayer.postedMarkets, {
       signal: controller.signal,
     })
-      .then((data) => setSelectionState({ status: 'ready', data, error: null }))
+      .then((data) => {
+        if (current) setSelectionState({ status: 'ready', data, error: null });
+      })
       .catch((error) => {
-        if (!isRequestCancelled(error))
+        if (current && !isRequestCancelled(error))
           setSelectionState({
             status: 'error',
             data: null,
             error: getRequestErrorMessage(error, 'Unable to load selection logs.'),
           });
       });
-    return () => controller.abort();
-  }, [gameId, matchup.teams, selectedPlayer]);
+    return () => {
+      current = false;
+      controller.abort();
+    };
+  }, [gameId, selectedPlayer]);
   useEffect(() => {
-    if (selectedPlayer && (market === 'All' || !selectedPlayer.postedMarkets.includes(market))) {
-      setMarket(selectedPlayer.postedMarkets[0]);
+    if (!selectedPlayer) return;
+    const selectedDefense = matchup.teams.find((team) => team.teamId !== selectedPlayer.teamId);
+    if (selectedDefense && selectedDefense.teamId !== teamId) setTeamId(selectedDefense.teamId);
+  }, [matchup.teams, selectedPlayer, teamId]);
+  useEffect(() => {
+    if (previousSelectedId.current && !selectedId) {
+      selectionTriggers.current.get(previousSelectedId.current)?.focus();
     }
-  }, [market, selectedPlayer]); // Market and window flips deliberately do not refetch.
-  const selectPlayer = (player) => setSearchParams({ player: player.id });
+    previousSelectedId.current = selectedId;
+  }, [selectedId]);
+  const updateSelectedPlayer = (playerId) => {
+    if (playerId === selectedId) return;
+    const next = new URLSearchParams(searchParams);
+    if (playerId) next.set('player', playerId);
+    else next.delete('player');
+    setSearchParams(next, { replace: false });
+  };
+  const registerTrigger = (playerId, node) => {
+    if (node) selectionTriggers.current.set(playerId, node);
+    else selectionTriggers.current.delete(playerId);
+  };
   return (
     <>
       <header className="matchup-heading">
@@ -658,7 +554,8 @@ function Detail({ matchup, gameId }) {
           windowKey={windowKey}
           targetableCount={poolAvailable ? (opposingGameTeam?.targetablePlayerCount ?? null) : null}
           selectedId={selectedId}
-          onSelect={selectPlayer}
+          onSelect={(player) => updateSelectedPlayer(player.id)}
+          registerTrigger={registerTrigger}
         />
       </div>
       {selectedId && !selectedPlayer && (
@@ -666,15 +563,19 @@ function Detail({ matchup, gameId }) {
           That player is not available in this matchup.
         </p>
       )}
-      {selectedPlayer && market !== 'All' && (
+      {selectedPlayer && (
         <SelectionCard
           player={selectedPlayer}
-          selection={selectionState.data}
-          status={selectionState.status}
+          selection={
+            selectionState.data?.playerId === selectedPlayer.id ? selectionState.data : null
+          }
+          status={
+            selectionState.data?.playerId === selectedPlayer.id ? selectionState.status : 'loading'
+          }
           error={selectionState.error}
           windowKey={windowKey}
-          market={market}
-          onClose={() => setSearchParams({})}
+          sheetMarket={market}
+          onClose={() => updateSelectedPlayer(null)}
         />
       )}
       <InjuryReport injuries={matchup.injuries} now={now} />

--- a/src/matchups/MatchupDetailPage.js
+++ b/src/matchups/MatchupDetailPage.js
@@ -400,7 +400,12 @@ function Detail({ matchup, gameId }) {
   const selectedPlayer = matchup.players.find((player) => player.id === selectedId) || null;
   const selectionTriggers = useRef(new Map());
   const previousSelectedId = useRef(null);
-  const [selectionState, setSelectionState] = useState({ status: 'idle', data: null, error: null });
+  const [selectionState, setSelectionState] = useState({
+    status: 'idle',
+    playerId: null,
+    data: null,
+    error: null,
+  });
   const defenseTeam = matchup.teams.find((team) => team.teamId === teamId) || initialTeam;
   const opposingTeam = matchup.teams.find((team) => team.teamId !== defenseTeam.teamId);
   const opposingTeamId = opposingTeam?.teamId;
@@ -422,24 +427,26 @@ function Detail({ matchup, gameId }) {
   }, [market, markets]);
   useEffect(() => {
     if (!selectedPlayer) {
-      setSelectionState({ status: 'idle', data: null, error: null });
+      setSelectionState({ status: 'idle', playerId: null, data: null, error: null });
       return undefined;
     }
     const controller = new AbortController();
     let current = true;
-    setSelectionState({ status: 'loading', data: null, error: null });
+    setSelectionState({ status: 'loading', playerId: selectedPlayer.id, data: null, error: null });
     fetchMatchupSelection(gameId, selectedPlayer.id, selectedPlayer.postedMarkets, {
       signal: controller.signal,
     })
       .then((data) => {
-        if (current) setSelectionState({ status: 'ready', data, error: null });
+        if (current)
+          setSelectionState({ status: 'ready', playerId: selectedPlayer.id, data, error: null });
       })
       .catch((error) => {
         if (current && !isRequestCancelled(error))
           setSelectionState({
             status: 'error',
+            playerId: selectedPlayer.id,
             data: null,
-            error: getRequestErrorMessage(error, 'Unable to load selection logs.'),
+            error: `Unable to load selection logs. ${getRequestErrorMessage(error, 'Please try again.')}`,
           });
       });
     return () => {
@@ -447,11 +454,6 @@ function Detail({ matchup, gameId }) {
       controller.abort();
     };
   }, [gameId, selectedPlayer]);
-  useEffect(() => {
-    if (!selectedPlayer) return;
-    const selectedDefense = matchup.teams.find((team) => team.teamId !== selectedPlayer.teamId);
-    if (selectedDefense && selectedDefense.teamId !== teamId) setTeamId(selectedDefense.teamId);
-  }, [matchup.teams, selectedPlayer, teamId]);
   useEffect(() => {
     if (previousSelectedId.current && !selectedId) {
       selectionTriggers.current.get(previousSelectedId.current)?.focus();
@@ -544,7 +546,7 @@ function Detail({ matchup, gameId }) {
             market={market}
             windowKey={windowKey}
             deviation={deviation}
-            selectedPlayer={selectedPlayer}
+            selectedPlayer={selectedPlayer?.teamId !== defenseTeam.teamId ? selectedPlayer : null}
           />
         )}
         <PlayerRail
@@ -566,15 +568,12 @@ function Detail({ matchup, gameId }) {
       {selectedPlayer && (
         <SelectionCard
           player={selectedPlayer}
-          selection={
-            selectionState.data?.playerId === selectedPlayer.id ? selectionState.data : null
-          }
-          status={
-            selectionState.data?.playerId === selectedPlayer.id ? selectionState.status : 'loading'
-          }
+          selection={selectionState.playerId === selectedPlayer.id ? selectionState.data : null}
+          status={selectionState.playerId === selectedPlayer.id ? selectionState.status : 'loading'}
           error={selectionState.error}
           windowKey={windowKey}
           sheetMarket={market}
+          whyRelevant={selectedPlayer.teamId !== defenseTeam.teamId}
           onClose={() => updateSelectedPlayer(null)}
         />
       )}

--- a/src/matchups/MatchupDetailPage.test.js
+++ b/src/matchups/MatchupDetailPage.test.js
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
@@ -164,12 +164,13 @@ const matchup = {
 };
 
 beforeEach(() => {
+  jest.clearAllMocks();
   useAuth.mockReturnValue({ isAuthenticated: true, loading: false });
   fetchMatchup.mockResolvedValue(matchup);
   fetchMatchupSelection.mockResolvedValue({
     playerId: 'player-one',
     h2h: {
-      status: 'ready',
+      thin: true,
       rows: [
         {
           date: '2025-12-25',
@@ -177,17 +178,19 @@ beforeEach(() => {
           minutes: 36,
           stats: { PTS: 31, FGA: 19 },
           deltas: { PTS: 0.083, FGA: 0.018 },
+          average: false,
+        },
+        {
+          date: null,
+          matchup: 'AVG',
+          minutes: 36,
+          stats: { PTS: 31, FGA: 19 },
+          deltas: { PTS: 0.083, FGA: 0.018 },
+          average: true,
         },
       ],
-      average: {
-        date: null,
-        matchup: 'AVG',
-        minutes: 36,
-        stats: { PTS: 31, FGA: 19 },
-        deltas: { PTS: 0.083, FGA: 0.018 },
-      },
     },
-    archetype: { status: 'empty', rows: [], average: null },
+    archetype: { thin: false, rows: [] },
   });
 });
 
@@ -228,6 +231,67 @@ test('toggles delivered windows and applies a two-sided sigma filter without ref
   await userEvent.click(screen.getByRole('button', { name: 'All deviations' }));
   expect(screen.getByText('Isolation')).toBeVisible();
   expect(fetchMatchup).toHaveBeenCalledTimes(1);
+});
+
+test('selection keeps All active and highlights only display-eligible shares for each window', async () => {
+  const candidate = JSON.parse(JSON.stringify(matchup));
+  candidate.players.find((player) => player.id === 'player-one').dietShares.playTypes[0].season = {
+    share: 0.02,
+    volumePerGame: 5,
+  };
+  fetchMatchup.mockResolvedValueOnce(candidate);
+  render(
+    <MemoryRouter initialEntries={['/matchups/game-1?player=player-one']}>
+      <Routes>
+        <Route path="/matchups/:gameId" element={<MatchupDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+  await screen.findByRole('heading', { name: 'LeBron James', level: 2 });
+  expect(screen.getByRole('button', { name: 'All', exact: true })).toHaveAttribute(
+    'aria-pressed',
+    'true',
+  );
+  expect(screen.getByText('Transition').closest('article')).not.toHaveClass('selection-why');
+  await userEvent.click(screen.getByRole('button', { name: 'Last 15' }));
+  expect(screen.getByText('Transition').closest('article')).toHaveClass('selection-why');
+});
+
+test('a late selection response cannot replace a newer player selection', async () => {
+  let resolveFirst;
+  const first = new Promise((resolve) => {
+    resolveFirst = resolve;
+  });
+  const austin = {
+    playerId: 'player-two',
+    h2h: { thin: false, rows: [] },
+    archetype: { thin: false, rows: [] },
+  };
+  fetchMatchupSelection.mockImplementation((_gameId, playerId) =>
+    playerId === 'player-one' ? first : Promise.resolve(austin),
+  );
+  render(
+    <MemoryRouter initialEntries={['/matchups/game-1?player=player-one']}>
+      <Routes>
+        <Route path="/matchups/:gameId" element={<MatchupDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+  await screen.findByRole('heading', { name: 'LeBron James', level: 2 });
+  await userEvent.click(
+    within(screen.getByRole('article', { name: 'Austin Reaves player' })).getByRole('button', {
+      name: 'Open selection card',
+    }),
+  );
+  expect(await screen.findByRole('heading', { name: 'Austin Reaves', level: 2 })).toBeVisible();
+  resolveFirst({
+    playerId: 'player-one',
+    h2h: { thin: false, rows: [] },
+    archetype: { thin: false, rows: [] },
+  });
+  await waitFor(() =>
+    expect(screen.getByRole('heading', { name: 'Austin Reaves', level: 2 })).toBeVisible(),
+  );
 });
 
 test('sorts the active market by delivered Matchup Score and scopes tabs to the displayed side', async () => {
@@ -296,7 +360,11 @@ test('opens and deep-links the selection card while market flips reuse delivered
   expect((await screen.findAllByText('+0.083')).length).toBeGreaterThan(0);
   expect(screen.getByText('No archetype sample data is available.')).toBeVisible();
   expect(screen.getByText('Transition').closest('article')).toHaveClass('selection-why');
-  await userEvent.click(screen.getByRole('button', { name: 'FGA' }));
+  await userEvent.click(
+    within(screen.getByRole('group', { name: 'Selection log stat' })).getByRole('button', {
+      name: 'FGA',
+    }),
+  );
   expect((await screen.findAllByText('+0.018')).length).toBeGreaterThan(0);
   expect(fetchMatchupSelection).toHaveBeenCalledTimes(1);
 });

--- a/src/matchups/MatchupDetailPage.test.js
+++ b/src/matchups/MatchupDetailPage.test.js
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
-import { fetchMatchup } from './matchupApi';
+import { fetchMatchup, fetchMatchupSelection } from './matchupApi';
 import MatchupDetailPage from './MatchupDetailPage';
 
 jest.mock('../contexts/AuthContext');
@@ -166,6 +166,29 @@ const matchup = {
 beforeEach(() => {
   useAuth.mockReturnValue({ isAuthenticated: true, loading: false });
   fetchMatchup.mockResolvedValue(matchup);
+  fetchMatchupSelection.mockResolvedValue({
+    playerId: 'player-one',
+    h2h: {
+      status: 'ready',
+      rows: [
+        {
+          date: '2025-12-25',
+          matchup: 'LAL vs. BOS',
+          minutes: 36,
+          stats: { PTS: 31, FGA: 19 },
+          deltas: { PTS: 0.083, FGA: 0.018 },
+        },
+      ],
+      average: {
+        date: null,
+        matchup: 'AVG',
+        minutes: 36,
+        stats: { PTS: 31, FGA: 19 },
+        deltas: { PTS: 0.083, FGA: 0.018 },
+      },
+    },
+    archetype: { status: 'empty', rows: [], average: null },
+  });
 });
 
 test('toggles delivered windows and applies a two-sided sigma filter without refetching', async () => {
@@ -256,4 +279,24 @@ test('renders raw injury statuses and keeps the signed-out shell honest', async 
   );
   expect(screen.getByRole('heading', { name: 'Sign in to view this matchup' })).toBeVisible();
   await waitFor(() => expect(fetchMatchup).not.toHaveBeenCalled());
+});
+
+test('opens and deep-links the selection card while market flips reuse delivered logs', async () => {
+  render(
+    <MemoryRouter initialEntries={['/matchups/game-1?player=player-one']}>
+      <Routes>
+        <Route path="/matchups/:gameId" element={<MatchupDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+  expect(await screen.findByRole('heading', { name: 'LeBron James', level: 2 })).toBeVisible();
+  expect(screen.getByRole('table', { name: 'LeBron James Score Matrix' })).toHaveTextContent(
+    '+12%',
+  );
+  expect((await screen.findAllByText('+0.083')).length).toBeGreaterThan(0);
+  expect(screen.getByText('No archetype sample data is available.')).toBeVisible();
+  expect(screen.getByText('Transition').closest('article')).toHaveClass('selection-why');
+  await userEvent.click(screen.getByRole('button', { name: 'FGA' }));
+  expect((await screen.findAllByText('+0.018')).length).toBeGreaterThan(0);
+  expect(fetchMatchupSelection).toHaveBeenCalledTimes(1);
 });

--- a/src/matchups/MatchupDetailPage.test.js
+++ b/src/matchups/MatchupDetailPage.test.js
@@ -409,6 +409,29 @@ test('player switches clamp the card stat and team toggles remain user-controlle
   expect(screen.getByText(/not opposing the viewed Defense Sheet/)).toBeVisible();
 });
 
+test('card stat choices persist while a different global sheet market remains active', async () => {
+  render(
+    <MemoryRouter initialEntries={['/matchups/game-1']}>
+      <Routes>
+        <Route path="/matchups/:gameId" element={<MatchupDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+  await screen.findByRole('heading', { name: 'BOS Defense Sheet' });
+  const sheetMarkets = within(screen.getByRole('group', { name: 'Market' }));
+  await userEvent.click(sheetMarkets.getByRole('button', { name: 'PTS' }));
+  await userEvent.click(
+    within(screen.getByRole('article', { name: 'LeBron James player' })).getByRole('button', {
+      name: 'Open selection card',
+    }),
+  );
+  const cardStats = within(await screen.findByRole('group', { name: 'Selection log stat' }));
+  await userEvent.click(cardStats.getByRole('button', { name: 'FGA' }));
+  expect(cardStats.getByRole('button', { name: 'FGA' })).toHaveAttribute('aria-pressed', 'true');
+  expect(sheetMarkets.getByRole('button', { name: 'PTS' })).toHaveAttribute('aria-pressed', 'true');
+  expect(fetchMatchupSelection).toHaveBeenCalledTimes(1);
+});
+
 test('selection request errors replace loading with an honest alert', async () => {
   fetchMatchupSelection.mockRejectedValueOnce(new Error('selection failed'));
   render(

--- a/src/matchups/MatchupDetailPage.test.js
+++ b/src/matchups/MatchupDetailPage.test.js
@@ -368,3 +368,56 @@ test('opens and deep-links the selection card while market flips reuse delivered
   expect((await screen.findAllByText('+0.018')).length).toBeGreaterThan(0);
   expect(fetchMatchupSelection).toHaveBeenCalledTimes(1);
 });
+
+test('player switches clamp the card stat and team toggles remain user-controlled', async () => {
+  const empty = (playerId) => ({
+    playerId,
+    h2h: { thin: false, rows: [] },
+    archetype: { thin: false, rows: [] },
+  });
+  fetchMatchupSelection.mockImplementation((_gameId, playerId) => Promise.resolve(empty(playerId)));
+  render(
+    <MemoryRouter initialEntries={['/matchups/game-1?player=player-one']}>
+      <Routes>
+        <Route path="/matchups/:gameId" element={<MatchupDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+  await screen.findByRole('heading', { name: 'LeBron James', level: 2 });
+  await userEvent.click(
+    within(screen.getByRole('group', { name: 'Selection log stat' })).getByRole('button', {
+      name: 'FGA',
+    }),
+  );
+  await userEvent.click(
+    within(screen.getByRole('article', { name: 'Austin Reaves player' })).getByRole('button', {
+      name: 'Open selection card',
+    }),
+  );
+  await screen.findByRole('heading', { name: 'Austin Reaves', level: 2 });
+  expect(
+    within(screen.getByRole('group', { name: 'Selection log stat' })).getByRole('button', {
+      name: 'PTS',
+    }),
+  ).toHaveAttribute('aria-pressed', 'true');
+  await userEvent.click(screen.getByRole('button', { name: 'LAL defense' }));
+  expect(screen.getByRole('button', { name: 'LAL defense' })).toHaveAttribute(
+    'aria-pressed',
+    'true',
+  );
+  expect(screen.getByRole('heading', { name: 'Austin Reaves', level: 2 })).toBeVisible();
+  expect(screen.getByText(/not opposing the viewed Defense Sheet/)).toBeVisible();
+});
+
+test('selection request errors replace loading with an honest alert', async () => {
+  fetchMatchupSelection.mockRejectedValueOnce(new Error('selection failed'));
+  render(
+    <MemoryRouter initialEntries={['/matchups/game-1?player=player-one']}>
+      <Routes>
+        <Route path="/matchups/:gameId" element={<MatchupDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+  expect(await screen.findByRole('alert')).toHaveTextContent('Unable to load selection logs');
+  expect(screen.queryByText('Loading selection logs…')).not.toBeInTheDocument();
+});

--- a/src/matchups/SelectionCard.js
+++ b/src/matchups/SelectionCard.js
@@ -61,17 +61,31 @@ export default function SelectionCard({
   onClose,
 }) {
   const panelRef = useRef(null);
+  const previousPlayerId = useRef(player.id);
+  const previousSheetMarket = useRef(sheetMarket);
   const [activeStat, setActiveStat] = useState(
     player.postedMarkets.includes(sheetMarket) ? sheetMarket : player.postedMarkets[0],
   );
   useEffect(() => panelRef.current?.focus(), [player.id]);
   useEffect(() => {
-    if (!player.postedMarkets.includes(activeStat)) {
-      setActiveStat(player.postedMarkets[0]);
-    } else if (sheetMarket !== 'All' && player.postedMarkets.includes(sheetMarket)) {
-      setActiveStat(sheetMarket);
-    }
-  }, [activeStat, player.id, player.postedMarkets, sheetMarket]);
+    const playerChanged = previousPlayerId.current !== player.id;
+    const sheetMarketChanged = previousSheetMarket.current !== sheetMarket;
+    setActiveStat((current) => {
+      if (playerChanged) {
+        return player.postedMarkets.includes(sheetMarket) ? sheetMarket : player.postedMarkets[0];
+      }
+      if (
+        sheetMarketChanged &&
+        sheetMarket !== 'All' &&
+        player.postedMarkets.includes(sheetMarket)
+      ) {
+        return sheetMarket;
+      }
+      return player.postedMarkets.includes(current) ? current : player.postedMarkets[0];
+    });
+    previousPlayerId.current = player.id;
+    previousSheetMarket.current = sheetMarket;
+  }, [player.id, player.postedMarkets, sheetMarket]);
   const rows = player.postedMarkets.map((market) => ({
     market,
     score: player.scores[market][windowKey],

--- a/src/matchups/SelectionCard.js
+++ b/src/matchups/SelectionCard.js
@@ -1,0 +1,169 @@
+import { useEffect, useRef, useState } from 'react';
+
+const BASE_LABELS = {
+  playTypes: 'Play types',
+  shotZones: 'Shot zones',
+  shotTypes: 'Shot types',
+  assistLocations: 'Assist locations',
+  traditional: 'Traditional',
+};
+const formatPercent = (value) => `${value >= 0 ? '+' : ''}${Math.round(value * 100)}%`;
+
+function LogTable({ title, table, market }) {
+  return (
+    <section className="selection-log" aria-labelledby={`${title.replaceAll(' ', '-')}-heading`}>
+      <h3 id={`${title.replaceAll(' ', '-')}-heading`}>{title}</h3>
+      {table.thin && <p className="thin-note">Thin sample — interpret cautiously.</p>}
+      {table.rows.length === 0 ? (
+        <p className="honest-empty">No {title.toLowerCase()} data is available.</p>
+      ) : (
+        <div className="selection-table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Game</th>
+                <th scope="col">MIN</th>
+                <th scope="col">{market}</th>
+                <th scope="col">±STAT/MIN</th>
+              </tr>
+            </thead>
+            <tbody>
+              {table.rows.map((row, index) => (
+                <tr
+                  key={row.date || `average-${index}`}
+                  className={row.average ? 'average-row' : undefined}
+                >
+                  <th scope="row">{row.average ? 'AVG' : `${row.date} · ${row.matchup}`}</th>
+                  <td>{row.minutes.toFixed(1)}</td>
+                  <td>{row.stats[market].toFixed(1)}</td>
+                  <td>
+                    {row.deltas[market] >= 0 ? '+' : ''}
+                    {row.deltas[market].toFixed(3)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default function SelectionCard({
+  player,
+  selection,
+  status,
+  error,
+  windowKey,
+  sheetMarket,
+  onClose,
+}) {
+  const panelRef = useRef(null);
+  const [activeStat, setActiveStat] = useState(
+    player.postedMarkets.includes(sheetMarket) ? sheetMarket : player.postedMarkets[0],
+  );
+  useEffect(() => panelRef.current?.focus(), [player.id]);
+  useEffect(() => {
+    if (sheetMarket !== 'All' && player.postedMarkets.includes(sheetMarket))
+      setActiveStat(sheetMarket);
+  }, [player.postedMarkets, sheetMarket]);
+  const rows = player.postedMarkets.map((market) => ({
+    market,
+    score: player.scores[market][windowKey],
+  }));
+  const bases = [...new Set(rows.flatMap(({ score }) => Object.keys(score.components)))];
+  const hasBlend = rows.some(({ score }) => score.blend);
+  return (
+    <section
+      ref={panelRef}
+      id="matchup-selection-card"
+      className="selection-card"
+      aria-labelledby="selection-heading"
+      tabIndex="-1"
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') onClose();
+      }}
+    >
+      <div className="selection-card-heading">
+        <div>
+          <p className="matchup-eyebrow">Selection card</p>
+          <h2 id="selection-heading">{player.name}</h2>
+        </div>
+        <button type="button" className="selection-close" onClick={onClose}>
+          Close selection card
+        </button>
+      </div>
+      <p className="selection-explainer">
+        Highlighted Defense Sheet rows show displayed Diet Share inputs for the current window.
+        Scores and deltas are delivered by the API.
+      </p>
+      <div className="selection-stat-control" role="group" aria-label="Selection log stat">
+        {player.postedMarkets.map((market) => (
+          <button
+            type="button"
+            key={market}
+            aria-pressed={activeStat === market}
+            onClick={() => setActiveStat(market)}
+          >
+            {market}
+          </button>
+        ))}
+      </div>
+      <div className="selection-table-wrap">
+        <table aria-label={`${player.name} Score Matrix`}>
+          <thead>
+            <tr>
+              <th scope="col">Market</th>
+              {bases.map((base) => (
+                <th scope="col" key={base}>
+                  {BASE_LABELS[base] || base}
+                </th>
+              ))}
+              {hasBlend && <th scope="col">Blend</th>}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(({ market, score }) => (
+              <tr key={market} className={market === activeStat ? 'active-market-row' : undefined}>
+                <th scope="row">{market}</th>
+                {bases.map((base) => (
+                  <td key={base}>
+                    {score.components[base] ? (
+                      <>
+                        {formatPercent(score.components[base].value)}
+                        {score.components[base].thin && <span className="thin-flag">thin</span>}
+                      </>
+                    ) : (
+                      '—'
+                    )}
+                  </td>
+                ))}
+                {hasBlend && (
+                  <td>
+                    {score.blend ? (
+                      <>
+                        {formatPercent(score.blend.value)}
+                        {score.blend.thin && <span className="thin-flag">thin</span>}
+                      </>
+                    ) : (
+                      '—'
+                    )}
+                  </td>
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {status === 'loading' && <p role="status">Loading selection logs…</p>}
+      {status === 'error' && <p role="alert">{error}</p>}
+      {status === 'ready' && (
+        <div className="selection-logs">
+          <LogTable title="Games vs this opponent" table={selection.h2h} market={activeStat} />
+          <LogTable title="Archetype sample" table={selection.archetype} market={activeStat} />
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/matchups/SelectionCard.js
+++ b/src/matchups/SelectionCard.js
@@ -57,6 +57,7 @@ export default function SelectionCard({
   error,
   windowKey,
   sheetMarket,
+  whyRelevant,
   onClose,
 }) {
   const panelRef = useRef(null);
@@ -65,9 +66,12 @@ export default function SelectionCard({
   );
   useEffect(() => panelRef.current?.focus(), [player.id]);
   useEffect(() => {
-    if (sheetMarket !== 'All' && player.postedMarkets.includes(sheetMarket))
+    if (!player.postedMarkets.includes(activeStat)) {
+      setActiveStat(player.postedMarkets[0]);
+    } else if (sheetMarket !== 'All' && player.postedMarkets.includes(sheetMarket)) {
       setActiveStat(sheetMarket);
-  }, [player.postedMarkets, sheetMarket]);
+    }
+  }, [activeStat, player.id, player.postedMarkets, sheetMarket]);
   const rows = player.postedMarkets.map((market) => ({
     market,
     score: player.scores[market][windowKey],
@@ -95,7 +99,9 @@ export default function SelectionCard({
         </button>
       </div>
       <p className="selection-explainer">
-        Highlighted Defense Sheet rows show displayed Diet Share inputs for the current window.
+        {whyRelevant
+          ? 'Highlighted Defense Sheet rows show displayed Diet Share inputs for the current window.'
+          : 'This player is not opposing the viewed Defense Sheet, so no why rows are highlighted.'}{' '}
         Scores and deltas are delivered by the API.
       </p>
       <div className="selection-stat-control" role="group" aria-label="Selection log stat">

--- a/src/matchups/displayConfig.js
+++ b/src/matchups/displayConfig.js
@@ -13,3 +13,8 @@ export const shouldDisplayDietShare = (base, value) => {
     value.volumePerGame >= threshold.minimumVolumePerGame
   );
 };
+
+export const getDisplayableDietShare = (player, base, rowKey, windowKey) => {
+  const value = player.dietShares[base]?.find((entry) => entry.key === rowKey)?.[windowKey];
+  return value && shouldDisplayDietShare(base, value) ? value : null;
+};

--- a/src/matchups/matchupApi.js
+++ b/src/matchups/matchupApi.js
@@ -7,6 +7,16 @@ import {
 } from '../slateStatus';
 
 const invalid = () => new Error('The matchup endpoint returned an invalid response.');
+const selectionInvalid = () =>
+  new Error('The matchup selection endpoint returned an invalid response.');
+const requireSelectionString = (value) => {
+  if (typeof value !== 'string' || !value) throw selectionInvalid();
+  return value;
+};
+const requireSelectionNumber = (value) => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) throw selectionInvalid();
+  return value;
+};
 const isRecord = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
 const requireString = (value) => {
   if (typeof value !== 'string' || !value) throw invalid();
@@ -147,7 +157,7 @@ const decodeScoreWindow = (window) => {
         decodeScoreCell(cell),
       ]),
     ),
-    blend: decodeScoreCell(window.blend),
+    blend: window.blend === undefined ? null : decodeScoreCell(window.blend),
   };
 };
 
@@ -334,45 +344,55 @@ export const fetchMatchup = async (gameId, { signal } = {}) => {
   return decodeMatchup(response.data);
 };
 
-const decodeStatMap = (value, markets) => {
-  if (!isRecord(value) || markets.some((market) => !(market in value))) throw invalid();
+const decodeSelectionStatMap = (value, markets) => {
+  if (!isRecord(value) || markets.some((market) => !(market in value))) throw selectionInvalid();
   return Object.fromEntries(
-    Object.entries(value).map(([key, number]) => [key, requireNumber(number)]),
+    Object.entries(value).map(([key, number]) => {
+      if (typeof number !== 'number' || !Number.isFinite(number)) throw selectionInvalid();
+      return [key, number];
+    }),
   );
 };
 
-const decodeLogLine = (line, markets, isAverage = false) => {
-  if (!isRecord(line)) throw invalid();
+const decodeLogLine = (line, markets) => {
+  if (!isRecord(line)) throw selectionInvalid();
+  const average = line.matchup === 'AVG';
+  if ((average && line.game_date !== null) || (!average && typeof line.game_date !== 'string')) {
+    throw selectionInvalid();
+  }
   return {
-    date: isAverage ? null : requireString(line.game_date),
-    matchup: isAverage ? 'AVG' : requireString(line.matchup),
-    minutes: requireNumber(line.minutes),
-    stats: decodeStatMap(line.stats, markets),
-    deltas: decodeStatMap(line.deltas, markets),
+    date: line.game_date,
+    matchup: requireSelectionString(line.matchup),
+    minutes: requireSelectionNumber(line.minutes),
+    stats: decodeSelectionStatMap(line.stats, markets),
+    deltas: decodeSelectionStatMap(line.deltas, markets),
+    average,
   };
 };
 
 const decodeLogTable = (table, markets) => {
-  if (
-    !isRecord(table) ||
-    !['ready', 'empty', 'thin'].includes(table.status) ||
-    !Array.isArray(table.rows)
-  ) {
-    throw invalid();
+  if (!isRecord(table) || !Array.isArray(table.rows)) throw selectionInvalid();
+  const rows = table.rows.map((row) => decodeLogLine(row, markets));
+  if (rows.some((row, index) => row.average && index !== rows.length - 1)) {
+    throw selectionInvalid();
   }
-  if (table.status === 'empty' && (table.rows.length || table.average !== null)) throw invalid();
+  if (rows.length > 0 && (!rows.at(-1).average || rows.filter((row) => row.average).length !== 1)) {
+    throw selectionInvalid();
+  }
   return {
-    status: table.status,
-    rows: table.rows.map((row) => decodeLogLine(row, markets)),
-    average: table.average === null ? null : decodeLogLine(table.average, markets, true),
+    rows,
+    thin:
+      rows.filter((row) => !row.average).length > 0 &&
+      rows.filter((row) => !row.average).length < 2,
   };
 };
 
-export const decodeMatchupSelection = (data, postedMarkets) => {
+export const decodeMatchupSelection = (data, postedMarkets, expectedPlayerId) => {
   if (!isRecord(data) || !Array.isArray(postedMarkets) || postedMarkets.length === 0)
-    throw invalid();
+    throw selectionInvalid();
+  if (data.player_id !== expectedPlayerId) throw selectionInvalid();
   return {
-    playerId: requireString(data.player_id),
+    playerId: data.player_id,
     h2h: decodeLogTable(data.h2h, postedMarkets),
     archetype: decodeLogTable(data.archetype, postedMarkets),
   };
@@ -383,5 +403,5 @@ export const fetchMatchupSelection = async (gameId, playerId, postedMarkets, { s
     params: { game_id: gameId, player_id: playerId },
     signal,
   });
-  return decodeMatchupSelection(response.data, postedMarkets);
+  return decodeMatchupSelection(response.data, postedMarkets, playerId);
 };

--- a/src/matchups/matchupApi.js
+++ b/src/matchups/matchupApi.js
@@ -148,8 +148,14 @@ const decodeScoreCell = (cell) => {
   return { value: requireNumber(cell.value), thin: cell.thin };
 };
 
-const decodeScoreWindow = (window) => {
+const DEFENSIVE_SCORE_MARKETS = new Set(['TOV', 'STL', 'BLK', 'STKS']);
+
+const decodeScoreWindow = (window, market) => {
   if (!isRecord(window) || !isRecord(window.components)) throw invalid();
+  const defensive = DEFENSIVE_SCORE_MARKETS.has(market);
+  if ((!defensive && !isRecord(window.blend)) || (defensive && window.blend != null)) {
+    throw invalid();
+  }
   return {
     components: Object.fromEntries(
       Object.entries(window.components).map(([base, cell]) => [
@@ -157,7 +163,7 @@ const decodeScoreWindow = (window) => {
         decodeScoreCell(cell),
       ]),
     ),
-    blend: window.blend === undefined ? null : decodeScoreCell(window.blend),
+    blend: defensive ? null : decodeScoreCell(window.blend),
   };
 };
 
@@ -169,8 +175,8 @@ function decodeScores(scores, postedMarkets) {
     postedMarkets.map((market) => [
       market,
       {
-        season: decodeScoreWindow(scores[market].season),
-        last15: decodeScoreWindow(scores[market].last_15),
+        season: decodeScoreWindow(scores[market].season, market),
+        last15: decodeScoreWindow(scores[market].last_15, market),
       },
     ]),
   );
@@ -375,11 +381,7 @@ const decodeLogLine = (line, markets) => {
 };
 
 const decodeLogTable = (table, markets) => {
-  if (
-    !isRecord(table) ||
-    !Array.isArray(table.rows) ||
-    (table.thin !== undefined && typeof table.thin !== 'boolean')
-  )
+  if (!isRecord(table) || !Array.isArray(table.rows) || typeof table.thin !== 'boolean')
     throw selectionInvalid();
   const rows = table.rows.map((row) => decodeLogLine(row, markets));
   if (rows.some((row, index) => row.average && index !== rows.length - 1)) {
@@ -390,7 +392,7 @@ const decodeLogTable = (table, markets) => {
   }
   return {
     rows,
-    thin: table.thin ?? false,
+    thin: table.thin,
   };
 };
 

--- a/src/matchups/matchupApi.js
+++ b/src/matchups/matchupApi.js
@@ -356,13 +356,17 @@ const decodeSelectionStatMap = (value, markets) => {
 
 const decodeLogLine = (line, markets) => {
   if (!isRecord(line)) throw selectionInvalid();
-  const average = line.matchup === 'AVG';
-  if ((average && line.game_date !== null) || (!average && typeof line.game_date !== 'string')) {
+  if (!['game', 'average'].includes(line.row_type)) throw selectionInvalid();
+  const average = line.row_type === 'average';
+  if (
+    (average && (line.game_date !== null || line.matchup !== null)) ||
+    (!average && (typeof line.game_date !== 'string' || typeof line.matchup !== 'string'))
+  ) {
     throw selectionInvalid();
   }
   return {
     date: line.game_date,
-    matchup: requireSelectionString(line.matchup),
+    matchup: average ? null : requireSelectionString(line.matchup),
     minutes: requireSelectionNumber(line.minutes),
     stats: decodeSelectionStatMap(line.stats, markets),
     deltas: decodeSelectionStatMap(line.deltas, markets),
@@ -371,7 +375,12 @@ const decodeLogLine = (line, markets) => {
 };
 
 const decodeLogTable = (table, markets) => {
-  if (!isRecord(table) || !Array.isArray(table.rows)) throw selectionInvalid();
+  if (
+    !isRecord(table) ||
+    !Array.isArray(table.rows) ||
+    (table.thin !== undefined && typeof table.thin !== 'boolean')
+  )
+    throw selectionInvalid();
   const rows = table.rows.map((row) => decodeLogLine(row, markets));
   if (rows.some((row, index) => row.average && index !== rows.length - 1)) {
     throw selectionInvalid();
@@ -381,9 +390,7 @@ const decodeLogTable = (table, markets) => {
   }
   return {
     rows,
-    thin:
-      rows.filter((row) => !row.average).length > 0 &&
-      rows.filter((row) => !row.average).length < 2,
+    thin: table.thin ?? false,
   };
 };
 

--- a/src/matchups/matchupApi.js
+++ b/src/matchups/matchupApi.js
@@ -333,3 +333,55 @@ export const fetchMatchup = async (gameId, { signal } = {}) => {
   });
   return decodeMatchup(response.data);
 };
+
+const decodeStatMap = (value, markets) => {
+  if (!isRecord(value) || markets.some((market) => !(market in value))) throw invalid();
+  return Object.fromEntries(
+    Object.entries(value).map(([key, number]) => [key, requireNumber(number)]),
+  );
+};
+
+const decodeLogLine = (line, markets, isAverage = false) => {
+  if (!isRecord(line)) throw invalid();
+  return {
+    date: isAverage ? null : requireString(line.game_date),
+    matchup: isAverage ? 'AVG' : requireString(line.matchup),
+    minutes: requireNumber(line.minutes),
+    stats: decodeStatMap(line.stats, markets),
+    deltas: decodeStatMap(line.deltas, markets),
+  };
+};
+
+const decodeLogTable = (table, markets) => {
+  if (
+    !isRecord(table) ||
+    !['ready', 'empty', 'thin'].includes(table.status) ||
+    !Array.isArray(table.rows)
+  ) {
+    throw invalid();
+  }
+  if (table.status === 'empty' && (table.rows.length || table.average !== null)) throw invalid();
+  return {
+    status: table.status,
+    rows: table.rows.map((row) => decodeLogLine(row, markets)),
+    average: table.average === null ? null : decodeLogLine(table.average, markets, true),
+  };
+};
+
+export const decodeMatchupSelection = (data, postedMarkets) => {
+  if (!isRecord(data) || !Array.isArray(postedMarkets) || postedMarkets.length === 0)
+    throw invalid();
+  return {
+    playerId: requireString(data.player_id),
+    h2h: decodeLogTable(data.h2h, postedMarkets),
+    archetype: decodeLogTable(data.archetype, postedMarkets),
+  };
+};
+
+export const fetchMatchupSelection = async (gameId, playerId, postedMarkets, { signal } = {}) => {
+  const response = await apiClient.get(getApiUrl('MATCHUP_SELECTION'), {
+    params: { game_id: gameId, player_id: playerId },
+    signal,
+  });
+  return decodeMatchupSelection(response.data, postedMarkets);
+};

--- a/src/matchups/matchupApi.test.js
+++ b/src/matchups/matchupApi.test.js
@@ -186,6 +186,31 @@ test('accepts clarified freshness with derived schedule and provider-only pool t
   );
 });
 
+test('requires Blend for offensive scores and accepts omitted or null Blend for defensive scores', () => {
+  const defensive = JSON.parse(JSON.stringify(payload));
+  defensive.players[0].posted_markets = ['TOV'];
+  defensive.players[0].scores = {
+    TOV: {
+      season: { components: { traditional: { value: 0.08, thin: false } } },
+      last_15: { components: { traditional: { value: -0.02, thin: false } }, blend: null },
+    },
+  };
+  expect(decodeMatchup(defensive).players[0].scores.TOV).toEqual(
+    expect.objectContaining({
+      season: expect.objectContaining({ blend: null }),
+      last15: expect.objectContaining({ blend: null }),
+    }),
+  );
+
+  const missingOffensiveBlend = JSON.parse(JSON.stringify(payload));
+  delete missingOffensiveBlend.players[0].scores.PTS.season.blend;
+  expect(() => decodeMatchup(missingOffensiveBlend)).toThrow('invalid response');
+
+  const inventedDefensiveBlend = JSON.parse(JSON.stringify(defensive));
+  inventedDefensiveBlend.players[0].scores.TOV.season.blend = { value: 0.08, thin: false };
+  expect(() => decodeMatchup(inventedDefensiveBlend)).toThrow('invalid response');
+});
+
 test.each([
   ['missing windows', { ...payload, teams: [{ ...payload.teams[0], defense_sheet: {} }] }],
   [
@@ -211,6 +236,7 @@ test('strictly decodes combo, attempts, and AVG rows from the raw selection resp
   const raw = {
     player_id: 'lebron-james',
     h2h: {
+      thin: false,
       rows: [
         {
           row_type: 'game',
@@ -230,7 +256,7 @@ test('strictly decodes combo, attempts, and AVG rows from the raw selection resp
         },
       ],
     },
-    archetype: { rows: [] },
+    archetype: { thin: false, rows: [] },
   };
   const selection = decodeMatchupSelection(raw, ['PRA', 'FGA'], 'lebron-james');
   expect(selection.h2h.rows.at(-1)).toEqual(

--- a/src/matchups/matchupApi.test.js
+++ b/src/matchups/matchupApi.test.js
@@ -207,32 +207,38 @@ test.each([
   expect(() => decodeMatchup(candidate)).toThrow('invalid response');
 });
 
-test('strictly decodes delivered selection rows and averages for every posted market', () => {
-  const selection = decodeMatchupSelection(
-    {
-      player_id: 'lebron-james',
-      h2h: {
-        status: 'ready',
-        rows: [
-          {
-            game_date: '2025-12-25',
-            matchup: 'LAL vs. BOS',
-            minutes: 36,
-            stats: { PTS: 31, AST: 9 },
-            deltas: { PTS: 0.083, AST: 0.031 },
-          },
-        ],
-        average: { minutes: 36, stats: { PTS: 31, AST: 9 }, deltas: { PTS: 0.083, AST: 0.031 } },
-      },
-      archetype: { status: 'empty', rows: [], average: null },
+test('strictly decodes combo, attempts, and AVG rows from the raw selection response', () => {
+  const raw = {
+    player_id: 'lebron-james',
+    h2h: {
+      rows: [
+        {
+          game_date: '2025-12-25',
+          matchup: 'LAL vs. BOS',
+          minutes: 36,
+          stats: { PRA: 48, FGA: 19 },
+          deltas: { PRA: 0.102, FGA: 0.018 },
+        },
+        {
+          game_date: null,
+          matchup: 'AVG',
+          minutes: 36,
+          stats: { PRA: 48, FGA: 19 },
+          deltas: { PRA: 0.102, FGA: 0.018 },
+        },
+      ],
     },
-    ['PTS', 'AST'],
+    archetype: { rows: [] },
+  };
+  const selection = decodeMatchupSelection(raw, ['PRA', 'FGA'], 'lebron-james');
+  expect(selection.h2h.rows.at(-1)).toEqual(
+    expect.objectContaining({ average: true, deltas: { PRA: 0.102, FGA: 0.018 } }),
   );
-  expect(selection.h2h.average).toEqual(
-    expect.objectContaining({ matchup: 'AVG', deltas: { PTS: 0.083, AST: 0.031 } }),
+  expect(selection.archetype.rows).toEqual([]);
+  expect(() => decodeMatchupSelection(raw, ['PRA', 'AST'], 'lebron-james')).toThrow(
+    'selection endpoint returned an invalid response',
   );
-  expect(selection.archetype.status).toBe('empty');
-  expect(() =>
-    decodeMatchupSelection({ ...selection, player_id: 'lebron-james' }, ['PTS']),
-  ).toThrow('invalid response');
+  expect(() => decodeMatchupSelection(raw, ['PRA', 'FGA'], 'another-player')).toThrow(
+    'selection endpoint returned an invalid response',
+  );
 });

--- a/src/matchups/matchupApi.test.js
+++ b/src/matchups/matchupApi.test.js
@@ -213,6 +213,7 @@ test('strictly decodes combo, attempts, and AVG rows from the raw selection resp
     h2h: {
       rows: [
         {
+          row_type: 'game',
           game_date: '2025-12-25',
           matchup: 'LAL vs. BOS',
           minutes: 36,
@@ -220,8 +221,9 @@ test('strictly decodes combo, attempts, and AVG rows from the raw selection resp
           deltas: { PRA: 0.102, FGA: 0.018 },
         },
         {
+          row_type: 'average',
           game_date: null,
-          matchup: 'AVG',
+          matchup: null,
           minutes: 36,
           stats: { PRA: 48, FGA: 19 },
           deltas: { PRA: 0.102, FGA: 0.018 },
@@ -241,4 +243,11 @@ test('strictly decodes combo, attempts, and AVG rows from the raw selection resp
   expect(() => decodeMatchupSelection(raw, ['PRA', 'FGA'], 'another-player')).toThrow(
     'selection endpoint returned an invalid response',
   );
+  expect(() =>
+    decodeMatchupSelection(
+      { ...raw, h2h: { ...raw.h2h, thin: 'yes' } },
+      ['PRA', 'FGA'],
+      'lebron-james',
+    ),
+  ).toThrow('selection endpoint returned an invalid response');
 });

--- a/src/matchups/matchupApi.test.js
+++ b/src/matchups/matchupApi.test.js
@@ -1,4 +1,4 @@
-import { decodeMatchup } from './matchupApi';
+import { decodeMatchup, decodeMatchupSelection } from './matchupApi';
 
 const payload = {
   game: {
@@ -205,4 +205,34 @@ test.each([
   ['invalid game', { ...payload, game: { ...payload.game, scheduled_at: 'not-a-date' } }],
 ])('rejects %s at the response boundary', (_name, candidate) => {
   expect(() => decodeMatchup(candidate)).toThrow('invalid response');
+});
+
+test('strictly decodes delivered selection rows and averages for every posted market', () => {
+  const selection = decodeMatchupSelection(
+    {
+      player_id: 'lebron-james',
+      h2h: {
+        status: 'ready',
+        rows: [
+          {
+            game_date: '2025-12-25',
+            matchup: 'LAL vs. BOS',
+            minutes: 36,
+            stats: { PTS: 31, AST: 9 },
+            deltas: { PTS: 0.083, AST: 0.031 },
+          },
+        ],
+        average: { minutes: 36, stats: { PTS: 31, AST: 9 }, deltas: { PTS: 0.083, AST: 0.031 } },
+      },
+      archetype: { status: 'empty', rows: [], average: null },
+    },
+    ['PTS', 'AST'],
+  );
+  expect(selection.h2h.average).toEqual(
+    expect.objectContaining({ matchup: 'AVG', deltas: { PTS: 0.083, AST: 0.031 } }),
+  );
+  expect(selection.archetype.status).toBe('empty');
+  expect(() =>
+    decodeMatchupSelection({ ...selection, player_id: 'lebron-james' }, ['PTS']),
+  ).toThrow('invalid response');
 });


### PR DESCRIPTION
Part of #5 and crf04/statsplus#14.

Merge after: crf04/statsplus-backend#43. This PR targets the non-deploying packet integration branch. Backend selection #49 is blocked on persisted game-log source facts; this frontend slice uses the clarified deterministic contract and does not invent live fallback behavior.

Adds URL-backed player selection, delivered Score Matrix and thin flags, active-stat log tables with explicit AVG rows, current-window why highlighting, deep-link/history/focus/error handling, and multi-player deterministic browser coverage.

Verification: lint/format/build; Jest 94/94; Chromium 23/23; desktop/narrow/player-switch/team-toggle/handled-error visual QA with no unexpected console/network/page errors.

Review: Opus 5 Standards CLEAR; Opus 5 Spec CLEAR after correction loops. Contract encoding clarified on crf04/statsplus#14.