### PR TITLE
Fix production smoke URL selection

### DIFF
--- a/.github/workflows/deployed-smoke.yml
+++ b/.github/workflows/deployed-smoke.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
-      E2E_BASE_URL: ${{ github.event_name == 'workflow_dispatch' && inputs.base_url || github.event.deployment_status.environment_url }}
+      E2E_BASE_URL: ${{ github.event_name == 'workflow_dispatch' && inputs.base_url || 'https://statsplus-frontend.vercel.app' }}
     steps:
       - name: Check out trusted smoke harness
         uses: actions/checkout@v4

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -97,13 +97,15 @@ npx playwright show-trace path/to/trace.zip
 ```
 
 The `Deployed smoke test` workflow runs automatically only after a successful Production deployment
-status, checks the allowlisted StatsPlus Vercel URL, and checks out the repository's trusted default
+status, always checks the public `https://statsplus-frontend.vercel.app` alias rather than the
+deployment's potentially protected immutable URL, and checks out the repository's trusted default
 branch harness. That public production path uses no bypass secret. Explicit `workflow_dispatch` runs
-for either production or Protected Preview instead check out `github.workflow_sha`, the immutable
-revision of the reviewed workflow selected for that dispatch; they never check out the moving
-deployed commit or an older default-branch harness. Protected Preview smoke validates its URL and
-fails closed when the encrypted repository secret is missing. Playwright trace and video are disabled
-whenever the secret is present; screenshots remain available for failure evidence.
+for production should provide that public alias; Protected Preview runs should provide the protected
+deployment URL. Both manual paths check out `github.workflow_sha`, the immutable revision of the
+reviewed workflow selected for that dispatch; they never check out the moving deployed commit or an
+older default-branch harness. Protected Preview smoke validates its URL and fails closed when the
+encrypted repository secret is missing. Playwright trace and video are disabled whenever the secret
+is present; screenshots remain available for failure evidence.
 
 For branch protection, require both `validate` and `E2E` before merging.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -96,16 +96,17 @@ bypass credential or cookie cannot enter CI artifacts. Open a retained hermetic 
 npx playwright show-trace path/to/trace.zip
 ```
 
-The `Deployed smoke test` workflow runs automatically only after a successful Production deployment
-status, always checks the public `https://statsplus-frontend.vercel.app` alias rather than the
+The `Deployed smoke test` workflow is triggered after a successful Production deployment status, then
+validates the current promoted public `https://statsplus-frontend.vercel.app` alias rather than the
 deployment's potentially protected immutable URL, and checks out the repository's trusted default
-branch harness. That public production path uses no bypass secret. Explicit `workflow_dispatch` runs
-for production should provide that public alias; Protected Preview runs should provide the protected
-deployment URL. Both manual paths check out `github.workflow_sha`, the immutable revision of the
-reviewed workflow selected for that dispatch; they never check out the moving deployed commit or an
-older default-branch harness. Protected Preview smoke validates its URL and fails closed when the
-encrypted repository secret is missing. Playwright trace and video are disabled whenever the secret
-is present; screenshots remain available for failure evidence.
+branch harness. If alias promotion lags the deployment status, this check can transiently exercise
+the prior build. That public production path uses no bypass secret. Explicit `workflow_dispatch`
+runs for production must provide exactly that public alias; Protected Preview runs should provide the
+protected deployment URL. Both manual paths check out `github.workflow_sha`, the immutable revision
+of the reviewed workflow selected for that dispatch; they never check out the moving deployed commit
+or an older default-branch harness. Protected Preview smoke validates its URL and fails closed when
+the encrypted repository secret is missing. Playwright trace and video are disabled whenever the
+secret is present; screenshots remain available for failure evidence.
 
 For branch protection, require both `validate` and `E2E` before merging.
 

--- a/e2e/fixtures/deployedSmokeConfig.js
+++ b/e2e/fixtures/deployedSmokeConfig.js
@@ -27,6 +27,7 @@ export const isAllowedDeploymentUrl = (candidate, mode = 'any') => {
     url.search === '' &&
     url.hash === '' &&
     vercelDeploymentHost.test(url.hostname) &&
+    !(mode === 'production' && url.hostname !== 'statsplus-frontend.vercel.app') &&
     !(mode === 'protected-preview' && url.hostname === 'statsplus-frontend.vercel.app')
   );
 };

--- a/src/deployedSmoke.test.js
+++ b/src/deployedSmoke.test.js
@@ -7,6 +7,7 @@ import {
 } from '../e2e/fixtures/deployedSmokeConfig';
 
 const deploymentUrl = 'https://statsplus-frontend-pj8o7a8n2-chris-fus-projects.vercel.app/';
