### PR TITLE
Align matchup contract and retire prototype scaffolding

### DIFF
--- a/e2e/fixtures/courtai.js
+++ b/e2e/fixtures/courtai.js
@@ -185,6 +185,7 @@ const league = {
       leagueRow('isolation', 8, 0.5, 8.1, 0.6),
       leagueRow('above-break', 11.5, 1, 11.7, 1),
       leagueRow('post-up', 11, 0.9, 11.4, 1.1),
+      leagueRow('handoff', 7.2, 0.7, 7.4, 0.8),
     ],
     shot_zones: [leagueRow('paint', 21, 1.7, 21.2, 1.5)],
     shot_types: [leagueRow('catch-shoot', 15.5, 1.2, 15.3, 1.1)],

--- a/e2e/fixtures/courtai.js
+++ b/e2e/fixtures/courtai.js
@@ -85,19 +85,13 @@ const scheduleOnlySlateGame = {
 export const slatePayload = (
   date,
   games,
-  {
-    poolStatus = 'unavailable',
-    poolFreshnessStatus = 'unavailable',
-    poolRetrievedAt = null,
-    providers = {},
-  } = {},
+  { poolFreshnessStatus = 'unavailable', poolRetrievedAt = null, providers = {} } = {},
 ) => ({
   slate_date: date,
   freshness: {
     schedule: { status: 'fresh', retrieved_at: '2026-01-15T10:00:00Z' },
     pool: { status: poolFreshnessStatus, retrieved_at: poolRetrievedAt, providers },
   },
-  pool_status: poolStatus,
   games,
 });
 

--- a/e2e/fixtures/courtai.js
+++ b/e2e/fixtures/courtai.js
@@ -171,6 +171,41 @@ const teamSheet = (team, playTypes, offset = 0) => ({
   defensive_columns: defensiveColumns(offset),
 });
 
+// Deterministic stand-ins for aggregates derived across all 30 NBA teams.
+const leagueRow = (key, seasonAverage, seasonSigma, last15Average, last15Sigma) => ({
+  key,
+  season: { average_allowed_per_48: seasonAverage, sigma: seasonSigma },
+  last_15: { average_allowed_per_48: last15Average, sigma: last15Sigma },
+});
+
+const league = {
+  defense_sheet: {
+    play_types: [
+      leagueRow('transition', 16.4, 1.4, 16.2, 1.2),
+      leagueRow('isolation', 8, 0.5, 8.1, 0.6),
+      leagueRow('above-break', 11.5, 1, 11.7, 1),
+      leagueRow('post-up', 11, 0.9, 11.4, 1.1),
+    ],
+    shot_zones: [leagueRow('paint', 21, 1.7, 21.2, 1.5)],
+    shot_types: [leagueRow('catch-shoot', 15.5, 1.2, 15.3, 1.1)],
+    assist_locations: [leagueRow('paint-assists', 10, 0.8, 10.1, 0.9)],
+    traditional: [leagueRow('opponent-rebounds', 46, 1.5, 46.2, 1.4)],
+  },
+  defensive_columns: Object.fromEntries(
+    [
+      ['OPP_TOV', 13.1, 1.1, 13, 1],
+      ['OPP_STL', 7.5, 0.8, 7.6, 0.7],
+      ['OPP_BLK', 4.9, 0.6, 4.8, 0.5],
+    ].map(([key, seasonAverage, seasonSigma, last15Average, last15Sigma]) => [
+      key,
+      {
+        season: { average_per_48: seasonAverage, sigma: seasonSigma },
+        last_15: { average_per_48: last15Average, sigma: last15Sigma },
+      },
+    ]),
+  ),
+};
+
 const dietShare = (key, seasonShare, last15Share, seasonVolume = 5.1, last15Volume = 5.4) => ({
   key,
   season: { share: seasonShare, volume_per_game: seasonVolume },
@@ -206,6 +241,7 @@ export const matchupPayload = {
     away_team: { ...slateGame.away_team, targetable_player_count: 2 },
     home_team: { ...slateGame.home_team, targetable_player_count: 1 },
   },
+  league,
   teams: [
     teamSheet(slateGame.away_team, [
       defenseRow(
@@ -263,11 +299,15 @@ export const matchupPayload = {
   // the frontend renders this authoritative result and does not reimplement it.
   players: [
     {
-      canonical_id: 'lebron-james',
+      canonical_id: 2544,
       name: 'LeBron James',
       team_id: slateGame.away_team.team_id,
       tricode: 'LAL',
       posted_markets: ['PTS', 'FGA', 'AST', 'REB', 'PRA', 'TOV'],
+      provenance: {
+        prizepicks: ['PTS', 'FGA', 'AST', 'REB', 'PRA'],
+        underdog: ['PTS', 'TOV'],
+      },
       season_scoring: 25.4,
       last_10_minutes: [35, 36, 38, 34, 37, 36, 35, 39, 36, 37],
       diet_shares: {
@@ -280,11 +320,12 @@ export const matchupPayload = {
       scores: scores(['PTS', 'FGA', 'AST', 'REB', 'PRA', 'TOV'], 0.12, -0.02),
     },
     {
-      canonical_id: 'austin-reaves',
+      canonical_id: 1630559,
       name: 'Austin Reaves',
       team_id: slateGame.away_team.team_id,
       tricode: 'LAL',
       posted_markets: ['PTS', 'FG3A', 'STL'],
+      provenance: { prizepicks: ['PTS', 'FG3A'], underdog: ['STL'] },
       season_scoring: 20.1,
       last_10_minutes: [32, 35, 34, 33, 31, 35, 36, 34, 35, 33],
       diet_shares: {
@@ -299,11 +340,12 @@ export const matchupPayload = {
       scores: scores(['PTS', 'FG3A', 'STL'], 0.24, 0.08),
     },
     {
-      canonical_id: 'jayson-tatum',
+      canonical_id: 1628369,
       name: 'Jayson Tatum',
       team_id: slateGame.home_team.team_id,
       tricode: 'BOS',
       posted_markets: ['PTS', 'FGA', 'FG3A', 'REB', 'BLK'],
+      provenance: { prizepicks: ['PTS', 'FGA', 'FG3A', 'REB'], underdog: ['BLK'] },
       season_scoring: 27.2,
       last_10_minutes: [36, 37, 35, 38, 34, 36, 39, 37, 36, 38],
       diet_shares: {
@@ -330,7 +372,8 @@ export const matchupPayload = {
         entries: [
           {
             entry_id: 'injury-austin',
-            canonical_player_id: 'austin-reaves',
+            source_player_id: '5440',
+            canonical_player_id: 1630559,
             source_player_name: 'Austin Reaves',
             team_id: slateGame.away_team.team_id,
             tricode: 'LAL',
@@ -341,7 +384,8 @@ export const matchupPayload = {
           },
           {
             entry_id: 'injury-non-pool',
-            canonical_player_id: 'maxi-kleber',
+            source_player_id: '3929',
+            canonical_player_id: 203114,
             source_player_name: 'Maxi Kleber',
             team_id: slateGame.away_team.team_id,
             tricode: 'LAL',
@@ -352,6 +396,7 @@ export const matchupPayload = {
           },
           ...['Probable', 'Questionable', 'Doubtful'].map((status, index) => ({
             entry_id: `injury-${status.toLowerCase()}`,
+            source_player_id: index === 2 ? null : `source-${index + 1}`,
             canonical_player_id: null,
             source_player_name: ['Gabe Vincent', 'Jarred Vanderbilt', 'Jordan Goodwin'][index],
             team_id: slateGame.away_team.team_id,
@@ -395,7 +440,7 @@ const selectionLine = (date, matchup, minutes, values, deltas) => ({
 });
 
 export const selectionPayload = {
-  player_id: 'lebron-james',
+  player_id: 2544,
   h2h: {
     thin: false,
     rows: [
@@ -437,7 +482,7 @@ export const selectionPayload = {
 };
 
 export const austinSelectionPayload = {
-  player_id: 'austin-reaves',
+  player_id: 1630559,
   h2h: { thin: false, rows: [] },
   archetype: {
     thin: true,
@@ -520,8 +565,8 @@ export const installApiContract = async (page, overrides = {}) => {
       const gameId = url.searchParams.get('game_id');
       const playerId = url.searchParams.get('player_id');
       const payloads = {
-        'lebron-james': selectionPayload,
-        'austin-reaves': austinSelectionPayload,
+        2544: selectionPayload,
+        1630559: austinSelectionPayload,
       };
       if (gameId !== matchupPayload.game.game_id || !payloads[playerId]) {
         await route.fulfill({ status: 404, json: { error: { code: 'resource_not_found' } } });

--- a/e2e/specs/matchup-detail.spec.js
+++ b/e2e/specs/matchup-detail.spec.js
@@ -42,6 +42,11 @@ test('@critical user opens a Defense Sheet and changes local spotting controls',
   await expect(page.getByText('15.2 per 48')).toBeVisible();
   await expect(page.getByText('2 targetable returned')).toBeVisible();
   await expect(page.getByRole('article', { name: 'LeBron James player' })).toBeVisible();
+  await expect(
+    page
+      .getByRole('article', { name: 'LeBron James player' })
+      .getByLabel('PTS from prizepicks, underdog'),
+  ).toBeVisible();
   await expect(page.getByRole('article', { name: 'Maxi Kleber player' })).toHaveCount(0);
   await expect(page.getByText('Game-time decision')).toHaveCount(2);
   await expect(page.getByText('Maxi Kleber')).toBeVisible();
@@ -98,7 +103,7 @@ test('matchup renders stale and unavailable surfaces without inventing data', as
         status: 'unavailable',
         unavailable_reason: 'permission_required',
         retrieved_at: null,
-        teams: [],
+        teams: matchupPayload.injuries.teams.map((team) => ({ ...team, entries: [] })),
       },
       freshness: {
         ...matchupPayload.freshness,
@@ -204,11 +209,12 @@ test('@critical selection card supports selection, deep links, and tab flips wit
   await page.goto('/matchups?date=2026-01-15');
   await page.getByRole('link', { name: 'Open Team Sheets' }).click();
   await expect(page).toHaveURL('/matchups/0022500584');
+  await page.goto('/matchups/0022500584?context=kept');
   await page
     .getByRole('article', { name: 'LeBron James player' })
     .getByRole('button', { name: 'Open selection card' })
     .click();
-  await expect(page).toHaveURL('/matchups/0022500584?player=lebron-james');
+  await expect(page).toHaveURL(/context=kept.*player=2544|player=2544.*context=kept/);
   await expect(page.getByRole('button', { name: 'All', exact: true })).toHaveAttribute(
     'aria-pressed',
     'true',
@@ -244,8 +250,10 @@ test('@critical selection card supports selection, deep links, and tab flips wit
   });
 
   await page.goBack();
+  await expect(page).toHaveURL('/matchups/0022500584?context=kept');
   await expect(page.getByRole('heading', { name: 'LeBron James', level: 2 })).toHaveCount(0);
   await page.goForward();
+  await expect(page).toHaveURL(/context=kept.*player=2544|player=2544.*context=kept/);
   await expect(page.getByRole('heading', { name: 'LeBron James', level: 2 })).toBeVisible();
   await page.keyboard.press('Escape');
   await expect(page.getByRole('heading', { name: 'LeBron James', level: 2 })).toHaveCount(0);
@@ -253,11 +261,11 @@ test('@critical selection card supports selection, deep links, and tab flips wit
     page.getByRole('article', { name: 'LeBron James player' }).getByRole('button'),
   ).toBeFocused();
 
-  await page.goto('/matchups/0022500584?player=austin-reaves');
+  await page.goto('/matchups/0022500584?player=1630559');
   await expect(page.getByRole('heading', { name: 'Austin Reaves', level: 2 })).toBeVisible();
   await expect(page.getByText('No games vs this opponent data is available.')).toBeVisible();
   await page.screenshot({ path: testInfo.outputPath('selection-empty-thin.png'), fullPage: true });
-  await page.goto('/matchups/0022500584?player=lebron-james');
+  await page.goto('/matchups/0022500584?player=2544');
   await expect(page.getByRole('heading', { name: 'LeBron James', level: 2 })).toBeVisible();
   await page.setViewportSize({ width: 393, height: 852 });
   expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(
@@ -329,7 +337,7 @@ test('selection request failure renders an honest handled error', async ({ page 
   page.on('response', (response) => {
     if (response.status() >= 400) failedResponses.push(`${response.status()} ${response.url()}`);
   });
-  await page.goto('/matchups/0022500584?player=lebron-james');
+  await page.goto('/matchups/0022500584?player=2544');
   await expect(page.getByRole('alert')).toContainText('Unable to load selection logs');
   await expect(page.getByText('Loading selection logs…')).toHaveCount(0);
   expect(failedResponses).toHaveLength(1);

--- a/e2e/specs/matchup-detail.spec.js
+++ b/e2e/specs/matchup-detail.spec.js
@@ -201,14 +201,14 @@ test('@critical selection card supports selection, deep links, and tab flips wit
   page.on('request', (request) => {
     if (new URL(request.url()).pathname === '/api/games/matchup/selection') selectionRequests += 1;
   });
-  await page.goto('/matchups/0022500584?context=kept');
+  await page.goto('/matchups?date=2026-01-15');
+  await page.getByRole('link', { name: 'Open Team Sheets' }).click();
+  await expect(page).toHaveURL('/matchups/0022500584');
   await page
     .getByRole('article', { name: 'LeBron James player' })
     .getByRole('button', { name: 'Open selection card' })
     .click();
-  await expect(page).toHaveURL(
-    /context=kept.*player=lebron-james|player=lebron-james.*context=kept/,
-  );
+  await expect(page).toHaveURL('/matchups/0022500584?player=lebron-james');
   await expect(page.getByRole('button', { name: 'All', exact: true })).toHaveAttribute(
     'aria-pressed',
     'true',
@@ -256,6 +256,7 @@ test('@critical selection card supports selection, deep links, and tab flips wit
   await page.goto('/matchups/0022500584?player=austin-reaves');
   await expect(page.getByRole('heading', { name: 'Austin Reaves', level: 2 })).toBeVisible();
   await expect(page.getByText('No games vs this opponent data is available.')).toBeVisible();
+  await page.screenshot({ path: testInfo.outputPath('selection-empty-thin.png'), fullPage: true });
   await page.goto('/matchups/0022500584?player=lebron-james');
   await expect(page.getByRole('heading', { name: 'LeBron James', level: 2 })).toBeVisible();
   await page.setViewportSize({ width: 393, height: 852 });

--- a/e2e/specs/matchup-detail.spec.js
+++ b/e2e/specs/matchup-detail.spec.js
@@ -103,7 +103,7 @@ test('matchup renders stale and unavailable surfaces without inventing data', as
         status: 'unavailable',
         unavailable_reason: 'permission_required',
         retrieved_at: null,
-        teams: matchupPayload.injuries.teams.map((team) => ({ ...team, entries: [] })),
+        teams: [],
       },
       freshness: {
         ...matchupPayload.freshness,

--- a/e2e/specs/slate.spec.js
+++ b/e2e/specs/slate.spec.js
@@ -111,6 +111,15 @@ test('signed-out matchups keeps the shared shell and does not redirect', async (
   await expect(page.getByRole('heading', { name: 'Sign in to view the slate' })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Sign in with Google' })).toBeVisible();
   await page.screenshot({ path: testInfo.outputPath('slate-signed-out.png'), fullPage: true });
+
+  await page.goto('/matchups/0022500584?player=2544');
+  await expect(page).toHaveURL('/matchups/0022500584?player=2544');
+  await expect(page.getByRole('heading', { name: 'Sign in to view this matchup' })).toBeVisible();
+  await expect(page.getByRole('navigation', { name: 'Primary' })).toBeVisible();
+  await page.screenshot({
+    path: testInfo.outputPath('matchup-signed-out-deep-link.png'),
+    fullPage: true,
+  });
 });
 
 test('unknown paths return to the search landing page', async ({ page }) => {

--- a/e2e/specs/slate.spec.js
+++ b/e2e/specs/slate.spec.js
@@ -2,7 +2,7 @@ import { expect, installApiContract, slateGame, slatePayload, test } from '../fi
 
 test('@critical authenticated user opens a slate and navigates dates', async ({
   authenticatedPage: page,
-}) => {
+}, testInfo) => {
   await page.clock.setFixedTime(new Date('2026-01-15T12:00:00Z'));
   const requests = [];
   page.on('request', (request) => {
@@ -35,14 +35,12 @@ test('@critical authenticated user opens a slate and navigates dates', async ({
             },
           ],
           {
-            poolStatus: 'fresh',
             poolFreshnessStatus: 'fresh',
             poolRetrievedAt: '2026-01-15T11:50:00Z',
           },
         );
       }
       return slatePayload(date, [slateGame], {
-        poolStatus: 'stale-served',
         poolFreshnessStatus: 'stale-served',
         poolRetrievedAt: '2026-01-15T10:00:00Z',
         providers: {
@@ -74,10 +72,12 @@ test('@critical authenticated user opens a slate and navigates dates', async ({
   await expect(
     page.getByText(/prizepicks pool is stale.*older than 15m freshness bar/i),
   ).toBeVisible();
+  await page.screenshot({ path: testInfo.outputPath('slate-stale-pool.png'), fullPage: true });
 
   await page.getByRole('button', { name: 'Previous date' }).click();
   await expect(page).toHaveURL(/date=2026-01-14/);
   await expect(page.getByText('No games on this slate.')).toBeVisible();
+  await page.screenshot({ path: testInfo.outputPath('slate-empty.png'), fullPage: true });
 
   await page.getByLabel('Slate date').fill('');
   await expect(page).toHaveURL(/\/matchups$/);
@@ -95,10 +95,13 @@ test('@critical authenticated user opens a slate and navigates dates', async ({
   ).toBeVisible();
   await expect(page.getByText('5 targetable')).toBeVisible();
   await expect(page.getByText('4 targetable')).toBeVisible();
+  await page.screenshot({ path: testInfo.outputPath('slate-past.png'), fullPage: true });
   expect(requests.some((url) => new URL(url).searchParams.get('date') === '2026-01-10')).toBe(true);
 });
 
-test('signed-out matchups keeps the shared shell and does not redirect', async ({ page }) => {
+test('signed-out matchups keeps the shared shell and does not redirect', async ({
+  page,
+}, testInfo) => {
   await installApiContract(page);
   await page.goto('/matchups?date=2026-01-15');
 
@@ -107,6 +110,7 @@ test('signed-out matchups keeps the shared shell and does not redirect', async (
   await expect(page.getByRole('link', { name: 'Matchups' })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Sign in to view the slate' })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Sign in with Google' })).toBeVisible();
+  await page.screenshot({ path: testInfo.outputPath('slate-signed-out.png'), fullPage: true });
 });
 
 test('unknown paths return to the search landing page', async ({ page }) => {
@@ -164,7 +168,7 @@ test('an invalid requested date stays neutral until the backend rejects it', asy
 
 test('explicit unavailable pool status wins over stale provider evidence', async ({
   authenticatedPage: page,
-}) => {
+}, testInfo) => {
   await page.clock.setFixedTime(new Date('2026-01-15T12:00:00Z'));
   await installApiContract(page, {
     '/api/games/slate': slatePayload(
@@ -177,7 +181,6 @@ test('explicit unavailable pool status wins over stale provider evidence', async
         },
       ],
       {
-        poolStatus: 'unavailable',
         poolFreshnessStatus: 'unavailable',
         providers: {
           prizepicks: { status: 'stale-served', retrieved_at: '2026-01-15T09:00:00Z' },
@@ -191,6 +194,10 @@ test('explicit unavailable pool status wins over stale provider evidence', async
   await expect(page.getByText(/player pool is unavailable; no targetable players/i)).toBeVisible();
   await expect(page.getByText('prizepicks pool is stale-served — as of 3h ago')).toBeVisible();
   await expect(page.getByText('0 targetable')).toHaveCount(2);
+  await page.screenshot({
+    path: testInfo.outputPath('slate-pool-unavailable.png'),
+    fullPage: true,
+  });
 });
 
 test('minimum slate freshness payload renders through the browser contract', async ({

--- a/src/SlatePage.js
+++ b/src/SlatePage.js
@@ -129,10 +129,10 @@ export default function SlatePage() {
       ? getSurfaceFreshnessPresentation(state.slate.freshness.pool, 'pool', now)
       : null;
   const effectivePoolStatus =
-    state.status === 'ready' && state.slate.poolStatus === 'fresh'
+    state.status === 'ready' && state.slate.freshness.pool.status === 'fresh'
       ? poolPresentation.status
       : state.status === 'ready'
-        ? state.slate.poolStatus
+        ? state.slate.freshness.pool.status
         : null;
 
   useEffect(() => {

--- a/src/SlatePage.test.js
+++ b/src/SlatePage.test.js
@@ -32,7 +32,6 @@ const game = {
 
 const slate = {
   slateDate: '2026-01-15',
-  poolStatus: 'stale-served',
   freshness: {
     schedule: { status: 'fresh', retrievedAt: '2026-01-15T11:50:00.000Z' },
     pool: {
@@ -115,7 +114,6 @@ test('warns when a fresh schedule crosses the 30h bar without refetching', async
 test('labels a fresh pool snapshot stale when it crosses the 15m bar', async () => {
   fetchSlate.mockResolvedValue({
     ...slate,
-    poolStatus: 'fresh',
     freshness: {
       ...slate.freshness,
       pool: {
@@ -182,7 +180,6 @@ test('offers Today as a recovery from an invalid requested date', async () => {
 test('explains mixed provider counts without claiming the whole pool is missing', async () => {
   fetchSlate.mockResolvedValue({
     ...slate,
-    poolStatus: 'partial',
     freshness: {
       ...slate.freshness,
       pool: {
@@ -214,7 +211,6 @@ test.each([
 ])('renders distinct %s pool copy', async (poolStatus, expected) => {
   fetchSlate.mockResolvedValue({
     ...slate,
-    poolStatus,
     freshness: {
       ...slate.freshness,
       pool: { status: poolStatus, retrievedAt: null, providers: [] },
@@ -292,7 +288,6 @@ test.each([
     fetchSlate.mockResolvedValue({
       ...slate,
       slateDate: '2026-01-10',
-      poolStatus,
       freshness: {
         ...slate.freshness,
         pool: {
@@ -342,7 +337,6 @@ test('uses the server slate date for the heading and historical pool state', asy
   fetchSlate.mockResolvedValue({
     ...slate,
     slateDate: '2026-01-14',
-    poolStatus: 'fresh',
     freshness: {
       ...slate.freshness,
       pool: {

--- a/src/matchups/MatchupDetailPage.js
+++ b/src/matchups/MatchupDetailPage.js
@@ -157,11 +157,12 @@ function PlayerRail({
         <div className="player-list">
           {scoped.map((player) => {
             const injury = injuryById.get(player.injuryBadgeRef);
+            const serializedPlayerId = String(player.id);
             return (
               <article
                 key={player.id}
                 aria-label={`${player.name} player`}
-                className={`player-card${selectedId === player.id ? ' selected' : ''}`}
+                className={`player-card${selectedId === serializedPlayerId ? ' selected' : ''}`}
               >
                 <div>
                   <h3>{player.name}</h3>
@@ -175,20 +176,28 @@ function PlayerRail({
                   role="group"
                   aria-label={`${player.name} posted markets`}
                 >
-                  {player.postedMarkets.map((postedMarket) => (
-                    <span key={postedMarket}>{postedMarket}</span>
-                  ))}
+                  {player.postedMarkets.map((postedMarket) => {
+                    const providers = Object.entries(player.provenance)
+                      .filter(([, markets]) => markets.includes(postedMarket))
+                      .map(([provider]) => provider);
+                    const provenanceLabel = `${postedMarket} from ${providers.join(', ')}`;
+                    return (
+                      <span key={postedMarket} aria-label={provenanceLabel} title={provenanceLabel}>
+                        {postedMarket}
+                      </span>
+                    );
+                  })}
                 </div>
                 <Sparkline values={player.last10Minutes} playerName={player.name} />
                 <button
-                  ref={(node) => registerTrigger(player.id, node)}
+                  ref={(node) => registerTrigger(serializedPlayerId, node)}
                   type="button"
                   className="select-player"
-                  aria-expanded={selectedId === player.id}
+                  aria-expanded={selectedId === serializedPlayerId}
                   aria-controls="matchup-selection-card"
                   onClick={() => onSelect(player)}
                 >
-                  {selectedId === player.id ? 'Selected' : 'Open selection card'}
+                  {selectedId === serializedPlayerId ? 'Selected' : 'Open selection card'}
                 </button>
               </article>
             );
@@ -397,7 +406,7 @@ function Detail({ matchup, gameId }) {
   const [windowKey, setWindowKey] = useState('season');
   const [deviation, setDeviation] = useState(1);
   const selectedId = searchParams.get('player');
-  const selectedPlayer = matchup.players.find((player) => player.id === selectedId) || null;
+  const selectedPlayer = matchup.players.find((player) => String(player.id) === selectedId) || null;
   const selectionTriggers = useRef(new Map());
   const previousSelectedId = useRef(null);
   const [selectionState, setSelectionState] = useState({
@@ -461,9 +470,10 @@ function Detail({ matchup, gameId }) {
     previousSelectedId.current = selectedId;
   }, [selectedId]);
   const updateSelectedPlayer = (playerId) => {
-    if (playerId === selectedId) return;
+    const serializedPlayerId = playerId === null ? null : String(playerId);
+    if (serializedPlayerId === selectedId) return;
     const next = new URLSearchParams(searchParams);
-    if (playerId) next.set('player', playerId);
+    if (serializedPlayerId) next.set('player', serializedPlayerId);
     else next.delete('player');
     setSearchParams(next, { replace: false });
   };

--- a/src/matchups/MatchupDetailPage.test.js
+++ b/src/matchups/MatchupDetailPage.test.js
@@ -81,11 +81,12 @@ const matchup = {
   ],
   players: [
     {
-      id: 'player-two',
+      id: 1630559,
       name: 'Austin Reaves',
       teamId: 1,
       tricode: 'LAL',
       postedMarkets: ['PTS', 'FG3A'],
+      provenance: { prizepicks: ['PTS', 'FG3A'], underdog: ['PTS'] },
       seasonScoring: 20.1,
       last10Minutes: [32, 35, 34],
       injuryBadgeRef: 'injury-1',
@@ -101,11 +102,12 @@ const matchup = {
       scores: { PTS: score(0.21, 0.03), FG3A: score(0.07, 0.02) },
     },
     {
-      id: 'player-one',
+      id: 2544,
       name: 'LeBron James',
       teamId: 1,
       tricode: 'LAL',
       postedMarkets: ['PTS', 'FGA'],
+      provenance: { prizepicks: ['PTS', 'FGA'], underdog: ['PTS'] },
       seasonScoring: 25.4,
       last10Minutes: [35, 36, 38],
       injuryBadgeRef: null,
@@ -121,11 +123,12 @@ const matchup = {
       scores: { PTS: score(0.12, -0.01), FGA: score(0.04, 0.02) },
     },
     {
-      id: 'player-three',
+      id: 1628369,
       name: 'Jayson Tatum',
       teamId: 2,
       tricode: 'BOS',
       postedMarkets: ['REB'],
+      provenance: { prizepicks: ['REB'] },
       seasonScoring: 27.2,
       last10Minutes: [36, 37, 38],
       injuryBadgeRef: null,
@@ -168,7 +171,7 @@ beforeEach(() => {
   useAuth.mockReturnValue({ isAuthenticated: true, loading: false });
   fetchMatchup.mockResolvedValue(matchup);
   fetchMatchupSelection.mockResolvedValue({
-    playerId: 'player-one',
+    playerId: 2544,
     h2h: {
       thin: true,
       rows: [
@@ -213,6 +216,11 @@ test('toggles delivered windows and applies a two-sided sigma filter without ref
   expect(screen.getByText(/19% poss/)).toBeVisible();
   expect(screen.getByText(/Austin Reaves · 18% poss/)).toBeVisible();
   expect(screen.getAllByRole('article', { name: /player/i })[0]).toHaveTextContent('LeBron James');
+  expect(
+    within(screen.getByRole('article', { name: 'LeBron James player' })).getByLabelText(
+      'PTS from prizepicks, underdog',
+    ),
+  ).toBeVisible();
 
   await userEvent.click(screen.getByRole('button', { name: 'Last 15' }));
   expect(screen.getByText('-8% vs league')).toBeVisible();
@@ -235,13 +243,13 @@ test('toggles delivered windows and applies a two-sided sigma filter without ref
 
 test('selection keeps All active and highlights only display-eligible shares for each window', async () => {
   const candidate = JSON.parse(JSON.stringify(matchup));
-  candidate.players.find((player) => player.id === 'player-one').dietShares.playTypes[0].season = {
+  candidate.players.find((player) => player.id === 2544).dietShares.playTypes[0].season = {
     share: 0.02,
     volumePerGame: 5,
   };
   fetchMatchup.mockResolvedValueOnce(candidate);
   render(
-    <MemoryRouter initialEntries={['/matchups/game-1?player=player-one']}>
+    <MemoryRouter initialEntries={['/matchups/game-1?player=2544']}>
       <Routes>
         <Route path="/matchups/:gameId" element={<MatchupDetailPage />} />
       </Routes>
@@ -263,15 +271,15 @@ test('a late selection response cannot replace a newer player selection', async 
     resolveFirst = resolve;
   });
   const austin = {
-    playerId: 'player-two',
+    playerId: 1630559,
     h2h: { thin: false, rows: [] },
     archetype: { thin: false, rows: [] },
   };
   fetchMatchupSelection.mockImplementation((_gameId, playerId) =>
-    playerId === 'player-one' ? first : Promise.resolve(austin),
+    playerId === 2544 ? first : Promise.resolve(austin),
   );
   render(
-    <MemoryRouter initialEntries={['/matchups/game-1?player=player-one']}>
+    <MemoryRouter initialEntries={['/matchups/game-1?player=2544']}>
       <Routes>
         <Route path="/matchups/:gameId" element={<MatchupDetailPage />} />
       </Routes>
@@ -285,7 +293,7 @@ test('a late selection response cannot replace a newer player selection', async 
   );
   expect(await screen.findByRole('heading', { name: 'Austin Reaves', level: 2 })).toBeVisible();
   resolveFirst({
-    playerId: 'player-one',
+    playerId: 2544,
     h2h: { thin: false, rows: [] },
     archetype: { thin: false, rows: [] },
   });
@@ -347,7 +355,7 @@ test('renders raw injury statuses and keeps the signed-out shell honest', async 
 
 test('opens and deep-links the selection card while market flips reuse delivered logs', async () => {
   render(
-    <MemoryRouter initialEntries={['/matchups/game-1?player=player-one']}>
+    <MemoryRouter initialEntries={['/matchups/game-1?player=2544']}>
       <Routes>
         <Route path="/matchups/:gameId" element={<MatchupDetailPage />} />
       </Routes>
@@ -377,7 +385,7 @@ test('player switches clamp the card stat and team toggles remain user-controlle
   });
   fetchMatchupSelection.mockImplementation((_gameId, playerId) => Promise.resolve(empty(playerId)));
   render(
-    <MemoryRouter initialEntries={['/matchups/game-1?player=player-one']}>
+    <MemoryRouter initialEntries={['/matchups/game-1?player=2544']}>
       <Routes>
         <Route path="/matchups/:gameId" element={<MatchupDetailPage />} />
       </Routes>
@@ -435,7 +443,7 @@ test('card stat choices persist while a different global sheet market remains ac
 test('selection request errors replace loading with an honest alert', async () => {
   fetchMatchupSelection.mockRejectedValueOnce(new Error('selection failed'));
   render(
-    <MemoryRouter initialEntries={['/matchups/game-1?player=player-one']}>
+    <MemoryRouter initialEntries={['/matchups/game-1?player=2544']}>
       <Routes>
         <Route path="/matchups/:gameId" element={<MatchupDetailPage />} />
       </Routes>

--- a/src/matchups/matchupApi.js
+++ b/src/matchups/matchupApi.js
@@ -234,7 +234,7 @@ const validateLeagueCoverage = (league, teams) => {
     const teamKeys = new Set(
       teams.flatMap((team) => team.defenseSheet[base].map((row) => row.key)),
     );
-    if (leagueKeys.size !== teamKeys.size || [...leagueKeys].some((key) => !teamKeys.has(key))) {
+    if ([...teamKeys].some((key) => !leagueKeys.has(key))) {
       throw invalid();
     }
   }
@@ -402,7 +402,23 @@ const decodeInjuries = (injuries, matchupTeams) => {
   if (!isRecord(injuries) || !['fresh', 'stale', 'unavailable'].includes(injuries.status)) {
     throw invalid();
   }
-  if (!Array.isArray(injuries.teams) || injuries.teams.length !== matchupTeams.length) {
+  if (!Object.hasOwn(injuries, 'unavailable_reason') || !Object.hasOwn(injuries, 'retrieved_at')) {
+    throw invalid();
+  }
+  const unavailableReasons = ['disabled', 'permission_required', 'fetch_failed', null];
+  if (
+    !unavailableReasons.includes(injuries.unavailable_reason) ||
+    (injuries.status === 'unavailable' && injuries.unavailable_reason === null) ||
+    (injuries.status !== 'unavailable' && injuries.unavailable_reason !== null)
+  ) {
+    throw invalid();
+  }
+  if (
+    !Array.isArray(injuries.teams) ||
+    (injuries.status === 'unavailable'
+      ? ![0, matchupTeams.length].includes(injuries.teams.length)
+      : injuries.teams.length !== matchupTeams.length)
+  ) {
     throw invalid();
   }
   const expectedTeams = new Map(matchupTeams.map((team) => [team.teamId, team.tricode]));

--- a/src/matchups/matchupApi.js
+++ b/src/matchups/matchupApi.js
@@ -26,6 +26,10 @@ const requireNumber = (value) => {
   if (typeof value !== 'number' || !Number.isFinite(value)) throw invalid();
   return value;
 };
+const requireInteger = (value) => {
+  if (!Number.isInteger(value)) throw invalid();
+  return value;
+};
 const requireStringList = (value) => {
   if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) throw invalid();
   return value;
@@ -54,7 +58,12 @@ const decodeSheetRow = (row) => {
 };
 
 const decodeDefenseSheet = (sheet) => {
-  if (!isRecord(sheet) || Object.keys(sheet).length === 0) throw invalid();
+  if (
+    !isRecord(sheet) ||
+    Object.keys(sheet).sort().join() !==
+      ['play_types', 'shot_zones', 'shot_types', 'assist_locations', 'traditional'].sort().join()
+  )
+    throw invalid();
   return Object.fromEntries(
     Object.entries(sheet).map(([base, rows]) => {
       if (!Array.isArray(rows)) throw invalid();
@@ -129,11 +138,12 @@ const decodePlayer = (player) => {
   if (!isRecord(player) || !Number.isInteger(player.team_id)) throw invalid();
   if (!Array.isArray(player.last_10_minutes)) throw invalid();
   return {
-    id: requireString(player.canonical_id),
+    id: requireInteger(player.canonical_id),
     name: requireString(player.name),
     teamId: player.team_id,
     tricode: requireString(player.tricode),
     postedMarkets: requireStringList(player.posted_markets),
+    provenance: decodeProvenance(player.provenance, player.posted_markets),
     seasonScoring: requireNumber(player.season_scoring),
     last10Minutes: player.last_10_minutes.map(requireNumber),
     dietShares: decodeDietShares(player.diet_shares),
@@ -141,6 +151,93 @@ const decodePlayer = (player) => {
       player.injury_badge_ref === null ? null : requireString(player.injury_badge_ref),
     scores: decodeScores(player.scores, player.posted_markets),
   };
+};
+
+function decodeProvenance(provenance, postedMarkets) {
+  if (!isRecord(provenance) || Object.keys(provenance).length === 0) throw invalid();
+  const decoded = Object.fromEntries(
+    Object.entries(provenance).map(([provider, markets]) => {
+      if (!provider || !Array.isArray(markets) || markets.length === 0) throw invalid();
+      const categories = requireStringList(markets);
+      if (categories.some((market) => !postedMarkets.includes(market))) throw invalid();
+      return [provider, categories];
+    }),
+  );
+  if (
+    postedMarkets.some(
+      (market) => !Object.values(decoded).some((markets) => markets.includes(market)),
+    )
+  ) {
+    throw invalid();
+  }
+  return decoded;
+}
+
+const DEFENSE_BASES = ['play_types', 'shot_zones', 'shot_types', 'assist_locations', 'traditional'];
+
+const decodeLeagueRowWindow = (value) => {
+  if (!isRecord(value)) throw invalid();
+  return {
+    averageAllowedPer48: requireNumber(value.average_allowed_per_48),
+    sigma: requireNumber(value.sigma),
+  };
+};
+
+const decodeLeague = (league) => {
+  if (!isRecord(league) || !isRecord(league.defense_sheet) || !isRecord(league.defensive_columns)) {
+    throw invalid();
+  }
+  if (Object.keys(league.defense_sheet).sort().join() !== [...DEFENSE_BASES].sort().join()) {
+    throw invalid();
+  }
+  const defenseSheet = Object.fromEntries(
+    DEFENSE_BASES.map((base) => {
+      const rows = league.defense_sheet[base];
+      if (!Array.isArray(rows)) throw invalid();
+      const decodedRows = rows.map((row) => {
+        if (!isRecord(row)) throw invalid();
+        return {
+          key: requireString(row.key),
+          season: decodeLeagueRowWindow(row.season),
+          last15: decodeLeagueRowWindow(row.last_15),
+        };
+      });
+      if (new Set(decodedRows.map((row) => row.key)).size !== decodedRows.length) throw invalid();
+      return [camelKey(base), decodedRows];
+    }),
+  );
+  const defensiveColumns = Object.fromEntries(
+    DEFENSIVE_COLUMN_KEYS.map((key) => {
+      const column = league.defensive_columns[key];
+      if (!isRecord(column)) throw invalid();
+      const decodeWindow = (value) => {
+        if (!isRecord(value)) throw invalid();
+        return {
+          averagePer48: requireNumber(value.average_per_48),
+          sigma: requireNumber(value.sigma),
+        };
+      };
+      return [key, { season: decodeWindow(column.season), last15: decodeWindow(column.last_15) }];
+    }),
+  );
+  if (
+    Object.keys(league.defensive_columns).sort().join() !== [...DEFENSIVE_COLUMN_KEYS].sort().join()
+  ) {
+    throw invalid();
+  }
+  return { defenseSheet, defensiveColumns };
+};
+
+const validateLeagueCoverage = (league, teams) => {
+  for (const [base, leagueRows] of Object.entries(league.defenseSheet)) {
+    const leagueKeys = new Set(leagueRows.map((row) => row.key));
+    const teamKeys = new Set(
+      teams.flatMap((team) => team.defenseSheet[base].map((row) => row.key)),
+    );
+    if (leagueKeys.size !== teamKeys.size || [...leagueKeys].some((key) => !teamKeys.has(key))) {
+      throw invalid();
+    }
+  }
 };
 
 const decodeScoreCell = (cell) => {
@@ -289,9 +386,10 @@ const decodeInjuryEntry = (entry) => {
   }
   return {
     id: requireString(entry.entry_id),
-    playerId: entry.canonical_player_id,
+    sourcePlayerId: entry.source_player_id === null ? null : requireString(entry.source_player_id),
+    playerId: entry.canonical_player_id === null ? null : requireInteger(entry.canonical_player_id),
     playerName: requireString(entry.source_player_name),
-    teamId: entry.team_id,
+    teamId: requireInteger(entry.team_id),
     tricode: requireString(entry.tricode),
     status: entry.status || null,
     rawStatus: entry.raw_status || null,
@@ -300,11 +398,15 @@ const decodeInjuryEntry = (entry) => {
   };
 };
 
-const decodeInjuries = (injuries) => {
+const decodeInjuries = (injuries, matchupTeams) => {
   if (!isRecord(injuries) || !['fresh', 'stale', 'unavailable'].includes(injuries.status)) {
     throw invalid();
   }
-  if (!Array.isArray(injuries.teams)) throw invalid();
+  if (!Array.isArray(injuries.teams) || injuries.teams.length !== matchupTeams.length) {
+    throw invalid();
+  }
+  const expectedTeams = new Map(matchupTeams.map((team) => [team.teamId, team.tricode]));
+  const seenTeams = new Set();
   return {
     status: injuries.status,
     unavailableReason: injuries.unavailable_reason || null,
@@ -312,12 +414,27 @@ const decodeInjuries = (injuries) => {
     source: requireString(injuries.source),
     sourceUrl: requireString(injuries.source_url),
     teams: injuries.teams.map((team) => {
-      if (!isRecord(team) || !Array.isArray(team.entries)) throw invalid();
+      if (
+        !isRecord(team) ||
+        !Array.isArray(team.entries) ||
+        !Number.isInteger(team.team_id) ||
+        team.submission_state !== 'unknown'
+      )
+        throw invalid();
+      const tricode = requireString(team.tricode);
+      if (seenTeams.has(team.team_id) || expectedTeams.get(team.team_id) !== tricode) {
+        throw invalid();
+      }
+      seenTeams.add(team.team_id);
+      const entries = team.entries.map(decodeInjuryEntry);
+      if (entries.some((entry) => entry.teamId !== team.team_id || entry.tricode !== tricode)) {
+        throw invalid();
+      }
       return {
         teamId: team.team_id,
-        tricode: requireString(team.tricode),
-        submissionState: team.submission_state || null,
-        entries: team.entries.map(decodeInjuryEntry),
+        tricode,
+        submissionState: team.submission_state,
+        entries,
       };
     }),
   };
@@ -333,11 +450,15 @@ export const decodeMatchup = (data) => {
   ) {
     throw invalid();
   }
+  const league = decodeLeague(data.league);
+  const teams = data.teams.map(decodeTeam);
+  validateLeagueCoverage(league, teams);
   return {
     game: decodeGame(data.game),
-    teams: data.teams.map(decodeTeam),
+    league,
+    teams,
     players: data.players.map(decodePlayer),
-    injuries: decodeInjuries(data.injuries),
+    injuries: decodeInjuries(data.injuries, teams),
     freshness: decodeFreshness(data.freshness),
   };
 };
@@ -399,7 +520,9 @@ const decodeLogTable = (table, markets) => {
 export const decodeMatchupSelection = (data, postedMarkets, expectedPlayerId) => {
   if (!isRecord(data) || !Array.isArray(postedMarkets) || postedMarkets.length === 0)
     throw selectionInvalid();
-  if (data.player_id !== expectedPlayerId) throw selectionInvalid();
+  if (!Number.isInteger(data.player_id) || data.player_id !== expectedPlayerId) {
+    throw selectionInvalid();
+  }
   return {
     playerId: data.player_id,
     h2h: decodeLogTable(data.h2h, postedMarkets),
@@ -408,6 +531,14 @@ export const decodeMatchupSelection = (data, postedMarkets, expectedPlayerId) =>
 };
 
 export const fetchMatchupSelection = async (gameId, playerId, postedMarkets, { signal } = {}) => {
+  if (
+    typeof gameId !== 'string' ||
+    !gameId ||
+    !Number.isInteger(playerId) ||
+    !Array.isArray(postedMarkets) ||
+    postedMarkets.length === 0
+  )
+    throw selectionInvalid();
   const response = await apiClient.get(getApiUrl('MATCHUP_SELECTION'), {
     params: { game_id: gameId, player_id: playerId },
     signal,

--- a/src/matchups/matchupApi.test.js
+++ b/src/matchups/matchupApi.test.js
@@ -278,6 +278,62 @@ test('strictly decodes injury identities and enforces the v1 team envelope', () 
   expect(() => decodeMatchup(missingSourceId)).toThrow('invalid response');
 });
 
+test('accepts unavailable injuries with an honest empty team envelope', () => {
+  const unavailable = {
+    ...payload,
+    injuries: { ...payload.injuries, teams: [] },
+  };
+  expect(decodeMatchup(unavailable).injuries).toEqual(
+    expect.objectContaining({
+      status: 'unavailable',
+      unavailableReason: 'permission_required',
+      teams: [],
+    }),
+  );
+
+  const staleWithoutTeams = {
+    ...payload,
+    injuries: {
+      ...payload.injuries,
+      status: 'stale',
+      unavailable_reason: null,
+      retrieved_at: '2026-01-15T11:00:00Z',
+      teams: [],
+    },
+  };
+  expect(() => decodeMatchup(staleWithoutTeams)).toThrow('invalid response');
+
+  const missingReason = JSON.parse(JSON.stringify(unavailable));
+  delete missingReason.injuries.unavailable_reason;
+  expect(() => decodeMatchup(missingReason)).toThrow('invalid response');
+  const unavailableWithoutReason = JSON.parse(JSON.stringify(unavailable));
+  unavailableWithoutReason.injuries.unavailable_reason = null;
+  expect(() => decodeMatchup(unavailableWithoutReason)).toThrow('invalid response');
+});
+
+test('accepts league taxonomy rows that neither matchup team happens to use', () => {
+  const extraLeagueRow = {
+    ...payload,
+    league: {
+      ...payload.league,
+      defense_sheet: {
+        ...payload.league.defense_sheet,
+        play_types: [
+          ...payload.league.defense_sheet.play_types,
+          {
+            key: 'handoff',
+            season: { average_allowed_per_48: 7.2, sigma: 0.7 },
+            last_15: { average_allowed_per_48: 7.4, sigma: 0.8 },
+          },
+        ],
+      },
+    },
+  };
+  expect(decodeMatchup(extraLeagueRow).league.defenseSheet.playTypes).toEqual(
+    expect.arrayContaining([expect.objectContaining({ key: 'handoff' })]),
+  );
+});
+
 test('requires Blend for offensive scores and accepts omitted or null Blend for defensive scores', () => {
   const defensive = JSON.parse(JSON.stringify(payload));
   defensive.players[0].posted_markets = ['TOV'];
@@ -329,26 +385,6 @@ test.each([
       league: {
         ...payload.league,
         defense_sheet: { ...payload.league.defense_sheet, play_types: [] },
-      },
-    },
-  ],
-  [
-    'unknown league row',
-    {
-      ...payload,
-      league: {
-        ...payload.league,
-        defense_sheet: {
-          ...payload.league.defense_sheet,
-          play_types: [
-            ...payload.league.defense_sheet.play_types,
-            {
-              key: 'unknown',
-              season: { average_allowed_per_48: 1, sigma: 1 },
-              last_15: { average_allowed_per_48: 1, sigma: 1 },
-            },
-          ],
-        },
       },
     },
   ],

--- a/src/matchups/matchupApi.test.js
+++ b/src/matchups/matchupApi.test.js
@@ -1,4 +1,10 @@
-import { decodeMatchup, decodeMatchupSelection } from './matchupApi';
+import { apiClient } from '../config';
+import { decodeMatchup, decodeMatchupSelection, fetchMatchupSelection } from './matchupApi';
+
+jest.mock('../config', () => ({
+  apiClient: { get: jest.fn() },
+  getApiUrl: jest.fn(() => '/api/games/matchup/selection'),
+}));
 
 const payload = {
   game: {
@@ -8,6 +14,30 @@ const payload = {
     scheduled_at: '2026-01-16T00:30:00Z',
     status: { state: 'scheduled', label: 'Scheduled' },
     preseason: false,
+  },
+  league: {
+    defense_sheet: {
+      play_types: [
+        {
+          key: 'transition',
+          season: { average_allowed_per_48: 16.4, sigma: 1.4 },
+          last_15: { average_allowed_per_48: 16.2, sigma: 1.2 },
+        },
+      ],
+      shot_zones: [],
+      shot_types: [],
+      assist_locations: [],
+      traditional: [],
+    },
+    defensive_columns: Object.fromEntries(
+      ['OPP_TOV', 'OPP_STL', 'OPP_BLK'].map((key) => [
+        key,
+        {
+          season: { average_per_48: 10, sigma: 1 },
+          last_15: { average_per_48: 11, sigma: 1.1 },
+        },
+      ]),
+    ),
   },
   teams: [
     {
@@ -34,6 +64,10 @@ const payload = {
             },
           },
         ],
+        shot_zones: [],
+        shot_types: [],
+        assist_locations: [],
+        traditional: [],
       },
       defensive_columns: {
         OPP_TOV: {
@@ -54,7 +88,13 @@ const payload = {
       team_id: 2,
       tricode: 'BOS',
       name: 'Boston Celtics',
-      defense_sheet: { play_types: [] },
+      defense_sheet: {
+        play_types: [],
+        shot_zones: [],
+        shot_types: [],
+        assist_locations: [],
+        traditional: [],
+      },
       defensive_columns: {
         OPP_TOV: {
           season: { per_48: 12, percent_vs_league_average: -4 },
@@ -73,11 +113,12 @@ const payload = {
   ],
   players: [
     {
-      canonical_id: 'lebron-james',
+      canonical_id: 2544,
       name: 'LeBron James',
       team_id: 1,
       tricode: 'LAL',
       posted_markets: ['PTS', 'FGA'],
+      provenance: { prizepicks: ['PTS', 'FGA'], underdog: ['PTS'] },
       season_scoring: 25.4,
       last_10_minutes: [35, 36],
       diet_shares: {
@@ -120,7 +161,10 @@ const payload = {
     retrieved_at: null,
     source: 'rotowire',
     source_url: 'https://example.com/injuries',
-    teams: [],
+    teams: [
+      { team_id: 1, tricode: 'LAL', submission_state: 'unknown', entries: [] },
+      { team_id: 2, tricode: 'BOS', submission_state: 'unknown', entries: [] },
+    ],
   },
   freshness: {
     schedule: { status: 'fresh', retrieved_at: '2026-01-15T10:00:00Z' },
@@ -142,8 +186,9 @@ test('decodes both delivered windows and preserves relative values', () => {
   );
   expect(matchup.players[0]).toEqual(
     expect.objectContaining({
-      id: 'lebron-james',
+      id: 2544,
       postedMarkets: ['PTS', 'FGA'],
+      provenance: { prizepicks: ['PTS', 'FGA'], underdog: ['PTS'] },
       scores: expect.objectContaining({
         PTS: expect.objectContaining({
           season: expect.objectContaining({ blend: { value: 0.12, thin: false } }),
@@ -160,6 +205,11 @@ test('decodes both delivered windows and preserves relative values', () => {
   expect(matchup.teams[0].defensiveColumns.OPP_TOV.season).toEqual({
     per48: 14.2,
     percentVsLeagueAverage: 8,
+  });
+  expect(matchup.league.defenseSheet.playTypes[0]).toEqual({
+    key: 'transition',
+    season: { averageAllowedPer48: 16.4, sigma: 1.4 },
+    last15: { averageAllowedPer48: 16.2, sigma: 1.2 },
   });
 });
 
@@ -186,9 +236,52 @@ test('accepts clarified freshness with derived schedule and provider-only pool t
   );
 });
 
+test('strictly decodes injury identities and enforces the v1 team envelope', () => {
+  const injuryPayload = JSON.parse(JSON.stringify(payload));
+  injuryPayload.injuries = {
+    ...injuryPayload.injuries,
+    teams: [
+      {
+        team_id: 1,
+        tricode: 'LAL',
+        submission_state: 'unknown',
+        entries: [
+          {
+            entry_id: 'injury-1',
+            source_player_id: 'source-1',
+            canonical_player_id: 2544,
+            source_player_name: 'LeBron James',
+            team_id: 1,
+            tricode: 'LAL',
+            status: 'Questionable',
+            raw_status: 'Questionable',
+            reason: 'Left ankle soreness',
+            source_url: 'https://example.com/injury-1',
+          },
+        ],
+      },
+      { team_id: 2, tricode: 'BOS', submission_state: 'unknown', entries: [] },
+    ],
+  };
+  expect(decodeMatchup(injuryPayload).injuries.teams[0].entries[0]).toEqual(
+    expect.objectContaining({ sourcePlayerId: 'source-1', playerId: 2544, teamId: 1 }),
+  );
+
+  const wrongTeam = JSON.parse(JSON.stringify(injuryPayload));
+  wrongTeam.injuries.teams[0].entries[0].team_id = 2;
+  expect(() => decodeMatchup(wrongTeam)).toThrow('invalid response');
+  const inventedSubmission = JSON.parse(JSON.stringify(injuryPayload));
+  inventedSubmission.injuries.teams[0].submission_state = 'submitted';
+  expect(() => decodeMatchup(inventedSubmission)).toThrow('invalid response');
+  const missingSourceId = JSON.parse(JSON.stringify(injuryPayload));
+  delete missingSourceId.injuries.teams[0].entries[0].source_player_id;
+  expect(() => decodeMatchup(missingSourceId)).toThrow('invalid response');
+});
+
 test('requires Blend for offensive scores and accepts omitted or null Blend for defensive scores', () => {
   const defensive = JSON.parse(JSON.stringify(payload));
   defensive.players[0].posted_markets = ['TOV'];
+  defensive.players[0].provenance = { prizepicks: ['TOV'] };
   defensive.players[0].scores = {
     TOV: {
       season: { components: { traditional: { value: 0.08, thin: false } } },
@@ -228,13 +321,71 @@ test.each([
     },
   ],
   ['invalid game', { ...payload, game: { ...payload.game, scheduled_at: 'not-a-date' } }],
+  ['missing league', { ...payload, league: undefined }],
+  [
+    'missing matching league row',
+    {
+      ...payload,
+      league: {
+        ...payload.league,
+        defense_sheet: { ...payload.league.defense_sheet, play_types: [] },
+      },
+    },
+  ],
+  [
+    'unknown league row',
+    {
+      ...payload,
+      league: {
+        ...payload.league,
+        defense_sheet: {
+          ...payload.league.defense_sheet,
+          play_types: [
+            ...payload.league.defense_sheet.play_types,
+            {
+              key: 'unknown',
+              season: { average_allowed_per_48: 1, sigma: 1 },
+              last_15: { average_allowed_per_48: 1, sigma: 1 },
+            },
+          ],
+        },
+      },
+    },
+  ],
+  [
+    'missing defensive column league denominator',
+    {
+      ...payload,
+      league: {
+        ...payload.league,
+        defensive_columns: Object.fromEntries(
+          Object.entries(payload.league.defensive_columns).filter(([key]) => key !== 'OPP_BLK'),
+        ),
+      },
+    },
+  ],
+  [
+    'string canonical player id',
+    { ...payload, players: [{ ...payload.players[0], canonical_id: '2544' }] },
+  ],
+  [
+    'uncovered posted market provenance',
+    { ...payload, players: [{ ...payload.players[0], provenance: { prizepicks: ['PTS'] } }] },
+  ],
+  [
+    'unposted provenance category',
+    {
+      ...payload,
+      players: [{ ...payload.players[0], provenance: { prizepicks: ['PTS', 'REB'] } }],
+    },
+  ],
 ])('rejects %s at the response boundary', (_name, candidate) => {
   expect(() => decodeMatchup(candidate)).toThrow('invalid response');
 });
 
 test('strictly decodes combo, attempts, and AVG rows from the raw selection response', () => {
   const raw = {
-    player_id: 'lebron-james',
+    player_id: 2544,
     h2h: {
       thin: false,
       rows: [
@@ -258,22 +409,38 @@ test('strictly decodes combo, attempts, and AVG rows from the raw selection resp
     },
     archetype: { thin: false, rows: [] },
   };
-  const selection = decodeMatchupSelection(raw, ['PRA', 'FGA'], 'lebron-james');
+  const selection = decodeMatchupSelection(raw, ['PRA', 'FGA'], 2544);
   expect(selection.h2h.rows.at(-1)).toEqual(
     expect.objectContaining({ average: true, deltas: { PRA: 0.102, FGA: 0.018 } }),
   );
   expect(selection.archetype.rows).toEqual([]);
-  expect(() => decodeMatchupSelection(raw, ['PRA', 'AST'], 'lebron-james')).toThrow(
+  expect(() => decodeMatchupSelection(raw, ['PRA', 'AST'], 2544)).toThrow(
     'selection endpoint returned an invalid response',
   );
-  expect(() => decodeMatchupSelection(raw, ['PRA', 'FGA'], 'another-player')).toThrow(
+  expect(() => decodeMatchupSelection(raw, ['PRA', 'FGA'], 1630559)).toThrow(
     'selection endpoint returned an invalid response',
   );
   expect(() =>
-    decodeMatchupSelection(
-      { ...raw, h2h: { ...raw.h2h, thin: 'yes' } },
-      ['PRA', 'FGA'],
-      'lebron-james',
-    ),
+    decodeMatchupSelection({ ...raw, h2h: { ...raw.h2h, thin: 'yes' } }, ['PRA', 'FGA'], 2544),
   ).toThrow('selection endpoint returned an invalid response');
+});
+
+test('selection requests keep the game string and canonical player integer distinct', async () => {
+  const response = {
+    player_id: 2544,
+    h2h: { thin: false, rows: [] },
+    archetype: { thin: false, rows: [] },
+  };
+  apiClient.get.mockResolvedValueOnce({ data: response });
+  await expect(fetchMatchupSelection('0022500584', 2544, ['PTS'])).resolves.toEqual(
+    expect.objectContaining({ playerId: 2544 }),
+  );
+  expect(apiClient.get).toHaveBeenCalledWith('/api/games/matchup/selection', {
+    params: { game_id: '0022500584', player_id: 2544 },
+    signal: undefined,
+  });
+  await expect(fetchMatchupSelection('0022500584', '2544', ['PTS'])).rejects.toThrow(
+    'selection endpoint returned an invalid response',
+  );
+  expect(apiClient.get).toHaveBeenCalledTimes(1);
 });

--- a/src/slateApi.js
+++ b/src/slateApi.js
@@ -128,13 +128,7 @@ const decodeGame = (game) => {
 };
 
 export const decodeSlate = (data) => {
-  if (
-    !data ||
-    !isCalendarDate(data.slate_date) ||
-    !Array.isArray(data.games) ||
-    !data.freshness ||
-    (data.pool_status !== undefined && !isStatusAllowed(data.pool_status, 'pool'))
-  ) {
+  if (!data || !isCalendarDate(data.slate_date) || !Array.isArray(data.games) || !data.freshness) {
     throw createInvalidSlateError();
   }
 
@@ -143,7 +137,7 @@ export const decodeSlate = (data) => {
   return {
     slateDate: data.slate_date,
     freshness,
-    poolStatus: data.pool_status ?? freshness.pool.status,
+    poolStatus: freshness.pool.status,
     games: data.games.map(decodeGame),
   };
 };

--- a/src/slateApi.js
+++ b/src/slateApi.js
@@ -137,7 +137,6 @@ export const decodeSlate = (data) => {
   return {
     slateDate: data.slate_date,
     freshness,
-    poolStatus: freshness.pool.status,
     games: data.games.map(decodeGame),
   };
 };

--- a/src/slateApi.test.js
+++ b/src/slateApi.test.js
@@ -19,7 +19,6 @@ const payload = {
       },
     },
   },
-  pool_status: 'stale-served',
   games: [
     {
       game_id: '0022500584',
@@ -103,8 +102,6 @@ test.each([
       },
     },
   ],
-  ['unknown aggregate pool status', { ...payload, pool_status: 'old' }],
-  ['frontend-derived aggregate pool status', { ...payload, pool_status: 'partial' }],
   [
     'frontend-derived pool freshness status',
     {
@@ -134,7 +131,6 @@ test('accepts schedule staleness and an unavailable aggregate pool from the back
   expect(
     decodeSlate({
       ...payload,
-      pool_status: 'unavailable',
       freshness: {
         schedule: { status: 'stale', retrieved_at: '2026-01-13T10:00:00Z' },
         pool: { status: 'unavailable', retrieved_at: null, providers: {} },
@@ -151,11 +147,15 @@ test('accepts schedule staleness and an unavailable aggregate pool from the back
   );
 });
 
-test('derives the aggregate pool status when the optional top-level field is absent', () => {
-  const { pool_status: _poolStatus, ...minimumPayload } = payload;
-  minimumPayload.freshness = {
-    ...minimumPayload.freshness,
-    pool: { status: 'fresh', retrieved_at: '2026-01-15T09:55:00Z' },
+test('uses the normative nested aggregate pool status', () => {
+  const minimumPayload = {
+    ...payload,
+    // A legacy, non-contract field cannot override the normative nested surface.
+    pool_status: 'unavailable',
+    freshness: {
+      ...payload.freshness,
+      pool: { status: 'fresh', retrieved_at: '2026-01-15T09:55:00Z' },
+    },
   };
 
   expect(decodeSlate(minimumPayload)).toEqual(
@@ -169,38 +169,33 @@ test('derives the aggregate pool status when the optional top-level field is abs
 });
 
 test.each([
-  ['unavailable', 'stale-served', 'stale-served', 'unavailable'],
-  ['fresh', 'unavailable', 'missing', 'fresh'],
-  [undefined, 'stale-served', 'fresh', 'stale-served'],
-])(
-  'uses aggregate %s with pool freshness %s and provider freshness %s',
-  (aggregateStatus, poolFreshnessStatus, providerStatus, expected) => {
-    const candidate = {
-      ...payload,
-      freshness: {
-        ...payload.freshness,
-        pool: {
-          status: poolFreshnessStatus,
-          retrieved_at: ['missing', 'unavailable'].includes(poolFreshnessStatus)
-            ? null
-            : '2026-01-15T09:55:00Z',
-          providers: {
-            prizepicks: {
-              status: providerStatus,
-              retrieved_at: ['missing', 'unavailable'].includes(providerStatus)
-                ? null
-                : '2026-01-15T09:55:00Z',
-            },
+  ['stale-served', 'stale-served'],
+  ['unavailable', 'unavailable'],
+  ['fresh', 'fresh'],
+])('uses nested aggregate pool freshness %s', (poolFreshnessStatus, expected) => {
+  const candidate = {
+    ...payload,
+    freshness: {
+      ...payload.freshness,
+      pool: {
+        status: poolFreshnessStatus,
+        retrieved_at: ['missing', 'unavailable'].includes(poolFreshnessStatus)
+          ? null
+          : '2026-01-15T09:55:00Z',
+        providers: {
+          prizepicks: {
+            status: poolFreshnessStatus === 'unavailable' ? 'missing' : poolFreshnessStatus,
+            retrieved_at: ['missing', 'unavailable'].includes(poolFreshnessStatus)
+              ? null
+              : '2026-01-15T09:55:00Z',
           },
         },
       },
-    };
-    if (aggregateStatus === undefined) delete candidate.pool_status;
-    else candidate.pool_status = aggregateStatus;
+    },
+  };
 
-    expect(decodeSlate(candidate).poolStatus).toBe(expected);
-  },
-);
+  expect(decodeSlate(candidate).poolStatus).toBe(expected);
+});
 
 test('derives missing pool freshness status from provider evidence', () => {
   const candidate = {
@@ -218,8 +213,6 @@ test('derives missing pool freshness status from provider evidence', () => {
       },
     },
   };
-  delete candidate.pool_status;
-
   expect(decodeSlate(candidate)).toEqual(
     expect.objectContaining({
       poolStatus: 'stale-served',
@@ -258,8 +251,6 @@ test.each([
       },
     },
   };
-  delete candidate.pool_status;
-
   expect(decodeSlate(candidate).poolStatus).toBe(expected);
 });
 
@@ -276,8 +267,6 @@ test('accepts provider freshness without a pool-level retrieved_at', () => {
       },
     },
   };
-  delete candidate.pool_status;
-
   expect(decodeSlate(candidate)).toEqual(
     expect.objectContaining({
       poolStatus: 'partial',
@@ -306,8 +295,6 @@ test.each([
     ...payload,
     freshness: { ...payload.freshness, pool: { providers } },
   };
-  delete candidate.pool_status;
-
   expect(decodeSlate(candidate).freshness.pool).toEqual(
     expect.objectContaining({
       status: 'fresh',

--- a/src/slateApi.test.js
+++ b/src/slateApi.test.js
@@ -60,7 +60,6 @@ test('decodes the complete slate freshness boundary and team counts', () => {
         ],
       },
     },
-    poolStatus: 'stale-served',
     games: [
       expect.objectContaining({
         gameId: '0022500584',
@@ -138,7 +137,6 @@ test('accepts schedule staleness and an unavailable aggregate pool from the back
     }),
   ).toEqual(
     expect.objectContaining({
-      poolStatus: 'unavailable',
       freshness: {
         schedule: { status: 'stale', retrievedAt: '2026-01-13T10:00:00.000Z' },
         pool: { status: 'unavailable', retrievedAt: null, providers: [] },
@@ -158,9 +156,10 @@ test('uses the normative nested aggregate pool status', () => {
     },
   };
 
-  expect(decodeSlate(minimumPayload)).toEqual(
+  const decoded = decodeSlate(minimumPayload);
+  expect(decoded).not.toHaveProperty('poolStatus');
+  expect(decoded).toEqual(
     expect.objectContaining({
-      poolStatus: 'fresh',
       freshness: expect.objectContaining({
         pool: expect.objectContaining({ status: 'fresh', providers: [] }),
       }),
@@ -194,7 +193,7 @@ test.each([
     },
   };
 
-  expect(decodeSlate(candidate).poolStatus).toBe(expected);
+  expect(decodeSlate(candidate).freshness.pool.status).toBe(expected);
 });
 
 test('derives missing pool freshness status from provider evidence', () => {
@@ -215,7 +214,6 @@ test('derives missing pool freshness status from provider evidence', () => {
   };
   expect(decodeSlate(candidate)).toEqual(
     expect.objectContaining({
-      poolStatus: 'stale-served',
       freshness: expect.objectContaining({
         pool: expect.objectContaining({
           status: 'stale-served',
@@ -251,7 +249,7 @@ test.each([
       },
     },
   };
-  expect(decodeSlate(candidate).poolStatus).toBe(expected);
+  expect(decodeSlate(candidate).freshness.pool.status).toBe(expected);
 });
 
 test('accepts provider freshness without a pool-level retrieved_at', () => {
@@ -269,7 +267,6 @@ test('accepts provider freshness without a pool-level retrieved_at', () => {
   };
   expect(decodeSlate(candidate)).toEqual(
     expect.objectContaining({
-      poolStatus: 'partial',
       freshness: expect.objectContaining({
         pool: expect.objectContaining({ status: 'partial' }),
       }),


### PR DESCRIPTION
Part of #9, #5, and crf04/statsplus#14.

Merge after: crf04/statsplus-backend#43. This PR targets the non-deploying packet integration branch. It does not close #9 because the required local-backend slate→detail→selection verification remains blocked by backend #47/#49.

Aligns Slate/Matchup/Selection decoders and deterministic fixtures with the clarified contract, including league denominators, numeric canonical player IDs, provider provenance, injury identity/status rules, and single nested pool-status authority. Expands all named signed-out/degraded/empty/past/deep-link journeys and verifies prototype code/gates/mock data are absent from source and bundle.

Verification: lint/format/build; Jest 102/102; Chromium 23/23; named desktop/narrow/degraded states visually inspected with no unexpected console/network/page errors.

Review: Opus 5 Standards CLEAR; Opus 5 Spec CLEAR for frontend-owned work. Local backend integration remains explicitly blocked and unclaimed.