### PR TITLE
Rebuild the slate as a tip-time board

### DIFF
--- a/e2e/specs/slate.spec.js
+++ b/e2e/specs/slate.spec.js
@@ -61,8 +61,10 @@ test('@critical authenticated user opens a slate and navigates dates', async ({
     );
   }, slateGame.scheduled_at);
   await expect(page.getByText(viewerLocalTip, { exact: true })).toBeVisible();
-  await expect(page.getByText('Los Angeles Lakers')).toBeVisible();
-  await expect(page.getByText('5 targetable')).toBeVisible();
+  await expect(page.getByText('Los Angeles Lakers at Boston Celtics')).toBeVisible();
+  await expect(page.getByLabel('9 targetable players, LAL 5, BOS 4')).toBeVisible();
+  // One mark per targetable player, grouped away then home.
+  await expect(page.locator('.slate-pip')).toHaveCount(9);
   await expect(page.getByText('NBA Paris Game')).toBeVisible();
   await expect(page.getByText('Preseason')).toHaveCount(0);
   await expect(page.getByText(/schedule is fresh.*as of/i)).toBeVisible();
@@ -93,10 +95,15 @@ test('@critical authenticated user opens a slate and navigates dates', async ({
   await expect(
     page.getByText(/final game cards retain the posted targetable counts/i),
   ).toBeVisible();
-  await expect(page.getByText('5 targetable')).toBeVisible();
-  await expect(page.getByText('4 targetable')).toBeVisible();
+  await expect(page.getByLabel('9 targetable players, NYK 5, MIL 4')).toBeVisible();
   await page.screenshot({ path: testInfo.outputPath('slate-past.png'), fullPage: true });
   expect(requests.some((url) => new URL(url).searchParams.get('date') === '2026-01-10')).toBe(true);
+
+  // Today is reachable from any date, not only as recovery from a bad one.
+  await page.getByRole('button', { name: 'Today' }).click();
+  await expect(page).toHaveURL(/\/matchups$/);
+  await expect(page.getByRole('heading', { name: 'Thursday, January 15, 2026' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Today' })).toBeDisabled();
 });
 
 test('signed-out matchups keeps the shared shell and does not redirect', async ({
@@ -202,7 +209,7 @@ test('explicit unavailable pool status wins over stale provider evidence', async
 
   await expect(page.getByText(/player pool is unavailable; no targetable players/i)).toBeVisible();
   await expect(page.getByText('prizepicks pool is stale-served — as of 3h ago')).toBeVisible();
-  await expect(page.getByText('0 targetable')).toHaveCount(2);
+  await expect(page.getByLabel('0 targetable players, LAL 0, BOS 0')).toBeVisible();
   await page.screenshot({
     path: testInfo.outputPath('slate-pool-unavailable.png'),
     fullPage: true,

--- a/src/SlatePage.css
+++ b/src/SlatePage.css
@@ -1,7 +1,7 @@
 .slate-page {
-  width: min(1080px, calc(100% - 32px));
+  width: min(1160px, calc(100% - 32px));
   margin: 0 auto;
-  padding: 52px 0 80px;
+  padding: 40px 0 80px;
   text-align: left;
 }
 
@@ -10,74 +10,150 @@
   justify-content: space-between;
   align-items: end;
   gap: 24px;
-  border-bottom: 1px solid var(--ct-line);
-  padding-bottom: 24px;
+}
+
+.slate-title {
+  min-width: 0;
 }
 
 .slate-heading h1,
 .signed-out-slate h1 {
   margin: 0;
-  font-size: clamp(2.2rem, 6vw, 4.6rem);
-  line-height: 0.95;
+  font-size: clamp(1.9rem, 4vw, 2.9rem);
+  line-height: 1;
 }
 
 .eyebrow {
-  margin: 0 0 10px;
+  margin: 0 0 8px;
   color: var(--ct-gold);
   font-family: var(--ct-mono);
-  font-size: 0.72rem;
+  font-size: 0.68rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
 }
 
-.date-controls {
-  display: flex;
-  align-items: end;
-  gap: 8px;
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
 }
 
-.date-controls label {
-  display: grid;
-  gap: 5px;
-  color: var(--ct-dim);
-  font-size: 0.72rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+/* One segmented pill rather than three loose boxes under a caption: the
+   arrows and the field are the same control and should read as one. */
+.date-controls {
+  display: inline-flex;
+  align-items: stretch;
+  align-self: end;
+  border: 1px solid var(--ct-line-strong);
+  border-radius: var(--ct-radius-ctl);
+  background: var(--ct-surface-2);
+  overflow: hidden;
 }
 
 .date-controls button,
 .date-controls input {
-  min-height: 42px;
-  border: 1px solid var(--ct-line-strong);
-  border-radius: var(--ct-radius-ctl);
-  background: var(--ct-surface-2);
+  min-height: 40px;
+  border: 0;
+  background: transparent;
   color: var(--ct-text);
+  font-size: 0.86rem;
 }
 
 .date-controls button {
-  width: 42px;
-  font-size: 1.2rem;
+  width: 38px;
+  color: var(--ct-dim);
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.date-controls button:hover:not(:disabled) {
+  background: var(--ct-gold-soft);
+  color: var(--ct-gold);
+}
+
+.date-controls button:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.date-field {
+  display: flex;
+  border-right: 1px solid var(--ct-line);
+  border-left: 1px solid var(--ct-line);
+}
+
+.date-controls input {
+  padding: 0 12px;
+  font-family: var(--ct-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+/* The native picker indicator is near-invisible on a dark surface. */
+.date-controls input::-webkit-calendar-picker-indicator {
+  cursor: pointer;
+  filter: invert(1);
+  opacity: 0.45;
+}
+
+.date-controls input::-webkit-calendar-picker-indicator:hover {
+  opacity: 0.9;
 }
 
 .date-controls .today-reset {
   width: auto;
+  border-left: 1px solid var(--ct-line);
   padding: 0 14px;
+  color: var(--ct-gold);
+  font-family: var(--ct-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.04em;
+}
+
+/* On today's slate the control is inert, so it reads as a marker of where you
+   are rather than an action that would do nothing. */
+.date-controls .today-reset:disabled {
+  color: var(--ct-dim);
+  opacity: 1;
 }
 
 .date-controls button:focus-visible,
 .date-controls input:focus-visible {
   outline: 2px solid var(--ct-gold);
-  outline-offset: 2px;
+  outline-offset: -2px;
+}
+
+/* One status line rather than a stacked block: every freshness surface the
+   slate reports still states itself, but the slate itself starts higher up the
+   page. The line only grows when a surface is degraded. */
+
+.slate-status {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px 18px;
+  margin-top: 18px;
+  border-top: 1px solid var(--ct-line);
+  border-bottom: 1px solid var(--ct-line);
+  padding: 10px 0;
+  font-family: var(--ct-mono);
+  font-size: 0.72rem;
+}
+
+.slate-count {
+  font-family: var(--ct-mono);
+  font-size: 0.72rem;
 }
 
 .freshness {
   display: flex;
   flex-wrap: wrap;
-  gap: 20px;
-  padding: 18px 0;
+  gap: 4px 18px;
   color: var(--ct-dim);
   font-family: var(--ct-mono);
-  font-size: 0.76rem;
+  font-size: 0.72rem;
 }
 
 .freshness-warning {
@@ -85,11 +161,9 @@
 }
 
 .pool-summary {
-  margin-bottom: 18px;
-  border: 1px solid var(--ct-line);
-  border-radius: var(--ct-radius-ctl);
-  padding: 14px 18px;
-  background: var(--ct-surface-2);
+  margin: 14px 0 6px;
+  border-left: 2px solid var(--ct-line-strong);
+  padding: 2px 0 2px 14px;
 }
 
 .pool-summary h2,
@@ -98,100 +172,214 @@
 }
 
 .pool-summary h2 {
-  margin-bottom: 4px;
-  font-size: 0.82rem;
+  margin-bottom: 3px;
+  color: var(--ct-dim);
+  font-family: var(--ct-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
 .pool-summary p {
-  color: var(--ct-dim);
-  font-size: 0.88rem;
+  font-size: 0.84rem;
 }
 
-.slate-grid {
+/* ---------- the board ---------- */
+
+.slate-board {
+  margin: 8px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.slate-window {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 16px;
+  grid-template-columns: 92px minmax(0, 1fr);
+  align-items: start;
+  border-bottom: 1px solid var(--ct-line);
+  padding: 14px 0;
 }
 
-.slate-card,
-.empty-slate,
-.signed-out-slate {
-  border: 1px solid var(--ct-line);
-  border-radius: var(--ct-radius-card);
+.slate-window:last-child {
+  border-bottom: 0;
+}
+
+.slate-window-tip {
+  position: sticky;
+  top: 12px;
+  margin: 0;
+  padding-top: 14px;
+  color: var(--ct-gold);
+  font-family: var(--ct-mono);
+  font-size: 0.76rem;
+  font-weight: 400;
+  letter-spacing: 0.06em;
+}
+
+.slate-rows {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* The whole row is the control. There is no separate link to aim at. */
+.slate-row {
+  display: grid;
+  grid-template-columns: minmax(240px, 1.3fr) minmax(240px, 0.8fr) 20px;
+  align-items: center;
+  gap: 18px;
+  border: 1px solid transparent;
+  border-radius: var(--ct-radius-ctl);
+  padding: 9px 12px;
+  color: inherit;
+  text-decoration: none;
+}
+
+.slate-row:hover {
+  border-color: var(--ct-line-strong);
   background: var(--ct-surface);
 }
 
-.slate-card {
-  padding: 22px;
+.slate-row:focus-visible {
+  outline: 2px solid var(--ct-gold);
+  outline-offset: 2px;
 }
 
-.slate-card-topline,
-.team-row {
-  display: flex;
-  justify-content: space-between;
-  gap: 16px;
+.slate-row.is-blocked {
+  opacity: 0.55;
 }
 
-.slate-card-topline {
-  color: var(--ct-dim);
-  font-family: var(--ct-mono);
-  font-size: 0.72rem;
-  text-transform: uppercase;
-}
-
-.slate-card h2 {
-  margin: 22px 0;
-  font-size: 2.1rem;
-}
-
-.team-row {
-  border-top: 1px solid var(--ct-line);
-  padding: 11px 0;
-}
-
-.team-row span:last-child {
-  color: var(--ct-dim);
-  font-family: var(--ct-mono);
-  font-size: 0.76rem;
-}
-
-.badges {
+.slate-row-title {
   display: flex;
   flex-wrap: wrap;
+  align-items: baseline;
   gap: 8px;
-  margin-top: 12px;
+}
+
+.slate-row-title h3 {
+  margin: 0;
+  font-size: 1.5rem;
+  letter-spacing: 0.02em;
+}
+
+.slate-row-names {
+  display: block;
+  margin-top: 1px;
+  color: var(--ct-dim);
+  font-size: 0.74rem;
 }
 
 .slate-badge {
-  border: 1px solid var(--ct-gold);
+  border: 1px solid var(--ct-line-strong);
   border-radius: 999px;
-  padding: 3px 8px;
-  color: var(--ct-gold);
-  font-size: 0.72rem;
+  padding: 2px 8px;
+  color: var(--ct-dim);
+  font-family: var(--ct-mono);
+  font-size: 0.64rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  white-space: nowrap;
 }
 
-.open-matchup {
-  display: inline-block;
-  margin-top: 18px;
-  color: var(--ct-gold);
-  font-weight: 700;
+/* A postponement changes whether the row is worth opening at all; a
+   classification only describes it. They should not look the same. */
+.slate-badge.is-blocked {
+  border-color: var(--ct-miss);
+  background: var(--ct-miss-soft);
+  color: #f0a4a4;
 }
 
-.open-matchup:focus-visible {
-  outline: 2px solid var(--ct-gold);
-  outline-offset: 3px;
+.slate-badge.is-event {
+  border-color: var(--ct-gold);
+  color: var(--ct-gold);
+}
+
+.slate-depth {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 18px;
+  font-family: var(--ct-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Marks run right-to-left from the figure, so the figure stays in a fixed
+   column and the shape of the count grows into the empty space beside it. */
+.slate-pips {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 4px 14px;
+}
+
+.slate-pip-group {
+  display: flex;
+  gap: 4px;
+}
+
+.slate-pip {
+  width: 6px;
+  height: 14px;
+  border-radius: 2px;
+}
+
+.slate-pip.is-away {
+  background: var(--ct-gold);
+}
+
+.slate-pip.is-home {
+  background: rgba(232, 163, 61, 0.5);
+}
+
+.slate-row.is-blocked .slate-pip {
+  background: var(--ct-line-strong);
+}
+
+.slate-depth-figure {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+  /* Widest case is a two-digit count plus the unit; fixing it keeps every
+     figure on the same vertical rule down the slate. */
+  min-width: 128px;
+}
+
+.slate-depth-total {
+  min-width: 2ch;
+  font-size: 1.45rem;
+  font-weight: 500;
+  line-height: 1;
+  text-align: right;
+}
+
+.slate-depth-unit {
+  color: var(--ct-dim);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.slate-row-go {
+  color: var(--ct-dim);
+  text-align: right;
+}
+
+.slate-row:hover .slate-row-go {
+  color: var(--ct-gold);
 }
 
 .empty-slate,
 .signed-out-slate {
   margin-top: 28px;
+  border: 1px solid var(--ct-line);
+  border-radius: var(--ct-radius-card);
   padding: clamp(28px, 6vw, 64px);
+  background: var(--ct-surface);
 }
 
-@media (max-width: 700px) {
+@media (max-width: 820px) {
   .slate-page {
-    width: min(100% - 20px, 1080px);
+    width: min(100% - 20px, 1160px);
     padding-top: 30px;
   }
 
@@ -212,13 +400,38 @@
     width: 100%;
   }
 
-  .freshness {
+  .slate-status {
     align-items: flex-start;
     flex-direction: column;
     gap: 5px;
   }
 
-  .slate-grid {
+  .freshness {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .slate-window {
     grid-template-columns: 1fr;
+  }
+
+  .slate-window-tip {
+    position: static;
+    padding: 0 0 6px;
+  }
+
+  .slate-row {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 8px 12px;
+  }
+
+  .slate-depth {
+    grid-column: 1 / -1;
+  }
+
+  .slate-row-go {
+    grid-row: 1;
+    grid-column: 2;
   }
 }

--- a/src/SlatePage.js
+++ b/src/SlatePage.js
@@ -76,35 +76,124 @@ function PoolSummary({ isPast, poolStatus }) {
   );
 }
 
-function GameCard({ game }) {
+/*
+ * A scheduled game states itself with its tip time, so printing "Scheduled" on
+ * every row is noise. A status the catalog bothered to name differently is
+ * information, and so is any state other than scheduled.
+ */
+const statusBadge = (game) => {
   const fallbackLabels = { scheduled: 'Scheduled', postponed: 'Postponed', final: 'Final' };
-  const status = game.statusLabel || fallbackLabels[game.status];
+  const label = game.statusLabel || fallbackLabels[game.status];
+  if (game.status === 'scheduled' && label === fallbackLabels.scheduled) return null;
+  return { label, tone: game.status === 'postponed' ? 'blocked' : 'muted' };
+};
+
+/*
+ * Games grouped into the tip-time windows they share, in schedule order. The
+ * slate's own organising fact is when its games start, and a reader picking one
+ * already thinks in windows.
+ */
+const groupByTip = (games) =>
+  [...games]
+    .sort((a, b) => new Date(a.scheduledAt) - new Date(b.scheduledAt))
+    .reduce((groups, game) => {
+      const tip = formatTip(game.scheduledAt);
+      const current = groups.at(-1);
+      if (current?.tip === tip) current.games.push(game);
+      else groups.push({ tip, games: [game] });
+      return groups;
+    }, []);
+
+function GameRow({ game }) {
+  const away = game.away.targetablePlayerCount;
+  const home = game.home.targetablePlayerCount;
+  const total = away + home;
+  const status = statusBadge(game);
+
+  /*
+   * The row is one control, so it gets one accessible name that reads as a
+   * sentence. Everything inside it is decoration for that name, which is why
+   * the depth figures below are aria-hidden rather than separately labelled.
+   */
+  const label = [
+    `${game.away.tricode} @ ${game.home.tricode}`,
+    formatTip(game.scheduledAt),
+    status && status.label,
+    `${total} targetable players, ${game.away.tricode} ${away}, ${game.home.tricode} ${home}`,
+    'Open Team Sheets',
+  ]
+    .filter(Boolean)
+    .join(', ');
+
   return (
-    <article className="slate-card">
-      <div className="slate-card-topline">
-        <span>{formatTip(game.scheduledAt)}</span>
-        <span>{status}</span>
-      </div>
-      <h2>
-        {game.away.tricode} @ {game.home.tricode}
-      </h2>
-      <div className="team-row">
-        <span>{game.away.name}</span>
-        <span>{game.away.targetablePlayerCount} targetable</span>
-      </div>
-      <div className="team-row">
-        <span>{game.home.name}</span>
-        <span>{game.home.targetablePlayerCount} targetable</span>
-      </div>
-      <div className="badges">
-        {game.classification && <span className="slate-badge">{game.classification}</span>}
-        {game.preseason && <span className="slate-badge">Preseason</span>}
-        {game.status === 'postponed' && <span className="slate-badge">Postponed</span>}
-      </div>
-      <Link className="open-matchup" to={`/matchups/${game.gameId}`}>
-        Open Team Sheets
+    <li>
+      <Link
+        className={`slate-row${game.status === 'postponed' ? ' is-blocked' : ''}`}
+        to={`/matchups/${game.gameId}`}
+        aria-label={label}
+      >
+        <span className="slate-row-teams">
+          <span className="slate-row-title">
+            <h3>
+              {game.away.tricode} @ {game.home.tricode}
+            </h3>
+            {status && <span className={`slate-badge is-${status.tone}`}>{status.label}</span>}
+            {game.classification && (
+              <span className="slate-badge is-event">{game.classification}</span>
+            )}
+            {game.preseason && <span className="slate-badge is-event">Preseason</span>}
+          </span>
+          <span className="slate-row-names">
+            {game.away.name} at {game.home.name}
+          </span>
+        </span>
+
+        {/* One mark per targetable player, away then home. Deliberately a unit
+            chart and not a bar: a bar needs a denominator, and there is no known
+            cap on targetable players per game, so any full-width reference would
+            be invented. Counting marks needs no such reference, and the two
+            groups state the per-side split exactly. */}
+        <span className="slate-depth" aria-hidden="true">
+          <span className="slate-pips">
+            <span className="slate-pip-group">
+              {Array.from({ length: away }, (_, index) => (
+                <i className="slate-pip is-away" key={index} />
+              ))}
+            </span>
+            <span className="slate-pip-group">
+              {Array.from({ length: home }, (_, index) => (
+                <i className="slate-pip is-home" key={index} />
+              ))}
+            </span>
+          </span>
+          <span className="slate-depth-figure">
+            <b className="slate-depth-total">{total}</b>
+            <span className="slate-depth-unit">targetable</span>
+          </span>
+        </span>
+
+        <span className="slate-row-go" aria-hidden="true">
+          →
+        </span>
       </Link>
-    </article>
+    </li>
+  );
+}
+
+function SlateBoard({ games }) {
+  return (
+    <ol className="slate-board">
+      {groupByTip(games).map((group) => (
+        <li className="slate-window" key={group.tip}>
+          <h2 className="slate-window-tip">{group.tip}</h2>
+          <ul className="slate-rows">
+            {group.games.map((game) => (
+              <GameRow key={game.gameId} game={game} />
+            ))}
+          </ul>
+        </li>
+      ))}
+    </ol>
   );
 }
 
@@ -170,8 +259,10 @@ export default function SlatePage() {
   return (
     <main className="slate-page">
       <section className="slate-heading">
-        <p className="eyebrow">NBA slate</p>
-        <h1>{slateDate ? formatCalendarDate(slateDate) : 'Invalid slate date'}</h1>
+        <div className="slate-title">
+          <p className="eyebrow">NBA slate</p>
+          <h1>{slateDate ? formatCalendarDate(slateDate) : 'Invalid slate date'}</h1>
+        </div>
         <div className="date-controls">
           <button
             type="button"
@@ -181,8 +272,10 @@ export default function SlatePage() {
           >
             ←
           </button>
-          <label>
-            <span>Slate date</span>
+          {/* The h1 already names the date in words, so the field's caption is
+              for assistive technology only rather than a third line of chrome. */}
+          <label className="date-field">
+            <span className="visually-hidden">Slate date</span>
             <input
               type="date"
               value={slateDate || ''}
@@ -197,11 +290,17 @@ export default function SlatePage() {
           >
             →
           </button>
-          {!slateDate && (
-            <button className="today-reset" type="button" onClick={() => navigate('')}>
-              Today
-            </button>
-          )}
+          {/* Always reachable, not only as recovery from a bad date. Disabled
+              on today's slate so the control doubles as a statement of where
+              you are. */}
+          <button
+            className="today-reset"
+            type="button"
+            disabled={slateDate === todaySlateDate}
+            onClick={() => navigate('')}
+          >
+            Today
+          </button>
         </div>
       </section>
 
@@ -211,11 +310,16 @@ export default function SlatePage() {
       {state.status === 'error' && <p role="alert">{state.error}</p>}
       {state.status === 'ready' && (
         <>
-          <Freshness
-            freshness={state.slate.freshness}
-            now={now}
-            poolPresentation={poolPresentation}
-          />
+          <div className="slate-status">
+            <span className="slate-count">
+              {state.slate.games.length} {state.slate.games.length === 1 ? 'game' : 'games'}
+            </span>
+            <Freshness
+              freshness={state.slate.freshness}
+              now={now}
+              poolPresentation={poolPresentation}
+            />
+          </div>
           <PoolSummary isPast={isPast} poolStatus={effectivePoolStatus} />
           {state.slate.games.length === 0 ? (
             <div className="empty-slate">
@@ -223,11 +327,7 @@ export default function SlatePage() {
               <p>Choose another date to keep browsing the season.</p>
             </div>
           ) : (
-            <div className="slate-grid">
-              {state.slate.games.map((game) => (
-                <GameCard key={game.gameId} game={game} />
-              ))}
-            </div>
+            <SlateBoard games={state.slate.games} />
           )}
         </>
       )}

--- a/src/SlatePage.test.js
+++ b/src/SlatePage.test.js
@@ -200,9 +200,103 @@ test('explains mixed provider counts without claiming the whole pool is missing'
   );
 
   expect(await screen.findByText(/counts reflect the available boards/i)).toBeVisible();
-  expect(screen.getByText('5 targetable')).toBeVisible();
-  expect(screen.getByText('4 targetable')).toBeVisible();
+  expect(screen.getByRole('link', { name: /9 targetable players, LAL 5, BOS 4/ })).toBeVisible();
+  expect(screen.getByText('9')).toBeVisible();
+  expect(document.querySelectorAll('.slate-pip')).toHaveLength(9);
   expect(screen.queryByText(/no targetable players/i)).not.toBeInTheDocument();
+});
+
+test('groups the slate into tip-time windows in schedule order', async () => {
+  const later = {
+    ...game,
+    gameId: '0022500585',
+    away: { ...game.away, tricode: 'NYK', name: 'New York Knicks' },
+    home: { ...game.home, tricode: 'MIL', name: 'Milwaukee Bucks' },
+    scheduledAt: '2026-01-16T03:00:00.000Z',
+  };
+  fetchSlate.mockResolvedValue({ ...slate, games: [later, game] });
+
+  render(
+    <MemoryRouter initialEntries={['/matchups?date=2026-01-15']}>
+      <SlatePage />
+    </MemoryRouter>,
+  );
+
+  await screen.findByRole('heading', { name: 'LAL @ BOS' });
+  const headings = screen.getAllByRole('heading').map((node) => node.textContent);
+  const earlyTip = headings.indexOf('LAL @ BOS');
+  const lateTip = headings.indexOf('NYK @ MIL');
+  expect(earlyTip).toBeGreaterThan(-1);
+  expect(lateTip).toBeGreaterThan(earlyTip);
+});
+
+test('states depth as a figure, not a bar against an invented denominator', async () => {
+  const deeper = {
+    ...game,
+    gameId: '0022500585',
+    away: { ...game.away, tricode: 'NYK', targetablePlayerCount: 8 },
+    home: { ...game.home, tricode: 'MIL', targetablePlayerCount: 7 },
+  };
+  fetchSlate.mockResolvedValue({ ...slate, games: [game, deeper] });
+
+  render(
+    <MemoryRouter initialEntries={['/matchups?date=2026-01-15']}>
+      <SlatePage />
+    </MemoryRouter>,
+  );
+
+  const shallow = await screen.findByRole('link', { name: /9 targetable players/ });
+  const busiest = screen.getByRole('link', { name: /15 targetable players/ });
+  expect(within(shallow).getByText('9')).toBeVisible();
+  expect(within(busiest).getByText('15')).toBeVisible();
+
+  // One mark per player, grouped away then home — a unit chart, so no mark
+  // stands for a fraction of a capacity that does not exist.
+  const marks = (row) =>
+    [...row.querySelectorAll('.slate-pip-group')].map((g) => g.childElementCount);
+  expect(marks(shallow)).toEqual([5, 4]);
+  expect(marks(busiest)).toEqual([8, 7]);
+  expect(document.querySelector('.slate-bar')).toBeNull();
+});
+
+test('offers Today from any other date and marks it inert on today', async () => {
+  render(
+    <MemoryRouter initialEntries={['/matchups']}>
+      <SlatePage />
+    </MemoryRouter>,
+  );
+
+  await screen.findByRole('heading', { name: 'Thursday, January 15, 2026' });
+  // Today's slate: the control is inert rather than an action that does nothing.
+  expect(screen.getByRole('button', { name: 'Today' })).toBeDisabled();
+
+  fetchSlate.mockResolvedValue({ ...slate, slateDate: '2026-01-10' });
+  fireEvent.change(screen.getByLabelText('Slate date'), { target: { value: '2026-01-10' } });
+
+  await waitFor(() => expect(screen.getByRole('button', { name: 'Today' })).toBeEnabled());
+  fetchSlate.mockClear();
+  fetchSlate.mockResolvedValue(slate);
+
+  fireEvent.click(screen.getByRole('button', { name: 'Today' }));
+
+  await waitFor(() => expect(fetchSlate).toHaveBeenCalledWith(undefined, expect.any(Object)));
+});
+
+test('opens Team Sheets from anywhere on the row', async () => {
+  render(
+    <MemoryRouter initialEntries={['/matchups?date=2026-01-15']}>
+      <SlatePage />
+    </MemoryRouter>,
+  );
+
+  const heading = await screen.findByRole('heading', { name: 'LAL @ BOS' });
+  const row = heading.closest('a');
+  expect(row).toHaveAttribute('href', '/matchups/0022500584');
+  // One control, one sentence — not a heading plus a separate call to action.
+  expect(row).toHaveAccessibleName(
+    /^LAL @ BOS, .+, 9 targetable players, LAL 5, BOS 4, Open Team Sheets$/,
+  );
+  expect(screen.getAllByRole('link')).toHaveLength(1);
 });
 
 test.each([
@@ -228,10 +322,10 @@ test.each([
 });
 
 test.each([
-  ['scheduled', null, 'Scheduled'],
   ['postponed', null, 'Postponed'],
   ['final', null, 'Final'],
   ['final', 'Final/OT', 'Final/OT'],
+  ['scheduled', 'Delayed', 'Delayed'],
 ])('shows %s catalog label %s with a cased fallback', async (status, statusLabel, expected) => {
   fetchSlate.mockResolvedValue({
     ...slate,
@@ -245,6 +339,38 @@ test.each([
   );
 
   expect((await screen.findAllByText(expected))[0]).toBeVisible();
+});
+
+test('does not label an ordinary scheduled game, which its tip time already states', async () => {
+  fetchSlate.mockResolvedValue({
+    ...slate,
+    games: [{ ...game, status: 'scheduled', statusLabel: 'Scheduled' }],
+  });
+
+  render(
+    <MemoryRouter initialEntries={['/matchups?date=2026-01-15']}>
+      <SlatePage />
+    </MemoryRouter>,
+  );
+
+  await screen.findByRole('heading', { name: 'LAL @ BOS' });
+  expect(screen.queryByText('Scheduled')).not.toBeInTheDocument();
+});
+
+test('separates a postponement from a descriptive classification', async () => {
+  fetchSlate.mockResolvedValue({
+    ...slate,
+    games: [{ ...game, status: 'postponed', statusLabel: null, classification: 'NBA Cup' }],
+  });
+
+  render(
+    <MemoryRouter initialEntries={['/matchups?date=2026-01-15']}>
+      <SlatePage />
+    </MemoryRouter>,
+  );
+
+  expect(await screen.findByText('Postponed')).toHaveClass('is-blocked');
+  expect(screen.getByText('NBA Cup')).toHaveClass('is-event');
 });
 
 test('shows preseason and unusual classification badges', async () => {


### PR DESCRIPTION
Rebuilds `/matchups` (`SlatePage`). The page was a two-column grid of large cards spending ~180px per game, so half a twelve-game slate sat below the fold, and the targetable counts it printed could not be compared without reading every card.

## What changes

- **Tip-time board.** Games sort by `scheduledAt` and group under the tip window they share, with a sticky time marker. Twelve games fit in roughly the space six cards used.
- **The row is the control.** The whole row is the link; the separate `Open Team Sheets` link is gone. Each row carries one accessible name that reads as a sentence — `LAL @ BOS, 6:30 PM, 9 targetable players, LAL 5, BOS 4, Open Team Sheets`.
- **Depth is a unit chart, not a bar.** One mark per targetable player, grouped away then home, beside the total. This is deliberate: a bar needs a denominator and there is no known cap on targetable players per game — it depends on which boards are up. Scaling against the deepest game on the slate would make a full bar mean 13 one night and 5 the next. Counting marks needs no such reference, and the grouping states the per-side split exactly.
- **Postponed is not a classification.** A postponement changes whether a row is worth opening; `NBA Cup` only describes it. They no longer share one gold pill — postponed is red and mutes the row.
- **No `Scheduled` label.** The tip time already states it. A status the catalog named differently (`Delayed`, `Final/OT`) still shows.
- **`Today` is always available**, not only as recovery from an invalid date, and is disabled on today's slate so the control doubles as a statement of where you are. The date controls become one segmented pill; the field caption moves to assistive technology since the `h1` already names the date in words.
- **Freshness keeps every surface it reported** — per-provider sentences, the `freshness-warning` treatment, the `Data freshness` group, the `Player pool` section — laid out as one wrapping line rather than a stacked block.

## Verification

Completion gate from `AGENTS.md`, run in a clean worktree off `master`:

- `npm run lint` — clean
- `npm run test:ci` — 245/245
- `npm run build` — clean
- `npm run test:e2e` — 37 passed, 2 skipped

New coverage: tip-window grouping and order, per-group mark counts (`[5, 4]`, `[8, 7]`) plus an assertion that no `.slate-bar` exists so nothing reintroduces the invented denominator, the row-as-link accessible name, the postponed/classification badge split, `Scheduled` suppression, and `Today` enabled/disabled/navigating. The e2e critical path now clicks `Today` from a past date back to the current one.

## Notes for the reviewer

- `npm run format:check` fails repo-wide (97 files) on a Windows checkout with `core.autocrlf=true`, including files this branch does not touch (`src/slateApi.js`). Not introduced here. The four changed files pass Prettier with EOL normalised. Left alone rather than reformatting the repo in this PR.
- `src/matchups/MatchupDetailPage.test.js` failed twice under full parallel `test:ci` runs and passed on re-run and in isolation each time. Untouched by this branch; looks like a pre-existing flake worth its own issue.

## Design history

Direction settled by a throwaway prototype of three structurally different layouts, on branch [`prototype/matchups-landing`](https://github.com/crf04/statsplus/tree/prototype/matchups-landing) in the coordination repository. Building it produced the finding that decided it: with no player pool every total is zero, so the ranked-table variant presented an arbitrary order as a ranking. This layout orders by tip and treats depth as an annotation, so it needs no such fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
