### PR TITLE
Repair production Matchups API routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Browser  ──►  CourtAI (Vercel static)  ──►  /api/*  ──►  Backe
 
 A few decisions worth calling out:
 
-- **Same-origin API in production.** Vercel rewrites `/api/*` to the backend origin, so the frontend never deals with CORS. In development the backend is hit directly via `REACT_APP_API_BASE_URL`.
+- **Same-origin API in production.** Vercel rewrites `/api/*` to the backend origin, so the frontend never deals with CORS. Production builds deliberately ignore `REACT_APP_API_BASE_URL`; in development it selects a direct backend origin.
 - **Auth on the frontend, authorization on the backend.** Firebase issues an ID token; an Axios interceptor (`src/utils/axiosConfig.js`) attaches it to every API request. The backend verifies the token before returning data.
 - **Two charting libraries on purpose.** Chart.js handles dense per-game charts (assists, shot zones) where its plugin ecosystem and label control matter; Recharts handles the simpler React-native dashboards where its declarative API is faster to write.
 - **Natural language is a backend concern.** The frontend renders the prompt, posts to `/api/nl-query`, and displays the resolved filters + results. Anything LLM- or parser-related lives outside this repo.
@@ -96,7 +96,7 @@ This repo is the frontend only. It expects a backend serving:
 - `GET  /api/teams/stats`
 - `POST /api/nl-query`
 
-In production the deployed host (Vercel) rewrites `/api/*` to the backend origin. In development, set `REACT_APP_API_BASE_URL` to point at a local or remote backend.
+In production the deployed host (Vercel) rewrites `/api/*` to the backend origin and ignores `REACT_APP_API_BASE_URL`. In development, set `REACT_APP_API_BASE_URL` to point at a local or remote backend.
 
 ## Deployment
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -3,15 +3,20 @@
 CourtAI uses three complementary test layers. Each layer exercises a stable public seam and has a
 different job.
 
-| Layer          | Public seam                              | Runs                                      | Purpose                                                                       |
-| -------------- | ---------------------------------------- | ----------------------------------------- | ----------------------------------------------------------------------------- |
-| Jest           | Pure modules and rendered React behavior | Local and every PR                        | Fast feedback on filter, response-decoding, formatting, and UI behavior       |
-| Playwright E2E | Browser UI and HTTP requests             | Local and every PR                        | Deterministic critical journeys using an in-browser API contract              |
-| Deployed smoke | Public deployment URL                    | Successful deployments or manual dispatch | Confirms that the built site loads and exposes its authentication entry point |
+| Layer          | Public seam                              | Runs                                      | Purpose                                                                                       |
+| -------------- | ---------------------------------------- | ----------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Jest           | Pure modules and rendered React behavior | Local and every PR                        | Fast feedback on filter, response-decoding, formatting, and UI behavior                       |
+| Playwright E2E | Browser UI and HTTP requests             | Local and every PR                        | Deterministic critical journeys using an in-browser API contract                              |
+| Deployed smoke | Public deployment URL                    | Successful deployments or manual dispatch | Confirms that the built site loads and Matchups API routing reaches the authenticated backend |
 
 Real Google authentication and backend data are intentionally outside the per-PR E2E gate. Popup
-authentication, credentials, and changing live data make a poor deterministic gate. Those flows can
-be exercised during exploratory QA or added later as a secret-backed scheduled suite.
+authentication, credentials, and changing live data make a poor deterministic gate. The deployed
+smoke does verify that an unauthenticated Slate request traverses the production proxy and receives
+the backend's stable `401 authentication_required` response. Authenticated flows can be exercised
+during exploratory QA or added later as a secret-backed scheduled suite.
+
+The production smoke intentionally fails when the backend is unavailable because a frontend release
+is not usable when its same-origin API dependency cannot enforce authentication.
 
 ## Commands
 

--- a/e2e/specs/core-flows.spec.js
+++ b/e2e/specs/core-flows.spec.js
@@ -1,5 +1,12 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import { E2E_AUTH_STORAGE_KEY, expect, installApiContract } from '../fixtures/courtai';
 import { test } from '../fixtures/deployedSmoke';
+
+const vercelConfig = JSON.parse(
+  fs.readFileSync(path.resolve(process.cwd(), 'vercel.json'), 'utf8'),
+);
+const productionBackendOrigin = new URL(vercelConfig.rewrites[0].destination).origin;
 
 test('@smoke public landing page explains how to authenticate', async ({ deployedPage: page }) => {
   const rawBypassHeaders = [];
@@ -15,6 +22,49 @@ test('@smoke public landing page explains how to authenticate', async ({ deploye
   await expect(page.getByRole('button', { name: 'Sign in with Google' })).toBeVisible();
   await expect(page.getByRole('textbox')).toBeDisabled();
   expect(rawBypassHeaders).toHaveLength(0);
+});
+
+test('@smoke deployed Matchups shell and deep links resolve', async ({ deployedPage: page }) => {
+  await page.goto('/matchups');
+  await expect(page.getByRole('heading', { name: 'Sign in to view the slate' })).toBeVisible();
+
+  await page.goto('/matchups/0022500584');
+  await expect(page.getByRole('heading', { name: 'Sign in to view this matchup' })).toBeVisible();
+
+  const bundledAssetUrls = await page
+    .locator('script[src], link[rel="modulepreload"][href]')
+    .evaluateAll((elements) =>
+      elements
+        .map((element) => element.src || element.href)
+        .filter((url) => new URL(url).origin === window.location.origin),
+    );
+  expect(bundledAssetUrls.length).toBeGreaterThan(0);
+
+  const bundledAssets = await Promise.all(
+    bundledAssetUrls.map((url) => page.request.get(url).then((response) => response.text())),
+  );
+  expect(bundledAssets.length).toBeGreaterThan(0);
+  expect(bundledAssets.join('\n')).not.toContain(productionBackendOrigin);
+});
+
+test('@smoke production Matchups API routing reaches authenticated backend', async ({
+  request,
+}) => {
+  test.skip(!process.env.E2E_BASE_URL, 'Only meaningful against a deployed environment.');
+  test.skip(
+    process.env.E2E_PROTECTED_PREVIEW === 'true',
+    'Production-only check avoids forwarding the protected-preview cookie through the proxy.',
+  );
+
+  const response = await request.get(
+    new URL('/api/games/slate?date=2026-01-15', process.env.E2E_BASE_URL).href,
+  );
+
+  expect(response.status()).toBe(401);
+  expect(response.headers()['content-type']).toContain('application/json');
+  await expect(response.json()).resolves.toMatchObject({
+    error: { code: 'authentication_required' },
+  });
 });
 
 test('@critical the development auth adapter unlocks the search seam', async ({ page }) => {

--- a/src/config.js
+++ b/src/config.js
@@ -2,11 +2,12 @@ import { API_TIMEOUT } from './apiSettings';
 
 const trimTrailingSlashes = (value) => value.replace(/\/+$/, '');
 const configuredApiBaseUrl = trimTrailingSlashes((process.env.REACT_APP_API_BASE_URL || '').trim());
-const defaultApiBaseUrl = process.env.NODE_ENV === 'production' ? '' : 'http://127.0.0.1:8000';
+const apiBaseUrl =
+  process.env.NODE_ENV === 'production' ? '' : configuredApiBaseUrl || 'http://127.0.0.1:8000';
 
 const config = {
-  // In production, an empty base URL keeps API calls relative to /api for Vercel rewrites.
-  API_BASE_URL: configuredApiBaseUrl || defaultApiBaseUrl,
+  // Production always stays same-origin so Vercel's /api rewrite owns backend routing.
+  API_BASE_URL: apiBaseUrl,
 
   // API endpoints
   API_ENDPOINTS: {

--- a/src/config.test.js
+++ b/src/config.test.js
@@ -1,0 +1,22 @@
+describe('API base URL', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalApiBaseUrl = process.env.REACT_APP_API_BASE_URL;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+    process.env.REACT_APP_API_BASE_URL = originalApiBaseUrl;
+    jest.resetModules();
+  });
+
+  test('keeps production requests relative even when an API origin is configured', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.REACT_APP_API_BASE_URL = 'https://configured-backend.example.com/';
+
+    let loadedConfig;
+    jest.isolateModules(() => {
+      loadedConfig = require('./config').default;
+    });
+
+    expect(loadedConfig.API_BASE_URL).toBe('');
+  });
+});

--- a/src/vercelConfig.test.js
+++ b/src/vercelConfig.test.js
@@ -45,7 +45,10 @@ describe('Vercel deployment configuration', () => {
 
   test('proxies API requests before applying the SPA fallback', () => {
     expect(vercelConfig.rewrites).toHaveLength(2);
-    expect(vercelConfig.rewrites[0]).toMatchObject({ source: '/api/:path*' });
+    expect(vercelConfig.rewrites[0]).toEqual({
+      source: '/api/:path*',
+      destination: 'https://statsplus-backend-production.up.railway.app/api/:path*',
+    });
     expect(vercelConfig.rewrites[1]).toEqual({ source: '/:path*', destination: '/index.html' });
   });
 

--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,10 @@
   "buildCommand": "npm run build",
   "outputDirectory": "build",
   "rewrites": [
-    { "source": "/api/:path*", "destination": "https://your-backend.example.com/api/:path*" },
+    {
+      "source": "/api/:path*",
+      "destination": "https://statsplus-backend-production.up.railway.app/api/:path*"
+    },
     { "source": "/:path*", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
Closes #16
Part of crf04/statsplus#14
Merge after: crf04/statsplus-backend#66

## Summary

- replace the placeholder Vercel `/api/*` destination with the production Railway backend
- force production builds to keep API calls same-origin even when the legacy base-URL environment variable is configured
- extend deployed smoke coverage across Matchups shell/deep links, production bundle routing, and the backend authentication boundary
- document the production routing and smoke-gate contract

## Verification

- `npm run lint`
- `npm run format:check`
- `npm run test:ci` — 182 passed
- `npm run build`
- isolated Playwright run — 29 passed with one existing timing-sensitive test passing on immediate focused rerun; 30 passed on the preceding full run before the final smoke-only hardening
- current production regression reproduces: `/api/games/slate` returns Vercel `502 DNS_HOSTNAME_EMPTY` instead of backend `401 authentication_required`
- fresh Opus reviews completed; all material findings addressed

## Rollout note

Do not merge until backend #66 restores hosted Firebase authentication. Once merged, remove the Vercel production `REACT_APP_API_BASE_URL` variable as cleanup (production code now ignores it) and require the deployed smoke to pass.