### PR TITLE
Wait for the stat clamp instead of racing it

### DIFF
--- a/src/matchups/MatchupDetailPage.test.js
+++ b/src/matchups/MatchupDetailPage.test.js
@@ -746,11 +746,15 @@ test('player switches clamp the card stat and team toggles remain user-controlle
     }),
   );
   await screen.findByRole('heading', { name: 'Austin Reaves', level: 2 });
-  expect(
-    within(screen.getByRole('group', { name: 'Selection log stat' })).getByRole('button', {
-      name: 'PTS',
-    }),
-  ).toHaveAttribute('aria-pressed', 'true');
+  // The clamp runs in an effect, so it lands a render after the heading. Waiting
+  // on the heading alone would sample the stat before the clamp is applied.
+  await waitFor(() =>
+    expect(
+      within(screen.getByRole('group', { name: 'Selection log stat' })).getByRole('button', {
+        name: 'PTS',
+      }),
+    ).toHaveAttribute('aria-pressed', 'true'),
+  );
   await userEvent.click(screen.getByRole('button', { name: 'LAL defense' }));
   expect(screen.getByRole('button', { name: 'LAL defense' })).toHaveAttribute(
     'aria-pressed',


### PR DESCRIPTION
Closes #41

## What was wrong

Switching the selection card to another player clamps the log stat back to a market that player actually posts. That clamp runs in an effect (`SelectionCard`), so it lands a render *after* the new player's heading appears.

The test awaited only the heading, then read the stat synchronously — sampling whatever was there before the effect flushed. When it hadn't, the assertion saw the pre-clamp value.

## Why it mattered more than a noisy test

`E2E` is gated behind `validate`. A flake in `validate` doesn't just add a red mark — it silently skips E2E entirely, so a pull request can fail without ever running the job most likely to catch a real regression. That happened on #40: the first run failed here, E2E never ran, and it took a re-run to get actual coverage.

## The fix

Await the clamped state rather than asserting it synchronously.

**The product behaviour was never wrong**, only later than the assertion assumed, so nothing in `SelectionCard` changes. I confirmed that rather than assuming it: the clamp is a `useEffect` keyed on the player, and waiting for it makes the test deterministic without touching the component. Had the clamp genuinely been failing some of the time, waiting would not have fixed it.

The `LAL defense` assertion immediately below follows a `userEvent.click`, which flushes effects, so it isn't racing anything and is left alone.

## Verification

Baseline was roughly one failure in four. After the change, 25 consecutive runs of the suite:

```
RESULT: 25 passed / 0 failed out of 25
```

At the observed failure rate, 25 clean runs would occur by chance less than 0.1% of the time.

Full documented gate also passes: `lint`, `format:check`, `test:ci` (259 tests), `build`, `test:e2e` (43 passed, 2 skipped — the deployed-only `@smoke` cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
