### PR TITLE
Make manual filters reach the API, and send only what the user chose

### DIFF
--- a/e2e/specs/core-flows.spec.js
+++ b/e2e/specs/core-flows.spec.js
@@ -197,3 +197,31 @@ test('@critical structured filters serialize through the game-log request seam',
   const latestRequest = new URL(gameLogRequests.at(-1));
   expect(latestRequest.searchParams.get('game_filter')).toBe('5');
 });
+
+test('@critical a manual defensive filter reaches the game-log request seam', async ({
+  authenticatedPage: page,
+}) => {
+  const gameLogRequests = [];
+  page.on('request', (request) => {
+    if (new URL(request.url()).pathname === '/api/games/game_logs') {
+      gameLogRequests.push(request.url());
+    }
+  });
+  await page.goto('/');
+  await page.getByRole('textbox').fill('LeBron James last 10 games');
+  await page.getByRole('textbox').press('Enter');
+  await expect(page.getByRole('heading', { name: 'Game Logs' })).toBeVisible();
+
+  const defensiveFilter = page.getByPlaceholder('Number').locator('xpath=..');
+  await defensiveFilter.getByRole('combobox').selectOption('Isolation');
+  await page.getByPlaceholder('Number').fill('5');
+  await defensiveFilter.getByRole('button', { name: 'Add' }).click();
+  await expect(page.getByRole('button', { name: 'Remove Isolation filter' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Apply Filters' }).click();
+
+  await expect.poll(() => gameLogRequests.length).toBeGreaterThan(1);
+  const latestRequest = new URL(gameLogRequests.at(-1));
+  expect(latestRequest.searchParams.getAll('teams_against[]')).toEqual(['Isolation']);
+  expect(latestRequest.searchParams.getAll('rank_filter[]')).toEqual(['5']);
+});

--- a/e2e/specs/core-flows.spec.js
+++ b/e2e/specs/core-flows.spec.js
@@ -225,24 +225,28 @@ test('@critical a manual defensive filter reaches the game-log request seam', as
   expect(latestRequest.searchParams.getAll('teams_against[]')).toEqual(['Isolation']);
   expect(latestRequest.searchParams.getAll('rank_filter[]')).toEqual(['5']);
 
-  // A rank left blank must still travel. An empty rank is stripped on the way
-  // out, which would leave one opponent filter against zero ranks and fail the
-  // backend's one-rank-per-filter rule.
-  const rankedRequestCount = gameLogRequests.length;
+  // A filter is only addable with a usable rank. A blank rank would be stripped
+  // on the way out and desynchronise rank_filter[] from teams_against[]; a rank
+  // of zero asks for the top nothing and silently returns an empty table.
   await defensiveFilter.getByRole('combobox').selectOption('Transition');
   await page.getByPlaceholder('Number').fill('');
+  await expect(defensiveFilter.getByRole('button', { name: 'Add' })).toBeDisabled();
+  await page.getByPlaceholder('Number').fill('0');
+  await expect(defensiveFilter.getByRole('button', { name: 'Add' })).toBeDisabled();
+  await expect(page.getByRole('button', { name: 'Remove Transition filter' })).toBeHidden();
+
+  // A real rank makes it addable, and both filters travel with paired ranks.
+  const rankedRequestCount = gameLogRequests.length;
+  await page.getByPlaceholder('Number').fill('-8');
   await defensiveFilter.getByRole('button', { name: 'Add' }).click();
   await expect(page.getByRole('button', { name: 'Remove Transition filter' })).toBeVisible();
 
   await page.getByRole('button', { name: 'Apply Filters' }).click();
 
   await expect.poll(() => gameLogRequests.length).toBeGreaterThan(rankedRequestCount);
-  const blankRankRequest = new URL(gameLogRequests.at(-1));
-  expect(blankRankRequest.searchParams.getAll('teams_against[]')).toEqual([
-    'Isolation',
-    'Transition',
-  ]);
-  expect(blankRankRequest.searchParams.getAll('rank_filter[]')).toEqual(['5', '0']);
+  const pairedRequest = new URL(gameLogRequests.at(-1));
+  expect(pairedRequest.searchParams.getAll('teams_against[]')).toEqual(['Isolation', 'Transition']);
+  expect(pairedRequest.searchParams.getAll('rank_filter[]')).toEqual(['5', '-8']);
 });
 
 test('@critical applying an untouched panel emits only the controls the user moved', async ({

--- a/e2e/specs/core-flows.spec.js
+++ b/e2e/specs/core-flows.spec.js
@@ -224,6 +224,25 @@ test('@critical a manual defensive filter reaches the game-log request seam', as
   const latestRequest = new URL(gameLogRequests.at(-1));
   expect(latestRequest.searchParams.getAll('teams_against[]')).toEqual(['Isolation']);
   expect(latestRequest.searchParams.getAll('rank_filter[]')).toEqual(['5']);
+
+  // A rank left blank must still travel. An empty rank is stripped on the way
+  // out, which would leave one opponent filter against zero ranks and fail the
+  // backend's one-rank-per-filter rule.
+  const rankedRequestCount = gameLogRequests.length;
+  await defensiveFilter.getByRole('combobox').selectOption('Transition');
+  await page.getByPlaceholder('Number').fill('');
+  await defensiveFilter.getByRole('button', { name: 'Add' }).click();
+  await expect(page.getByRole('button', { name: 'Remove Transition filter' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Apply Filters' }).click();
+
+  await expect.poll(() => gameLogRequests.length).toBeGreaterThan(rankedRequestCount);
+  const blankRankRequest = new URL(gameLogRequests.at(-1));
+  expect(blankRankRequest.searchParams.getAll('teams_against[]')).toEqual([
+    'Isolation',
+    'Transition',
+  ]);
+  expect(blankRankRequest.searchParams.getAll('rank_filter[]')).toEqual(['5', '0']);
 });
 
 test('@critical applying an untouched panel emits only the controls the user moved', async ({

--- a/e2e/specs/core-flows.spec.js
+++ b/e2e/specs/core-flows.spec.js
@@ -197,3 +197,46 @@ test('@critical structured filters serialize through the game-log request seam',
   const latestRequest = new URL(gameLogRequests.at(-1));
   expect(latestRequest.searchParams.get('game_filter')).toBe('5');
 });
+
+test('@critical applying an untouched panel emits only the controls the user moved', async ({
+  authenticatedPage: page,
+}) => {
+  const gameLogRequests = [];
+  page.on('request', (request) => {
+    if (new URL(request.url()).pathname === '/api/games/game_logs') {
+      gameLogRequests.push(request.url());
+    }
+  });
+  await page.goto('/');
+  await page.getByRole('textbox').fill('LeBron James last 10 games');
+  await page.getByRole('textbox').press('Enter');
+  await expect(page.getByRole('heading', { name: 'Game Logs' })).toBeVisible();
+
+  await page.getByLabel('Last N games:').fill('5');
+  await page.getByRole('button', { name: 'Apply Filters' }).click();
+
+  await expect.poll(() => gameLogRequests.length).toBeGreaterThan(1);
+  const latestRequest = new URL(gameLogRequests.at(-1));
+
+  // The one moved control and the player travel; every untouched control stays
+  // home so the API applies its own defaults.
+  expect([...latestRequest.searchParams.keys()].sort()).toEqual(['game_filter', 'player_name']);
+  expect(latestRequest.searchParams.get('game_filter')).toBe('5');
+  expect(latestRequest.searchParams.get('player_name')).toBe('LeBron James');
+
+  // Moving a second control keeps the filter the panel was pre-populated with,
+  // and still leaves the untouched controls behind.
+  const appliedRequestCount = gameLogRequests.length;
+  await page.getByLabel('Date Filter:').fill('2025-01-09');
+  await page.getByRole('button', { name: 'Apply Filters' }).click();
+
+  await expect.poll(() => gameLogRequests.length).toBeGreaterThan(appliedRequestCount);
+  const secondRequest = new URL(gameLogRequests.at(-1));
+  expect([...secondRequest.searchParams.keys()].sort()).toEqual([
+    'date_filter',
+    'game_filter',
+    'player_name',
+  ]);
+  expect(secondRequest.searchParams.get('date_filter')).toBe('2025-01-09');
+  expect(secondRequest.searchParams.get('game_filter')).toBe('5');
+});

--- a/src/AppliedFilters.js
+++ b/src/AppliedFilters.js
@@ -14,14 +14,7 @@ const AppliedFilters = ({ filters }) => {
       return null;
     }
 
-    if (key === 'teams_against' && filters.filter_numbers) {
-      return filters.teams_against.map((team, index) => (
-        <Badge key={`${key}-${index}`} bg="primary" className="me-1">
-          {`${team} (${filters.filter_numbers[index]})`}
-        </Badge>
-      ));
-    } else if (key === 'teams_against[]' && filters['rank_filter[]']) {
-      // Handle opponent filters from natural language queries
+    if (key === 'teams_against[]' && filters['rank_filter[]']) {
       const teamsArray = Array.isArray(value) ? value : [value];
       const ranksArray = Array.isArray(filters['rank_filter[]'])
         ? filters['rank_filter[]']
@@ -124,7 +117,6 @@ const AppliedFilters = ({ filters }) => {
       );
 
   const nonDefaultFilters = Object.entries(filters).filter(([key, value]) => {
-    if (key === 'filter_numbers') return false; // Skip filter_numbers as it's handled with teams_against
     if (key === 'rank_filter[]') return false; // Skip rank_filter[] as it's handled with teams_against[]
     if (key in defaultValues) {
       return value !== defaultValues[key];

--- a/src/FilterOptions.js
+++ b/src/FilterOptions.js
@@ -213,9 +213,13 @@ const FilterOptions = ({
     if (selectedDefensiveFilter !== 'None') {
       const existingFilter = activeFilters.find((f) => f.filter === selectedDefensiveFilter);
       if (!existingFilter) {
+        // Store a real number: a blank rank is stripped as empty on the way out,
+        // desynchronising rank_filter[] from teams_against[] and failing the
+        // backend's one-rank-per-filter rule.
+        const rank = parseInt(filterNumber, 10);
         setActiveFilters([
           ...activeFilters,
-          { filter: selectedDefensiveFilter, number: filterNumber },
+          { filter: selectedDefensiveFilter, number: Number.isNaN(rank) ? 0 : rank },
         ]);
         markControlTouched('teams_against');
         setSelectedDefensiveFilter('None');

--- a/src/FilterOptions.js
+++ b/src/FilterOptions.js
@@ -25,7 +25,7 @@ const FilterOptions = ({
   appliedFilters,
 }) => {
   const [selectedDefensiveFilter, setSelectedDefensiveFilter] = useState('None');
-  const [filterNumber, setFilterNumber] = useState(0);
+  const [filterNumber, setFilterNumber] = useState('');
   const [activeFilters, setActiveFilters] = useState([]);
   const [playerInput, setPlayerInput] = useState('');
   const [playerStatus, setPlayerStatus] = useState('on');
@@ -85,7 +85,7 @@ const FilterOptions = ({
   useEffect(() => {
     // Always reset all form fields to their defaults first
     setSelectedDefensiveFilter('None');
-    setFilterNumber(0);
+    setFilterNumber('');
     setActiveFilters([]);
     setPlayerInput('');
     setPlayerStatus('on');
@@ -176,12 +176,15 @@ const FilterOptions = ({
           ? appliedFilters['rank_filter[]']
           : [appliedFilters['rank_filter[]']];
 
-        const filtersToAdd = teamsAgainst.map((team, index) => ({
-          filter: team,
-          number: parseInt(rankFilter[index]) || 0,
-        }));
-        setActiveFilters(filtersToAdd);
-        prepopulatedControls.add('teams_against');
+        // Same rule as adding by hand: a rank of zero matches no team, so an
+        // unusable rank drops its filter rather than silently emptying the table.
+        const filtersToAdd = teamsAgainst
+          .map((team, index) => ({ filter: team, number: parseInt(rankFilter[index], 10) }))
+          .filter(({ number }) => !Number.isNaN(number) && number !== 0);
+        if (filtersToAdd.length > 0) {
+          setActiveFilters(filtersToAdd);
+          prepopulatedControls.add('teams_against');
+        }
       }
 
       // Pre-populate self filters
@@ -209,23 +212,25 @@ const FilterOptions = ({
     setTouchedControls(prepopulatedControls);
   }, [appliedFilters]);
 
+  // A rank is a league position: positive counts from the best defenses, negative
+  // from the worst. Zero asks for the top nothing, which silently matches no team
+  // and returns an empty table, so it is not an addable filter.
+  const parsedFilterRank = parseInt(filterNumber, 10);
+  const canAddFilter =
+    selectedDefensiveFilter !== 'None' &&
+    !Number.isNaN(parsedFilterRank) &&
+    parsedFilterRank !== 0 &&
+    !activeFilters.some((f) => f.filter === selectedDefensiveFilter);
+
   const handleAddFilter = () => {
-    if (selectedDefensiveFilter !== 'None') {
-      const existingFilter = activeFilters.find((f) => f.filter === selectedDefensiveFilter);
-      if (!existingFilter) {
-        // Store a real number: a blank rank is stripped as empty on the way out,
-        // desynchronising rank_filter[] from teams_against[] and failing the
-        // backend's one-rank-per-filter rule.
-        const rank = parseInt(filterNumber, 10);
-        setActiveFilters([
-          ...activeFilters,
-          { filter: selectedDefensiveFilter, number: Number.isNaN(rank) ? 0 : rank },
-        ]);
-        markControlTouched('teams_against');
-        setSelectedDefensiveFilter('None');
-        setFilterNumber(0);
-      }
-    }
+    if (!canAddFilter) return;
+    setActiveFilters([
+      ...activeFilters,
+      { filter: selectedDefensiveFilter, number: parsedFilterRank },
+    ]);
+    markControlTouched('teams_against');
+    setSelectedDefensiveFilter('None');
+    setFilterNumber('');
   };
 
   const handleRemoveFilter = (index) => {
@@ -646,7 +651,12 @@ const FilterOptions = ({
               placeholder="Number"
               style={{ appearance: 'textfield' }}
             />
-            <Button type="button" variant="outline-primary" onClick={handleAddFilter}>
+            <Button
+              type="button"
+              variant="outline-primary"
+              onClick={handleAddFilter}
+              disabled={!canAddFilter}
+            >
               Add
             </Button>
           </InputGroup>

--- a/src/FilterOptions.js
+++ b/src/FilterOptions.js
@@ -42,6 +42,19 @@ const FilterOptions = ({
   const [selfFilterRange, setSelfFilterRange] = useState([0, 0]);
   const [activeSelfFilters, setActiveSelfFilters] = useState([]);
   const [columnRanges, setColumnRanges] = useState({});
+  // Only controls the user touched are emitted, so the API applies its own
+  // defaults to the rest. Touched-ness is tracked rather than compared against
+  // a copy of those defaults, which would drift from the API.
+  const [touchedControls, setTouchedControls] = useState(() => new Set());
+
+  const markControlTouched = (control) => {
+    setTouchedControls((previous) => {
+      if (previous.has(control)) return previous;
+      const next = new Set(previous);
+      next.add(control);
+      return next;
+    });
+  };
 
   useEffect(() => {
     if (initialGameLogs && initialGameLogs.length > 0) {
@@ -88,21 +101,28 @@ const FilterOptions = ({
     setPlayerSuggestions([]);
     setActivePlayerSuggestionIndex(0);
 
+    // A control pre-populated from an existing filter set counts as touched, so
+    // a later apply preserves it instead of dropping it.
+    const prepopulatedControls = new Set();
+
     // Then pre-populate with new applied filters if they exist
     if (appliedFilters && Object.keys(appliedFilters).length > 0) {
       // Pre-populate game filter
       if (appliedFilters.game_filter) {
         setGameFilter(appliedFilters.game_filter);
+        prepopulatedControls.add('game_filter');
       }
 
       // Pre-populate location filter
       if (appliedFilters.location_filter) {
         setLocationFilter(appliedFilters.location_filter);
+        prepopulatedControls.add('location_filter');
       }
 
       // Pre-populate date filter
       if (appliedFilters.date_filter) {
         setDateFilter(appliedFilters.date_filter);
+        prepopulatedControls.add('date_filter');
       }
 
       // Pre-populate minutes filter
@@ -111,6 +131,7 @@ const FilterOptions = ({
         if (parts.length === 2) {
           const [min, max] = parts.map(Number);
           setMinutesFilter([min, max]);
+          prepopulatedControls.add('minutes_filter');
         }
       }
 
@@ -120,6 +141,7 @@ const FilterOptions = ({
           appliedFilters.playstyle_RTG_min,
           appliedFilters.playstyle_RTG_max,
         ]);
+        prepopulatedControls.add('playstyle_RTG');
       }
 
       // Pre-populate players on/off
@@ -142,6 +164,7 @@ const FilterOptions = ({
       }
       if (playersToAdd.length > 0) {
         setActivePlayers(playersToAdd);
+        prepopulatedControls.add('players');
       }
 
       // Pre-populate teams against filter (legacy format)
@@ -158,6 +181,7 @@ const FilterOptions = ({
           number: filterNumbers[index] || 0,
         }));
         setActiveFilters(filtersToAdd);
+        prepopulatedControls.add('teams_against');
       }
 
       // Pre-populate opponent filters from natural language queries
@@ -174,6 +198,7 @@ const FilterOptions = ({
           number: parseInt(rankFilter[index]) || 0,
         }));
         setActiveFilters(filtersToAdd);
+        prepopulatedControls.add('teams_against');
       }
 
       // Pre-populate self filters
@@ -194,8 +219,11 @@ const FilterOptions = ({
       });
       if (selfFiltersToAdd.length > 0) {
         setActiveSelfFilters(selfFiltersToAdd);
+        prepopulatedControls.add('self_filters');
       }
     }
+
+    setTouchedControls(prepopulatedControls);
   }, [appliedFilters]);
 
   const handleAddFilter = () => {
@@ -206,6 +234,7 @@ const FilterOptions = ({
           ...activeFilters,
           { filter: selectedDefensiveFilter, number: filterNumber },
         ]);
+        markControlTouched('teams_against');
         setSelectedDefensiveFilter('None');
         setFilterNumber(0);
       }
@@ -272,6 +301,7 @@ const FilterOptions = ({
   const handleAddPlayer = () => {
     if (playerInput.trim() && !activePlayers.some((p) => p.name === playerInput.trim())) {
       setActivePlayers([...activePlayers, { name: playerInput.trim(), status: playerStatus }]);
+      markControlTouched('players');
       setPlayerInput('');
       setPlayerSuggestions([]);
       setActivePlayerSuggestionIndex(0);
@@ -280,14 +310,17 @@ const FilterOptions = ({
 
   const handleLocationChange = (val) => {
     setLocationFilter(val);
+    markControlTouched('location_filter');
   };
 
   const handleMinutesFilterChange = (newValues) => {
     setMinutesFilter(newValues);
+    markControlTouched('minutes_filter');
   };
 
   const handlePlaystyleMatchupRatingChange = (newRange) => {
     setPlaystyleMatchupRating(newRange);
+    markControlTouched('playstyle_RTG');
   };
 
   const handleSelfFilterSelect = (column) => {
@@ -308,6 +341,7 @@ const FilterOptions = ({
         range: selfFilterRange,
       };
       setActiveSelfFilters([...activeSelfFilters, newFilter]);
+      markControlTouched('self_filters');
       setSelectedSelfFilter('');
       setSelfFilterRange([0, 0]);
     }
@@ -321,22 +355,38 @@ const FilterOptions = ({
     // Use displayPlayer if selectedPlayer is 'None' (from natural language queries)
     const playerName = selectedPlayer !== 'None' ? selectedPlayer : displayPlayer;
 
-    const filterParams = {
-      player_name: playerName,
-      minutes_filter: `${minutesFilter[0]},${minutesFilter[1]}`,
-      players_on: activePlayers.filter((p) => p.status === 'on').map((p) => p.name),
-      players_off: activePlayers.filter((p) => p.status === 'off').map((p) => p.name),
-      date_filter: dateFilter || null,
-      teams_against: activeFilters.map((filter) => filter.filter),
-      filter_numbers: activeFilters.map((filter) => filter.number),
-      location_filter: locationFilter,
-      game_filter: gameFilter || null,
-      playstyle_RTG_min: playstyleMatchupRating[0],
-      playstyle_RTG_max: playstyleMatchupRating[1],
-    };
-    activeSelfFilters.forEach((filter) => {
-      filterParams[`self_filters[${filter.column}]`] = filter.range.join(',');
-    });
+    const filterParams = { player_name: playerName };
+
+    if (touchedControls.has('minutes_filter')) {
+      filterParams.minutes_filter = `${minutesFilter[0]},${minutesFilter[1]}`;
+    }
+    if (touchedControls.has('players')) {
+      filterParams.players_on = activePlayers.filter((p) => p.status === 'on').map((p) => p.name);
+      filterParams.players_off = activePlayers.filter((p) => p.status === 'off').map((p) => p.name);
+    }
+    if (touchedControls.has('date_filter')) {
+      filterParams.date_filter = dateFilter || null;
+    }
+    if (touchedControls.has('teams_against')) {
+      filterParams.teams_against = activeFilters.map((filter) => filter.filter);
+      filterParams.filter_numbers = activeFilters.map((filter) => filter.number);
+    }
+    if (touchedControls.has('location_filter')) {
+      filterParams.location_filter = locationFilter;
+    }
+    if (touchedControls.has('game_filter')) {
+      filterParams.game_filter = gameFilter || null;
+    }
+    if (touchedControls.has('playstyle_RTG')) {
+      filterParams.playstyle_RTG_min = playstyleMatchupRating[0];
+      filterParams.playstyle_RTG_max = playstyleMatchupRating[1];
+    }
+    if (touchedControls.has('self_filters')) {
+      activeSelfFilters.forEach((filter) => {
+        filterParams[`self_filters[${filter.column}]`] = filter.range.join(',');
+      });
+    }
+
     onApplyFilters(filterParams);
   };
 
@@ -480,7 +530,10 @@ const FilterOptions = ({
                 id="filter-date"
                 type="date"
                 value={dateFilter}
-                onChange={(e) => setDateFilter(e.target.value)}
+                onChange={(e) => {
+                  setDateFilter(e.target.value);
+                  markControlTouched('date_filter');
+                }}
               />
             </Form.Group>
             <Form.Group className="mb-4">
@@ -527,9 +580,10 @@ const FilterOptions = ({
                 type="number"
                 min="0"
                 value={gameFilter}
-                onChange={(e) =>
-                  setGameFilter(e.target.value === '' ? '' : parseInt(e.target.value, 10))
-                }
+                onChange={(e) => {
+                  setGameFilter(e.target.value === '' ? '' : parseInt(e.target.value, 10));
+                  markControlTouched('game_filter');
+                }}
               />
             </Form.Group>
             <Form.Group className="mb-4">

--- a/src/FilterOptions.js
+++ b/src/FilterOptions.js
@@ -144,23 +144,7 @@ const FilterOptions = ({
         setActivePlayers(playersToAdd);
       }
 
-      // Pre-populate teams against filter (legacy format)
-      if (appliedFilters.teams_against && appliedFilters.filter_numbers) {
-        const teamsAgainst = Array.isArray(appliedFilters.teams_against)
-          ? appliedFilters.teams_against
-          : [appliedFilters.teams_against];
-        const filterNumbers = Array.isArray(appliedFilters.filter_numbers)
-          ? appliedFilters.filter_numbers
-          : [appliedFilters.filter_numbers];
-
-        const filtersToAdd = teamsAgainst.map((team, index) => ({
-          filter: team,
-          number: filterNumbers[index] || 0,
-        }));
-        setActiveFilters(filtersToAdd);
-      }
-
-      // Pre-populate opponent filters from natural language queries
+      // Pre-populate opponent filters
       if (appliedFilters['teams_against[]'] && appliedFilters['rank_filter[]']) {
         const teamsAgainst = Array.isArray(appliedFilters['teams_against[]'])
           ? appliedFilters['teams_against[]']
@@ -327,8 +311,8 @@ const FilterOptions = ({
       players_on: activePlayers.filter((p) => p.status === 'on').map((p) => p.name),
       players_off: activePlayers.filter((p) => p.status === 'off').map((p) => p.name),
       date_filter: dateFilter || null,
-      teams_against: activeFilters.map((filter) => filter.filter),
-      filter_numbers: activeFilters.map((filter) => filter.number),
+      'teams_against[]': activeFilters.map((filter) => filter.filter),
+      'rank_filter[]': activeFilters.map((filter) => filter.number),
       location_filter: locationFilter,
       game_filter: gameFilter || null,
       playstyle_RTG_min: playstyleMatchupRating[0],


### PR DESCRIPTION
Closes #33
Closes #34
Part of #32
Part of crf04/statsplus#28

Two prefactors for the URL work in #32, plus two defects the review found on top of them. Both tickets land together because they collided in the same function; the commits keep them separable.

## What changes for a user

**A defensive filter set in the manual panel works at all.** It never has. The panel emitted its ranks as `filter_numbers`, the API reads `rank_filter[]`, and the length mismatch meant every attempt returned 400. Only the natural-language path could set one.

**Applying sends only what you chose.** The panel serialised its whole form on every apply. Most of that was already stripped upstream, but three always-populated controls leaked — and one of them mattered: the playstyle slider is capped 75..125 while the API's own default is 0..200, so the manual path always applied a playstyle filter the natural-language path never sent. The same intent produced different results depending on which door you came through. That's now gone.

**An opponent filter needs a usable rank before you can add it.** A rank is a league position — positive from the best defenses, negative from the worst. Zero asks for the top nothing, which the backend resolves to an empty team set, so the whole request returns no games and no error. The field defaulted to `0`, so adding a filter without touching it silently emptied the table. The field now starts empty and **Add** stays disabled until the rank is a non-zero integer.

## Implementation notes

Touched-ness is tracked per control rather than comparing values against a copy of the API's defaults. Duplicating those defaults would drift, and #36 is about to make Filter Sets shareable URLs — a changed API default must not silently alter the meaning of a link someone already sent. It also has to distinguish "absent" from "explicitly emptied", which a value comparison cannot.

Pre-populated controls count as touched, so a Filter Set arriving from the natural-language path survives a later apply.

The legacy `filter_numbers` dialect is deleted rather than left alongside the correct one. Two dialects, and the branches that existed to interpret whichever arrived, are what let the 400 go unnoticed.

## Verification

Full documented gate on the merged result: `lint`, `format:check`, `test:ci` (259 tests), `build`, `test:e2e` (43 passed, 2 skipped — the deployed-only `@smoke` cases that skip without `E2E_BASE_URL`).

Both new browser tests assert at the outgoing `/api/games/game_logs` request seam, following the existing prior art, so they check what the backend actually receives rather than component internals. Each was verified by reverting its fix and confirming the assertion fails:

- without the parameter-name fix, `rank_filter[]` comes back `['5']` against two opponent filters;
- without the zero guard, **Add** is enabled when the rank is blank.

No component-level tests were added for `GameLogFilter` or `FilterOptions`, deliberately — their behaviour is observable at the request and URL seams, and asserting on the state model here would couple tests to what #37 replaces.

## Review

Reviewed cross-vendor in two passes. The first found the blank-rank desync. The second questioned the *value* the first fix coerced to, which turned out to be the more serious finding: it satisfied #33's acceptance criterion while trading a visible 400 for a silent empty table. Confirmed against the backend's rank slicing before fixing.

Two further findings were confirmed and deliberately deferred to #36, which owns the URL contract: `season_filter` is dropped by an apply (pre-existing — the previous emission never sent it either), and `AppliedFilters` holds its own hardcoded copy of the API's defaults. Both are recorded there with failing scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