+const productionUrl = 'https://statsplus-frontend.vercel.app/';
 
 const makeResponse = ({ status = 307, headers = [] } = {}) => ({
   status: jest.fn(() => status),
@@ -112,14 +113,10 @@ describe('deployed smoke Vercel bootstrap', () => {
 describe('deployed smoke URL and fixture wiring', () => {
   test('allows only the StatsPlus Vercel project deployment host over HTTPS', () => {
     expect(isAllowedDeploymentUrl(deploymentUrl)).toBe(true);
-    expect(isAllowedDeploymentUrl('https://statsplus-frontend.vercel.app/')).toBe(true);
-    expect(isAllowedDeploymentUrl('https://statsplus-frontend.vercel.app/', 'production')).toBe(
-      true,
-    );
+    expect(isAllowedDeploymentUrl(productionUrl)).toBe(true);
+    expect(isAllowedDeploymentUrl(productionUrl, 'production')).toBe(true);
     expect(isAllowedDeploymentUrl(deploymentUrl, 'production')).toBe(false);
-    expect(
-      isAllowedDeploymentUrl('https://statsplus-frontend.vercel.app/', 'protected-preview'),
-    ).toBe(false);
+    expect(isAllowedDeploymentUrl(productionUrl, 'protected-preview')).toBe(false);
     expect(
       isAllowedDeploymentUrl(
         'https://statsplus-frontend-git-feature-chris-fus-projects.vercel.app/',
@@ -164,7 +161,9 @@ describe('deployed smoke URL and fixture wiring', () => {
       "github.event_name == 'workflow_dispatch' && inputs.mode == 'protected-preview'",
     );
     expect(workflowSource).toContain('github.event.repository.default_branch');
-    expect(workflowSource).toContain('node scripts/validate-deployment-url.mjs');
+    expect(workflowSource).toContain(
+      'run: node scripts/validate-deployment-url.mjs production "$E2E_BASE_URL"',
+    );
     expect(workflowSource).toContain('VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.');
     expect(workflowSource.indexOf('Validate protected preview deployment URL')).toBeLessThan(
       workflowSource.indexOf('VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.'),
@@ -191,6 +190,19 @@ describe('deployed smoke URL and fixture wiring', () => {
       expect.stringContaining(manualWorkflowRevision),
       expect.stringContaining(manualWorkflowRevision),
     ]);
+  });
+
+  test.each([
+    { label: 'public production alias', url: productionUrl, status: 0 },
+    { label: 'immutable deployment URL', url: deploymentUrl, status: 1 },
+  ])('validates the production URL for $label', ({ url, status }) => {
+    const result = spawnSync(
+      process.execPath,
+      ['scripts/validate-deployment-url.mjs', 'production', url],
+      { cwd: process.cwd(), encoding: 'utf8' },
+    );
+
+    expect(result.status).toBe(status);
   });
 
   test.each([

--- a/src/deployedSmoke.test.js
+++ b/src/deployedSmoke.test.js
@@ -113,6 +113,10 @@ describe('deployed smoke URL and fixture wiring', () => {
   test('allows only the StatsPlus Vercel project deployment host over HTTPS', () => {
     expect(isAllowedDeploymentUrl(deploymentUrl)).toBe(true);
     expect(isAllowedDeploymentUrl('https://statsplus-frontend.vercel.app/')).toBe(true);
+    expect(isAllowedDeploymentUrl('https://statsplus-frontend.vercel.app/', 'production')).toBe(
+      true,
+    );
+    expect(isAllowedDeploymentUrl(deploymentUrl, 'production')).toBe(false);
     expect(
       isAllowedDeploymentUrl('https://statsplus-frontend.vercel.app/', 'protected-preview'),
     ).toBe(false);
@@ -165,6 +169,10 @@ describe('deployed smoke URL and fixture wiring', () => {
     expect(workflowSource.indexOf('Validate protected preview deployment URL')).toBeLessThan(
       workflowSource.indexOf('VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.'),
     );
+    expect(workflowSource).toContain(
+      "E2E_BASE_URL: ${{ github.event_name == 'workflow_dispatch' && inputs.base_url || 'https://statsplus-frontend.vercel.app' }}",
+    );
+    expect(workflowSource).not.toContain('github.event.deployment_status.environment_url');
   });
 
   test('uses the immutable workflow revision for manual smoke runs', () => {


### PR DESCRIPTION
## Summary
- target the public production alias for automatic deployed smoke
- reject immutable Vercel URLs in production mode
- preserve protected-preview bypass security
- cover workflow wiring and CLI exit behavior
- document alias-promotion timing

## Verification
- lint and formatting
- 181 Jest tests
- production build
- 28 Playwright E2E tests
- fresh Opus 5 Standards + Spec review: clear

Follow-up to #14.