### PR TITLE
Open the Log Workspace from a URL

### DIFF
--- a/docs/adr/0001-url-is-the-game-log-query-string.md
+++ b/docs/adr/0001-url-is-the-game-log-query-string.md
@@ -1,0 +1,19 @@
+# The URL is the game-log API's query string
+
+**Status:** accepted
+
+A Filter Set in the address bar uses the game-log API's own parameter names verbatim — `player_name`, `minutes_filter`, `players_on[]`, `teams_against[]`, `rank_filter[]`, `self_filters[STAT]`, and the rest — rather than a friendlier alias vocabulary. A link is therefore readable against the existing API documentation, and the decoder is close to `Object.fromEntries`. The cost is accepted: `self_filters[PTS]=20,60` is ugly in a URL a human might read.
+
+## Considered options
+
+**An alias layer** (`?player=lebron-james&last=10&at=home`) reads better and is easier to hand-type. It was rejected because it is a second vocabulary requiring its own documentation, validation, and synchronisation every time a filter is added — and any curated alias set is a subset, so the long tail (`playstyle_RTG_min`, per-stat `self_filters`) would either leak through in raw form anyway or become unreachable by URL. One vocabulary that is occasionally ugly beats two that can disagree.
+
+**Carrying the prose of a natural-language query** alongside the filters, so a shared link could show the question that produced it. Rejected: a parameter that is displayed but never re-parsed becomes untrue the moment anyone hand-edits a filter in the URL. The applied-filter badges already state what is actually filtered.
+
+## Consequences
+
+Published links become a contract. Once someone bookmarks or shares one, changing the parameter vocabulary breaks it, so the API's names and this URL's names are now coupled deliberately rather than incidentally.
+
+**Applying emits only the controls the user touched**, and untouched controls are absent so the API applies its own defaults. This follows from the decision above rather than standing on its own: the alternative — suppressing values that equal a default — requires a copy of the API's defaults in the frontend, and that copy would drift. A changed API default must not silently alter the meaning of a link someone already sent. Tracking touched-ness also preserves the distinction between "absent" and "explicitly emptied", which a value comparison cannot express.
+
+A stray unrecognised parameter is ignored, so tracking parameters appended by a chat client or mail reader do not break a link. A recognised parameter carrying a value we cannot honour names itself and withholds the entire Filter Set, because showing results that quietly disagree with the URL is worse than refusing to show any.

--- a/e2e/specs/core-flows.spec.js
+++ b/e2e/specs/core-flows.spec.js
@@ -397,3 +397,28 @@ test('@critical a signed-out visitor keeps the link they followed', async ({ pag
   expect(requested.searchParams.get('player_name')).toBe('LeBron James');
   expect(requested.searchParams.get('game_filter')).toBe('10');
 });
+
+test('a bound the link arrived with survives a later apply', async ({
+  authenticatedPage: page,
+}) => {
+  const gameLogRequests = [];
+  page.on('request', (request) => {
+    if (new URL(request.url()).pathname === '/api/games/game_logs') {
+      gameLogRequests.push(request.url());
+    }
+  });
+
+  // 0 is the API's own lower playstyle bound, so the panel must be able to hold
+  // it. A falsy check here would drop the bound the link arrived with.
+  await page.goto('/?player_name=LeBron+James&playstyle_RTG_min=0&playstyle_RTG_max=80');
+  await expect(page.getByRole('heading', { name: 'Game Logs' })).toBeVisible();
+  await expect.poll(() => gameLogRequests.length).toBeGreaterThan(0);
+
+  const arrivedCount = gameLogRequests.length;
+  await page.getByRole('button', { name: 'Apply Filters' }).click();
+  await expect.poll(() => gameLogRequests.length).toBeGreaterThan(arrivedCount);
+
+  const reapplied = new URL(gameLogRequests.at(-1));
+  expect(reapplied.searchParams.get('playstyle_RTG_min')).toBe('0');
+  expect(reapplied.searchParams.get('playstyle_RTG_max')).toBe('80');
+});

--- a/e2e/specs/core-flows.spec.js
+++ b/e2e/specs/core-flows.spec.js
@@ -422,3 +422,22 @@ test('a bound the link arrived with survives a later apply', async ({
   expect(reapplied.searchParams.get('playstyle_RTG_min')).toBe('0');
   expect(reapplied.searchParams.get('playstyle_RTG_max')).toBe('80');
 });
+
+test('applying a playerless link asks for a player instead of sending a placeholder', async ({
+  authenticatedPage: page,
+}) => {
+  const gameLogRequests = [];
+  page.on('request', (request) => {
+    if (new URL(request.url()).pathname === '/api/games/game_logs') {
+      gameLogRequests.push(request.url());
+    }
+  });
+
+  await page.goto('/?game_filter=10');
+  await expect(page.getByLabel('Last N games:')).toHaveValue('10');
+
+  await page.getByRole('button', { name: 'Apply Filters' }).click();
+
+  await expect(page.getByRole('alert')).toContainText('Choose a player');
+  expect(gameLogRequests).toHaveLength(0);
+});

--- a/e2e/specs/core-flows.spec.js
+++ b/e2e/specs/core-flows.spec.js
@@ -291,3 +291,94 @@ test('@critical applying an untouched panel emits only the controls the user mov
   expect(secondRequest.searchParams.get('date_filter')).toBe('2025-01-09');
   expect(secondRequest.searchParams.get('game_filter')).toBe('5');
 });
+
+test('@critical a link carrying a Filter Set opens the workspace and survives reload', async ({
+  authenticatedPage: page,
+}) => {
+  const gameLogRequests = [];
+  page.on('request', (request) => {
+    if (new URL(request.url()).pathname === '/api/games/game_logs') {
+      gameLogRequests.push(request.url());
+    }
+  });
+
+  await page.goto('/?player_name=LeBron+James&game_filter=10&location_filter=Home');
+
+  // No prose was typed and no parser was called, yet the workspace is open.
+  await expect(page.getByRole('heading', { name: 'Game Logs' })).toBeVisible();
+  await expect.poll(() => gameLogRequests.length).toBeGreaterThan(0);
+  const requested = new URL(gameLogRequests.at(-1));
+  expect(requested.searchParams.get('player_name')).toBe('LeBron James');
+  expect(requested.searchParams.get('game_filter')).toBe('10');
+  expect(requested.searchParams.get('location_filter')).toBe('Home');
+
+  await page.reload();
+  await expect(page.getByRole('heading', { name: 'Game Logs' })).toBeVisible();
+  expect(page.url()).toContain('player_name=LeBron+James');
+});
+
+test('@critical a link without a player waits for one instead of erroring', async ({
+  authenticatedPage: page,
+}) => {
+  const gameLogRequests = [];
+  page.on('request', (request) => {
+    if (new URL(request.url()).pathname === '/api/games/game_logs') {
+      gameLogRequests.push(request.url());
+    }
+  });
+
+  await page.goto('/?game_filter=10');
+
+  // A Filter Set without a player is partial, not malformed: the panel holds it.
+  await expect(page.getByLabel('Last N games:')).toHaveValue('10');
+  await expect(page.getByRole('alert')).toBeHidden();
+  expect(gameLogRequests).toHaveLength(0);
+});
+
+test('a link with an unusable value names it and applies nothing', async ({
+  authenticatedPage: page,
+}) => {
+  const gameLogRequests = [];
+  page.on('request', (request) => {
+    if (new URL(request.url()).pathname === '/api/games/game_logs') {
+      gameLogRequests.push(request.url());
+    }
+  });
+
+  await page.goto('/?player_name=LeBron+James&game_filter=-3');
+
+  await expect(page.getByRole('alert')).toContainText('game_filter');
+  expect(gameLogRequests).toHaveLength(0);
+});
+
+test('a link keeps working when it carries an unrecognised parameter', async ({
+  authenticatedPage: page,
+}) => {
+  const gameLogRequests = [];
+  page.on('request', (request) => {
+    if (new URL(request.url()).pathname === '/api/games/game_logs') {
+      gameLogRequests.push(request.url());
+    }
+  });
+
+  await page.goto('/?player_name=LeBron+James&utm_source=twitter');
+
+  await expect(page.getByRole('heading', { name: 'Game Logs' })).toBeVisible();
+  await expect.poll(() => gameLogRequests.length).toBeGreaterThan(0);
+  const requested = new URL(gameLogRequests.at(-1));
+  expect(requested.searchParams.get('player_name')).toBe('LeBron James');
+  expect(requested.searchParams.has('utm_source')).toBe(false);
+});
+
+test('@critical a signed-out visitor keeps the link they followed', async ({ page }) => {
+  await installApiContract(page);
+
+  await page.goto('/?player_name=LeBron+James&game_filter=10');
+
+  await expect(
+    page.getByRole('status').filter({ hasText: 'Sign in to load these game logs' }),
+  ).toBeVisible();
+  // The requested URL is honoured, not rewritten, so signing in lands here.
+  expect(page.url()).toContain('player_name=LeBron+James');
+  expect(page.url()).toContain('game_filter=10');
+});

--- a/e2e/specs/core-flows.spec.js
+++ b/e2e/specs/core-flows.spec.js
@@ -371,6 +371,12 @@ test('a link keeps working when it carries an unrecognised parameter', async ({
 });
 
 test('@critical a signed-out visitor keeps the link they followed', async ({ page }) => {
+  const gameLogRequests = [];
+  page.on('request', (request) => {
+    if (new URL(request.url()).pathname === '/api/games/game_logs') {
+      gameLogRequests.push(request.url());
+    }
+  });
   await installApiContract(page);
 
   await page.goto('/?player_name=LeBron+James&game_filter=10');
@@ -381,4 +387,13 @@ test('@critical a signed-out visitor keeps the link they followed', async ({ pag
   // The requested URL is honoured, not rewritten, so signing in lands here.
   expect(page.url()).toContain('player_name=LeBron+James');
   expect(page.url()).toContain('game_filter=10');
+  expect(gameLogRequests).toHaveLength(0);
+
+  // Signing in fires the held Filter Set exactly once, without a second visit.
+  await page.getByRole('button', { name: 'Sign in with Google' }).click();
+  await expect(page.getByRole('heading', { name: 'Game Logs' })).toBeVisible();
+  await expect.poll(() => gameLogRequests.length).toBe(1);
+  const requested = new URL(gameLogRequests[0]);
+  expect(requested.searchParams.get('player_name')).toBe('LeBron James');
+  expect(requested.searchParams.get('game_filter')).toBe('10');
 });

--- a/src/FilterOptions.js
+++ b/src/FilterOptions.js
@@ -16,6 +16,8 @@ import ReactSlider from 'react-slider';
 import { defensiveOptions } from './utils';
 import { formatNumber, toFiniteNumber } from './numberUtils';
 
+const hasFilterValue = (value) => value !== null && value !== undefined && value !== '';
+
 const FilterOptions = ({
   playerList,
   onApplyFilters,
@@ -135,8 +137,13 @@ const FilterOptions = ({
         }
       }
 
-      // Pre-populate playstyle rating
-      if (appliedFilters.playstyle_RTG_min && appliedFilters.playstyle_RTG_max) {
+      // Pre-populate playstyle rating. Presence, not truthiness: the API's own
+      // lower bound is 0, so a link carrying it must reach the slider or a later
+      // apply would silently drop the bound the user arrived with.
+      if (
+        hasFilterValue(appliedFilters.playstyle_RTG_min) &&
+        hasFilterValue(appliedFilters.playstyle_RTG_max)
+      ) {
         setPlaystyleMatchupRating([
           appliedFilters.playstyle_RTG_min,
           appliedFilters.playstyle_RTG_max,

--- a/src/GameLogFilter.js
+++ b/src/GameLogFilter.js
@@ -276,6 +276,15 @@ const GameLogFilter = () => {
       return Promise.resolve({ ok: false, empty: true });
     }
 
+    // Arriving on a link that carries filters but no player leaves the panel
+    // holding a Filter Set with nobody to apply it to. Say so, rather than
+    // sending the placeholder and reporting a player the user never named.
+    if (!cleanedFilters.player_name || cleanedFilters.player_name === 'None') {
+      setGameLogsError('Choose a player before applying these filters.');
+      if (isFromNL && nlLoadingCallback) nlLoadingCallback(false);
+      return Promise.resolve({ ok: false, empty: true });
+    }
+
     const request = requestGameLogs(cleanedFilters, {
       includeInitial: isFromNL,
       updateSelectedTeam: true,

--- a/src/GameLogFilter.js
+++ b/src/GameLogFilter.js
@@ -1,4 +1,5 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Container, Row, Col, Card, Alert, Spinner } from 'react-bootstrap';
 import { apiClient, getApiUrl } from './config';
 import './GameLogFilter.css';
@@ -13,10 +14,26 @@ import NaturalLanguageQuery from './NaturalLanguageQuery';
 import PlayerStatsCards from './PlayerStatsCards';
 import { useAuth } from './contexts/AuthContext';
 import { fetchGameLogsData, getRequestErrorMessage, isRequestCancelled } from './gameLogsApi';
-import { cleanFilterParams, filtersForDisplay, toGameLogParams } from './filterUtils';
+import {
+  cleanFilterParams,
+  filterSetFromSearchParams,
+  filtersForDisplay,
+  toGameLogParams,
+} from './filterUtils';
+
+const listNames = (names) =>
+  names.length === 1 ? names[0] : `${names.slice(0, -1).join(', ')} and ${names.at(-1)}`;
 
 const GameLogFilter = () => {
   const { isAuthenticated, loading: authLoading } = useAuth();
+  const [searchParams] = useSearchParams();
+  // The URL is the game-log API's own query string, so a link is readable
+  // against the API documentation and needs no alias vocabulary.
+  const { filters: urlFilters, invalid: urlInvalid } = useMemo(
+    () => filterSetFromSearchParams(searchParams),
+    [searchParams],
+  );
+  const hasUrlFilterSet = Object.keys(urlFilters).length > 0 || urlInvalid.length > 0;
   const [selectedPlayer, setSelectedPlayer] = useState('None');
   const [displayPlayer, setDisplayPlayer] = useState('None'); // For UI display (includes NL queries)
   const [selectedTeam, setSelectedTeam] = useState('');
@@ -28,7 +45,7 @@ const GameLogFilter = () => {
   const [teams, setTeams] = useState([]);
   const [appliedFilters, setAppliedFilters] = useState({});
   const [initialGameLogs, setInitialGameLogs] = useState([]);
-  const [showLandingPage, setShowLandingPage] = useState(true); // Track if landing page should show
+  const [showLandingPage, setShowLandingPage] = useState(!hasUrlFilterSet);
   const [currentQuery, setCurrentQuery] = useState(''); // Track the current search query
   const [resetToLanding, setResetToLanding] = useState(false); // Signal to reset NL component
   const [isGameLogsLoading, setIsGameLogsLoading] = useState(false); // Track game logs API loading
@@ -197,6 +214,47 @@ const GameLogFilter = () => {
     return undefined;
   }, [abortGameLogsRequest, requestGameLogs, selectedPlayer]);
 
+  // A URL carrying a Filter Set opens the Log Workspace with it applied, so a
+  // view can be bookmarked, shared, and reloaded. Requests wait for auth rather
+  // than firing and failing, and the requested URL is never rewritten.
+  useEffect(() => {
+    if (!hasUrlFilterSet) return undefined;
+    setShowLandingPage(false);
+
+    if (urlInvalid.length > 0) {
+      abortGameLogsRequest();
+      setGameLogs([]);
+      setInitialGameLogs([]);
+      setAverages([]);
+      setAppliedFilters({});
+      setGameLogsError(
+        `This link could not be opened: ${listNames(urlInvalid)} ` +
+          `${urlInvalid.length === 1 ? 'is not a value' : 'are not values'} we can apply. ` +
+          'No filters were applied.',
+      );
+      return undefined;
+    }
+
+    setGameLogsError(null);
+    setAppliedFilters(urlFilters);
+    setDisplayPlayer(urlFilters.player_name || 'None');
+
+    // A Filter Set without a player is partial, not malformed: hold it in the
+    // panel and wait for the user to choose who to apply it to.
+    if (!urlFilters.player_name || authLoading || !isAuthenticated) return undefined;
+
+    requestGameLogs(urlFilters, { includeInitial: true, updateSelectedTeam: true });
+    return undefined;
+  }, [
+    abortGameLogsRequest,
+    authLoading,
+    hasUrlFilterSet,
+    isAuthenticated,
+    requestGameLogs,
+    urlFilters,
+    urlInvalid,
+  ]);
+
   const handleApplyFilters = (filterParams, isFromNL = false, nlLoadingCallback = null) => {
     const cleanedFilters = cleanFilterParams(filterParams);
     const appliedFilters = filtersForDisplay(filterParams, { naturalLanguage: isFromNL });
@@ -255,6 +313,7 @@ const GameLogFilter = () => {
         onQueryUpdate={setCurrentQuery}
         resetToLanding={resetToLanding}
         gameLogsLoading={isGameLogsLoading}
+        inWorkspace={!showLandingPage}
       />
 
       {(authLoading || listsLoading) && (
@@ -271,6 +330,12 @@ const GameLogFilter = () => {
       {gameLogsError && (
         <Alert variant="danger" className="mx-3" role="alert">
           {gameLogsError}
+        </Alert>
+      )}
+      {!showLandingPage && !authLoading && !isAuthenticated && (
+        <Alert variant="info" className="mx-3" role="status">
+          Sign in to load these game logs. This link is kept as-is, so signing in opens exactly what
+          it points at.
         </Alert>
       )}
       {isGameLogsLoading && !showLandingPage && (

--- a/src/GameLogFilter.js
+++ b/src/GameLogFilter.js
@@ -239,12 +239,22 @@ const GameLogFilter = () => {
     setAppliedFilters(urlFilters);
     setDisplayPlayer(urlFilters.player_name || 'None');
 
+    // Signing out mid-flight must not publish protected logs underneath the
+    // sign-in prompt, so drop anything already in the air.
+    if (!authLoading && !isAuthenticated) {
+      abortGameLogsRequest();
+      setGameLogs([]);
+      setInitialGameLogs([]);
+      setAverages([]);
+      return undefined;
+    }
+
     // A Filter Set without a player is partial, not malformed: hold it in the
     // panel and wait for the user to choose who to apply it to.
-    if (!urlFilters.player_name || authLoading || !isAuthenticated) return undefined;
+    if (!urlFilters.player_name || authLoading) return undefined;
 
     requestGameLogs(urlFilters, { includeInitial: true, updateSelectedTeam: true });
-    return undefined;
+    return abortGameLogsRequest;
   }, [
     abortGameLogsRequest,
     authLoading,

--- a/src/NaturalLanguageQuery.js
+++ b/src/NaturalLanguageQuery.js
@@ -23,6 +23,7 @@ const NaturalLanguageQuery = ({
   onQueryUpdate,
   resetToLanding,
   gameLogsLoading,
+  inWorkspace = false,
 }) => {
   const { isAuthenticated } = useAuth();
   const [query, setQuery] = useState('');
@@ -188,7 +189,7 @@ const NaturalLanguageQuery = ({
   };
 
   // Landing page interface (before first search)
-  if (!hasSearched) {
+  if (!hasSearched && !inWorkspace) {
     return (
       <div className="landing-page">
         <svg className="court-lines" viewBox="0 0 1200 800" aria-hidden="true" focusable="false">

--- a/src/filterUtils.js
+++ b/src/filterUtils.js
@@ -205,7 +205,6 @@ export const filtersForDisplay = (filters = {}, { naturalLanguage = false } = {}
 
 const LOCATION_VALUES = new Set(['Both', 'Home', 'Away']);
 const SELF_FILTER_KEY = /^self_filters\[(.+)\]$/;
-const MINUTES_BOUNDS = { min: 0, max: 48 };
 
 const finiteNumber = (value) => {
   if (typeof value !== 'string' || value.trim() === '') return null;
@@ -219,23 +218,33 @@ const wholeNumber = (value) => {
 };
 
 /**
- * Decode a "low,high" pair, optionally constrained to an inclusive envelope.
+ * Decode a "low,high" pair.
  *
  * Returns the pair re-spelled as plain decimals. Exponent and hex forms satisfy
  * `Number()` but are not the decimals the API reads, so a link we accepted would
  * otherwise produce a request it rejects with an error naming nothing.
+ *
+ * `whole` mirrors the API, which parses minutes as integers. No range is capped
+ * here: the API caps nothing, and overtime games really do log more than 48
+ * minutes, so an envelope would refuse links the API would honour.
  */
-const boundedRange = (value, bounds) => {
+const numericRange = (value, { whole = false } = {}) => {
   if (typeof value !== 'string') return null;
   const parts = value.split(',');
   if (parts.length !== 2) return null;
-  const [low, high] = parts.map(finiteNumber);
+  const [low, high] = parts.map(whole ? wholeNumber : finiteNumber);
   if (low === null || high === null || low > high) return null;
-  if (bounds && (low < bounds.min || high > bounds.max)) return null;
   return `${low},${high}`;
 };
 
-const SEASON_FORMAT = /^\d{4}-\d{2}$/;
+const SEASON_FORMAT = /^(\d{4})-(\d{2})$/;
+
+/** The API requires the suffix to be the following calendar year's last two digits. */
+const isCanonicalSeason = (value) => {
+  const match = SEASON_FORMAT.exec(value);
+  if (match === null) return false;
+  return match[2] === String((Number(match[1]) + 1) % 100).padStart(2, '0');
+};
 
 export const filterSetFromSearchParams = (searchParams) => {
   const filters = {};
@@ -281,8 +290,8 @@ export const filterSetFromSearchParams = (searchParams) => {
   };
 
   readText('player_name');
-  readText('season_filter', (value) => SEASON_FORMAT.test(value));
-  readDecoded('minutes_filter', (value) => boundedRange(value, MINUTES_BOUNDS));
+  readText('season_filter', isCanonicalSeason);
+  readDecoded('minutes_filter', (value) => numericRange(value, { whole: true }));
   readDecoded('date_filter', parseCalendarDate);
   readDecoded('location_filter', (value) => (LOCATION_VALUES.has(value) ? value : null));
   readDecoded('game_filter', (value) => {
@@ -301,8 +310,9 @@ export const filterSetFromSearchParams = (searchParams) => {
 
   readNames('players_on[]');
   readNames('players_off[]');
-  const presentPlayers = new Set(filters['players_on[]'] || []);
-  if ((filters['players_off[]'] || []).some((player) => presentPlayers.has(player))) {
+  const samePlayer = (name) => name.toLowerCase().replace(/\s+/g, ' ');
+  const presentPlayers = new Set((filters['players_on[]'] || []).map(samePlayer));
+  if ((filters['players_off[]'] || []).some((player) => presentPlayers.has(samePlayer(player)))) {
     reject('players_off[]');
   }
 
@@ -329,7 +339,7 @@ export const filterSetFromSearchParams = (searchParams) => {
     if (!SELF_FILTER_KEY.test(key)) continue;
     const raw = readOnce(key);
     if (raw === null) continue;
-    const range = boundedRange(raw);
+    const range = numericRange(raw);
     if (range === null) reject(key);
     else filters[key] = range;
   }

--- a/src/filterUtils.js
+++ b/src/filterUtils.js
@@ -1,3 +1,5 @@
+import { defensiveOptions } from './utils';
+import { parseCalendarDate } from './calendarDate';
 /**
  * Shared filter translation and cleaning.
  *
@@ -189,4 +191,123 @@ export const filtersForDisplay = (filters = {}, { naturalLanguage = false } = {}
   }
 
   return cleaned;
+};
+
+/**
+ * URL decoding.
+ *
+ * A shared link carries the game-log API's own parameter names, so a link is
+ * self-describing against the API documentation and needs no alias vocabulary.
+ * An unrecognised name is ignored, because a stray tracking parameter must not
+ * break someone's link. A recognised name carrying a value we cannot honour
+ * names itself and blocks the whole Filter Set: showing results that quietly
+ * disagree with the URL is worse than refusing.
+ */
+
+const LOCATION_VALUES = new Set(['Both', 'Home', 'Away']);
+const RANKABLE_FILTERS = new Set(defensiveOptions.filter((option) => option !== 'None'));
+const SELF_FILTER_KEY = /^self_filters\[(.+)\]$/;
+const MINUTES_BOUNDS = { min: 0, max: 48 };
+
+const finiteNumber = (value) => {
+  if (typeof value !== 'string' || value.trim() === '') return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const wholeNumber = (value) => {
+  const parsed = finiteNumber(value);
+  return parsed !== null && Number.isInteger(parsed) ? parsed : null;
+};
+
+/** Decode a "low,high" pair, optionally constrained to an inclusive envelope. */
+const boundedRange = (value, bounds) => {
+  if (typeof value !== 'string') return null;
+  const parts = value.split(',');
+  if (parts.length !== 2) return null;
+  const [low, high] = parts.map(finiteNumber);
+  if (low === null || high === null || low > high) return null;
+  if (bounds && (low < bounds.min || high > bounds.max)) return null;
+  return value;
+};
+
+export const filterSetFromSearchParams = (searchParams) => {
+  const filters = {};
+  const invalid = [];
+  const reject = (name) => {
+    if (!invalid.includes(name)) invalid.push(name);
+  };
+
+  const readText = (name) => {
+    const raw = searchParams.get(name);
+    if (raw === null) return;
+    const value = raw.trim();
+    if (value === '') return reject(name);
+    filters[name] = value;
+  };
+
+  const readDecoded = (name, decode) => {
+    const raw = searchParams.get(name);
+    if (raw === null) return;
+    const value = decode(raw);
+    if (value === null) return reject(name);
+    filters[name] = value;
+  };
+
+  const readNames = (name) => {
+    const values = searchParams.getAll(name);
+    if (values.length === 0) return;
+    const trimmed = values.map((value) => value.trim());
+    if (trimmed.some((value) => value === '')) return reject(name);
+    filters[name] = trimmed;
+  };
+
+  readText('player_name');
+  readText('season_filter');
+  readDecoded('minutes_filter', (value) => boundedRange(value, MINUTES_BOUNDS));
+  readDecoded('date_filter', parseCalendarDate);
+  readDecoded('location_filter', (value) => (LOCATION_VALUES.has(value) ? value : null));
+  readDecoded('game_filter', (value) => {
+    const parsed = wholeNumber(value);
+    return parsed !== null && parsed >= 0 ? parsed : null;
+  });
+  readDecoded('playstyle_RTG_min', finiteNumber);
+  readDecoded('playstyle_RTG_max', finiteNumber);
+  if (
+    hasValue(filters.playstyle_RTG_min) &&
+    hasValue(filters.playstyle_RTG_max) &&
+    filters.playstyle_RTG_min > filters.playstyle_RTG_max
+  ) {
+    reject('playstyle_RTG_max');
+  }
+
+  readNames('players_on[]');
+  readNames('players_off[]');
+
+  // Opponent filters and their ranks are one filter expressed across two
+  // parameters: the API pairs them by position and rejects any length mismatch.
+  const teams = searchParams.getAll('teams_against[]');
+  const ranks = searchParams.getAll('rank_filter[]');
+  if (teams.length > 0 || ranks.length > 0) {
+    if (teams.some((team) => !RANKABLE_FILTERS.has(team))) reject('teams_against[]');
+    // Zero asks for the top nothing, which matches no team and empties the table.
+    const parsedRanks = ranks.map(wholeNumber);
+    if (parsedRanks.some((rank) => rank === null || rank === 0)) reject('rank_filter[]');
+    if (teams.length !== ranks.length) reject('rank_filter[]');
+    if (invalid.length === 0) {
+      filters['teams_against[]'] = teams;
+      filters['rank_filter[]'] = parsedRanks;
+    }
+  }
+
+  for (const key of new Set(searchParams.keys())) {
+    if (!SELF_FILTER_KEY.test(key)) continue;
+    const range = boundedRange(searchParams.get(key));
+    if (range === null) reject(key);
+    else filters[key] = range;
+  }
+
+  // A known filter is never partially applied: what is on screen must always
+  // match what the URL says, so one bad value withholds the whole Filter Set.
+  return invalid.length > 0 ? { filters: {}, invalid } : { filters, invalid };
 };

--- a/src/filterUtils.js
+++ b/src/filterUtils.js
@@ -1,4 +1,3 @@
-import { defensiveOptions } from './utils';
 import { parseCalendarDate } from './calendarDate';
 /**
  * Shared filter translation and cleaning.
@@ -205,7 +204,6 @@ export const filtersForDisplay = (filters = {}, { naturalLanguage = false } = {}
  */
 
 const LOCATION_VALUES = new Set(['Both', 'Home', 'Away']);
-const RANKABLE_FILTERS = new Set(defensiveOptions.filter((option) => option !== 'None'));
 const SELF_FILTER_KEY = /^self_filters\[(.+)\]$/;
 const MINUTES_BOUNDS = { min: 0, max: 48 };
 
@@ -303,13 +301,20 @@ export const filterSetFromSearchParams = (searchParams) => {
 
   readNames('players_on[]');
   readNames('players_off[]');
+  const presentPlayers = new Set(filters['players_on[]'] || []);
+  if ((filters['players_off[]'] || []).some((player) => presentPlayers.has(player))) {
+    reject('players_off[]');
+  }
 
   // Opponent filters and their ranks are one filter expressed across two
   // parameters: the API pairs them by position and rejects any length mismatch.
   const teams = searchParams.getAll('teams_against[]');
   const ranks = searchParams.getAll('rank_filter[]');
   if (teams.length > 0 || ranks.length > 0) {
-    if (teams.some((team) => !RANKABLE_FILTERS.has(team))) reject('teams_against[]');
+    // Which opponent filters are rankable is the API's vocabulary, and it is
+    // wider than the panel dropdown. Validating names here would refuse links
+    // written from the API documentation, so only the structure is checked.
+    if (teams.some((team) => team.trim() === '')) reject('teams_against[]');
     // Zero asks for the top nothing, which matches no team and empties the table.
     const parsedRanks = ranks.map(wholeNumber);
     if (parsedRanks.some((rank) => rank === null || rank === 0)) reject('rank_filter[]');

--- a/src/filterUtils.js
+++ b/src/filterUtils.js
@@ -220,7 +220,13 @@ const wholeNumber = (value) => {
   return parsed !== null && Number.isInteger(parsed) ? parsed : null;
 };
 
-/** Decode a "low,high" pair, optionally constrained to an inclusive envelope. */
+/**
+ * Decode a "low,high" pair, optionally constrained to an inclusive envelope.
+ *
+ * Returns the pair re-spelled as plain decimals. Exponent and hex forms satisfy
+ * `Number()` but are not the decimals the API reads, so a link we accepted would
+ * otherwise produce a request it rejects with an error naming nothing.
+ */
 const boundedRange = (value, bounds) => {
   if (typeof value !== 'string') return null;
   const parts = value.split(',');
@@ -228,8 +234,10 @@ const boundedRange = (value, bounds) => {
   const [low, high] = parts.map(finiteNumber);
   if (low === null || high === null || low > high) return null;
   if (bounds && (low < bounds.min || high > bounds.max)) return null;
-  return value;
+  return `${low},${high}`;
 };
+
+const SEASON_FORMAT = /^\d{4}-\d{2}$/;
 
 export const filterSetFromSearchParams = (searchParams) => {
   const filters = {};
@@ -238,16 +246,28 @@ export const filterSetFromSearchParams = (searchParams) => {
     if (!invalid.includes(name)) invalid.push(name);
   };
 
-  const readText = (name) => {
-    const raw = searchParams.get(name);
+  // `get` returns only the first value, so a repeated scalar would hide any
+  // later one from validation entirely. Refuse rather than pick.
+  const readOnce = (name) => {
+    const values = searchParams.getAll(name);
+    if (values.length === 0) return null;
+    if (values.length > 1) {
+      reject(name);
+      return null;
+    }
+    return values[0];
+  };
+
+  const readText = (name, isValid) => {
+    const raw = readOnce(name);
     if (raw === null) return;
     const value = raw.trim();
-    if (value === '') return reject(name);
+    if (value === '' || (isValid && !isValid(value))) return reject(name);
     filters[name] = value;
   };
 
   const readDecoded = (name, decode) => {
-    const raw = searchParams.get(name);
+    const raw = readOnce(name);
     if (raw === null) return;
     const value = decode(raw);
     if (value === null) return reject(name);
@@ -263,13 +283,13 @@ export const filterSetFromSearchParams = (searchParams) => {
   };
 
   readText('player_name');
-  readText('season_filter');
+  readText('season_filter', (value) => SEASON_FORMAT.test(value));
   readDecoded('minutes_filter', (value) => boundedRange(value, MINUTES_BOUNDS));
   readDecoded('date_filter', parseCalendarDate);
   readDecoded('location_filter', (value) => (LOCATION_VALUES.has(value) ? value : null));
   readDecoded('game_filter', (value) => {
     const parsed = wholeNumber(value);
-    return parsed !== null && parsed >= 0 ? parsed : null;
+    return parsed !== null && parsed >= 1 ? parsed : null;
   });
   readDecoded('playstyle_RTG_min', finiteNumber);
   readDecoded('playstyle_RTG_max', finiteNumber);
@@ -302,7 +322,9 @@ export const filterSetFromSearchParams = (searchParams) => {
 
   for (const key of new Set(searchParams.keys())) {
     if (!SELF_FILTER_KEY.test(key)) continue;
-    const range = boundedRange(searchParams.get(key));
+    const raw = readOnce(key);
+    if (raw === null) continue;
+    const range = boundedRange(raw);
     if (range === null) reject(key);
     else filters[key] = range;
   }

--- a/src/filterUtils.test.js
+++ b/src/filterUtils.test.js
@@ -1,4 +1,5 @@
 import {
+  filterSetFromSearchParams,
   cleanFilterParams,
   convertNLToFilters,
   filtersForDisplay,
@@ -54,5 +55,93 @@ describe('filterUtils', () => {
         { naturalLanguage: true },
       ),
     ).toEqual({ playstyle_RTG_min: 80, playstyle_RTG_max: 120 });
+  });
+});
+
+describe('filterSetFromSearchParams', () => {
+  const decode = (query) => filterSetFromSearchParams(new URLSearchParams(query));
+
+  test('decodes every recognised parameter into a request-ready Filter Set', () => {
+    const { filters, invalid } = decode(
+      'player_name=LeBron+James&season_filter=2023-24&minutes_filter=20%2C40' +
+        '&date_filter=2026-01-09&location_filter=Home&game_filter=10' +
+        '&playstyle_RTG_min=80&playstyle_RTG_max=120' +
+        '&players_on%5B%5D=Anthony+Davis&players_off%5B%5D=Austin+Reaves' +
+        '&teams_against%5B%5D=Isolation&rank_filter%5B%5D=5' +
+        '&self_filters%5BPTS%5D=20%2C60',
+    );
+
+    expect(invalid).toEqual([]);
+    expect(filters).toEqual({
+      player_name: 'LeBron James',
+      season_filter: '2023-24',
+      minutes_filter: '20,40',
+      date_filter: '2026-01-09',
+      location_filter: 'Home',
+      game_filter: 10,
+      playstyle_RTG_min: 80,
+      playstyle_RTG_max: 120,
+      'players_on[]': ['Anthony Davis'],
+      'players_off[]': ['Austin Reaves'],
+      'teams_against[]': ['Isolation'],
+      'rank_filter[]': [5],
+      'self_filters[PTS]': '20,60',
+    });
+  });
+
+  test('keeps repeated parameters in order', () => {
+    const { filters } = decode(
+      'players_on%5B%5D=A&players_on%5B%5D=B&teams_against%5B%5D=Isolation' +
+        '&teams_against%5B%5D=Transition&rank_filter%5B%5D=5&rank_filter%5B%5D=-8',
+    );
+
+    expect(filters['players_on[]']).toEqual(['A', 'B']);
+    expect(filters['teams_against[]']).toEqual(['Isolation', 'Transition']);
+    expect(filters['rank_filter[]']).toEqual([5, -8]);
+  });
+
+  test('decodes a Filter Set carrying no player', () => {
+    const { filters, invalid } = decode('game_filter=10&location_filter=Away');
+
+    expect(invalid).toEqual([]);
+    expect(filters).toEqual({ game_filter: 10, location_filter: 'Away' });
+  });
+
+  test('ignores unrecognised parameters instead of failing', () => {
+    const { filters, invalid } = decode('player_name=LeBron+James&utm_source=twitter&ref=abc');
+
+    expect(invalid).toEqual([]);
+    expect(filters).toEqual({ player_name: 'LeBron James' });
+  });
+
+  test('empty search parameters decode to an empty Filter Set', () => {
+    expect(decode('')).toEqual({ filters: {}, invalid: [] });
+  });
+
+  test.each([
+    ['minutes_filter=oops', 'minutes_filter'],
+    ['minutes_filter=40%2C20', 'minutes_filter'],
+    ['minutes_filter=0%2C60', 'minutes_filter'],
+    ['location_filter=Somewhere', 'location_filter'],
+    ['game_filter=-3', 'game_filter'],
+    ['game_filter=1.5', 'game_filter'],
+    ['date_filter=2026-13-45', 'date_filter'],
+    ['playstyle_RTG_min=abc', 'playstyle_RTG_min'],
+    ['playstyle_RTG_min=120&playstyle_RTG_max=80', 'playstyle_RTG_max'],
+    ['player_name=+', 'player_name'],
+    ['self_filters%5BPTS%5D=20', 'self_filters[PTS]'],
+    ['teams_against%5B%5D=NotAFilter&rank_filter%5B%5D=5', 'teams_against[]'],
+    ['teams_against%5B%5D=Isolation&rank_filter%5B%5D=0', 'rank_filter[]'],
+    ['teams_against%5B%5D=Isolation', 'rank_filter[]'],
+  ])('names %s as invalid rather than guessing', (query, expected) => {
+    const { invalid } = decode(query);
+    expect(invalid).toContain(expected);
+  });
+
+  test('never partially applies a Filter Set containing an invalid value', () => {
+    const { filters, invalid } = decode('player_name=LeBron+James&game_filter=-3');
+
+    expect(invalid).toEqual(['game_filter']);
+    expect(filters).toEqual({});
   });
 });

--- a/src/filterUtils.test.js
+++ b/src/filterUtils.test.js
@@ -121,7 +121,6 @@ describe('filterSetFromSearchParams', () => {
   test.each([
     ['minutes_filter=oops', 'minutes_filter'],
     ['minutes_filter=40%2C20', 'minutes_filter'],
-    ['minutes_filter=0%2C60', 'minutes_filter'],
     ['location_filter=Somewhere', 'location_filter'],
     ['game_filter=-3', 'game_filter'],
     ['game_filter=1.5', 'game_filter'],
@@ -182,6 +181,40 @@ describe('filterSetFromSearchParams', () => {
 
     expect(invalid).toEqual(['players_off[]']);
     expect(filters).toEqual({});
+  });
+
+  test('accepts a minute range beyond the panel slider', () => {
+    // The API caps nothing; overtime games really do log 50+ minutes, so
+    // refusing them here would refuse a link the API would honour.
+    const { filters, invalid } = decode('minutes_filter=0%2C53');
+
+    expect(invalid).toEqual([]);
+    expect(filters.minutes_filter).toBe('0,53');
+  });
+
+  test.each([
+    ['minutes_filter=20.5%2C40', 'minutes_filter'],
+    ['season_filter=2023-25', 'season_filter'],
+    ['season_filter=2023-23', 'season_filter'],
+  ])('names %s, which the API would reject without naming it', (query, expected) => {
+    expect(decode(query).invalid).toContain(expected);
+  });
+
+  test('accepts a fractional self-filter range, which the API allows', () => {
+    const { filters, invalid } = decode('self_filters%5BFG_PCT%5D=0.4%2C0.6');
+
+    expect(invalid).toEqual([]);
+    expect(filters['self_filters[FG_PCT]']).toBe('0.4,0.6');
+  });
+
+  test('rejects the same player named present and absent under either spelling', () => {
+    // The API resolves names by fuzzy match, so casing and spacing collapse to
+    // the same player and the table comes back silently empty.
+    const { invalid } = decode(
+      'player_name=X&players_on%5B%5D=LeBron+James&players_off%5B%5D=lebron++james',
+    );
+
+    expect(invalid).toEqual(['players_off[]']);
   });
 
   test('never partially applies a Filter Set containing an invalid value', () => {

--- a/src/filterUtils.test.js
+++ b/src/filterUtils.test.js
@@ -130,7 +130,6 @@ describe('filterSetFromSearchParams', () => {
     ['playstyle_RTG_min=120&playstyle_RTG_max=80', 'playstyle_RTG_max'],
     ['player_name=+', 'player_name'],
     ['self_filters%5BPTS%5D=20', 'self_filters[PTS]'],
-    ['teams_against%5B%5D=NotAFilter&rank_filter%5B%5D=5', 'teams_against[]'],
     ['teams_against%5B%5D=Isolation&rank_filter%5B%5D=0', 'rank_filter[]'],
     ['teams_against%5B%5D=Isolation', 'rank_filter[]'],
   ])('names %s as invalid rather than guessing', (query, expected) => {
@@ -163,6 +162,26 @@ describe('filterSetFromSearchParams', () => {
     ['game_filter=0', 'game_filter'],
   ])('names %s as invalid rather than letting the API reject it', (query, expected) => {
     expect(decode(query).invalid).toContain(expected);
+  });
+
+  test('accepts opponent filters the panel does not offer', () => {
+    // The API's rankable vocabulary is wider than the panel dropdown; a link
+    // written from the API documentation must not be refused here.
+    const { filters, invalid } = decode('teams_against%5B%5D=Arc3Assists&rank_filter%5B%5D=8');
+
+    expect(invalid).toEqual([]);
+    expect(filters['teams_against[]']).toEqual(['Arc3Assists']);
+  });
+
+  test('rejects a player named both present and absent', () => {
+    // The API intersects on-games then subtracts off-games, so naming one
+    // player in both returns an empty table with no error.
+    const { filters, invalid } = decode(
+      'player_name=X&players_on%5B%5D=LeBron+James&players_off%5B%5D=LeBron+James',
+    );
+
+    expect(invalid).toEqual(['players_off[]']);
+    expect(filters).toEqual({});
   });
 
   test('never partially applies a Filter Set containing an invalid value', () => {

--- a/src/filterUtils.test.js
+++ b/src/filterUtils.test.js
@@ -138,6 +138,33 @@ describe('filterSetFromSearchParams', () => {
     expect(invalid).toContain(expected);
   });
 
+  test('normalises a numerically valid range to plain decimals', () => {
+    // The backend parses "low,high" as plain numbers; exponent and hex spellings
+    // satisfy Number() but are not what it reads, so canonicalise them here.
+    const { filters, invalid } = decode(
+      'minutes_filter=1e1%2C2e1&self_filters%5BPTS%5D=0x10%2C0x20',
+    );
+
+    expect(invalid).toEqual([]);
+    expect(filters.minutes_filter).toBe('10,20');
+    expect(filters['self_filters[PTS]']).toBe('16,32');
+  });
+
+  test('rejects a repeated scalar rather than honouring only the first', () => {
+    const { filters, invalid } = decode('player_name=X&game_filter=5&game_filter=-3');
+
+    expect(invalid).toEqual(['game_filter']);
+    expect(filters).toEqual({});
+  });
+
+  test.each([
+    ['season_filter=banana', 'season_filter'],
+    ['season_filter=2025', 'season_filter'],
+    ['game_filter=0', 'game_filter'],
+  ])('names %s as invalid rather than letting the API reject it', (query, expected) => {
+    expect(decode(query).invalid).toContain(expected);
+  });
+
   test('never partially applies a Filter Set containing an invalid value', () => {
     const { filters, invalid } = decode('player_name=LeBron+James&game_filter=-3');
 


### PR DESCRIPTION
Closes #35
Part of #32
Part of crf04/statsplus#28

Nothing in game-log research was addressable. A view could not be bookmarked, sent to anyone, or returned to; a reload discarded it and dropped you back at the prompt. The only way in was to type prose and have a language model parse it.

A URL carrying a Filter Set now opens the workspace with it applied.

## What a user gets

Paste or share `/?player_name=LeBron%20James&game_filter=10&location_filter=Home` and the workspace opens with those filters applied — no prose, no parser call. Reload keeps it. A link carrying filters but **no player** is treated as partial rather than broken: the panel holds the filters and waits, so "here is my filter setup, bring your own player" is a thing you can send someone. A signed-out visitor keeps the URL they followed and lands exactly there after signing in.

## Decisions

**The URL is the game-log API's query string, verbatim.** No alias layer. A link reads against the existing API documentation and the decoder needs no second vocabulary to maintain. Recorded in `docs/adr/0001-url-is-the-game-log-query-string.md`, along with the rejected alternatives — an alias layer, and carrying the prose of a parsed query.

**An unrecognised parameter is ignored; a recognised one we cannot honour names itself and withholds the entire Filter Set.** A tracking parameter appended by a chat client must not break a link, and results that quietly disagree with the URL are worse than refusing to show any.

This is the **decode direction only**. Writing Filter Sets back to the URL is #36, and the two stored landing-page flags stay until every writer writes the URL in #37.

## Review

Three passes, each verified against the backend before fixing. Thirteen defects found and closed. They fell into one shape: **a link the decoder blessed that the API would then reject with a message naming nothing** — `detail` is sanitised and logged, so a client only ever sees "One or more game log filters are invalid."

- Repeated scalars hid later values from validation (`get()` returns the first), so `?game_filter=5&game_filter=-3` applied.
- Ranges validated the number but transmitted the raw spelling, so exponent and hex forms went out verbatim.
- `season_filter` accepted any string, then only the `YYYY-YY` shape — the API also requires the suffix to be the following calendar year, so `2023-25` still 400ed.
- `game_filter=0` was accepted; the API declares `ge=1`.
- `minutes_filter` was wrong in both directions: it accepted fractions the API parses with `int()`, and imposed a 0–48 cap the API does not have, refusing overtime ranges it would honour.
- Opponent-filter names were validated against the panel dropdown, which is narrower than the API's rankable vocabulary — `Arc3Assists` and friends were refused outright.
- A player named in both `players_on` and `players_off` returns an empty table with no error; raw-string comparison then let casing and spacing evade the check.
- A playstyle bound of `0` decoded and applied but could not reach the slider, because the panel pre-populated on truthiness.
- Signing out mid-flight left the request running, so protected logs could publish beneath the sign-in prompt.
- The effect had no cleanup, so a StrictMode mount left two requests in the air.

Twice over, the mistake was treating **the panel as the contract** rather than the API — first for opponent filters, then for minutes. The panel's dropdown and slider bounds are what we offer, not what the API accepts.

## Verification

Gate green: `lint`, `format:check`, `test:ci` (290), `build`, `test:e2e` (50 passed, 2 skipped — the deployed-only `@smoke` cases).

The codec carries an exhaustive unit matrix in `filterUtils.test.js`; six browser journeys assert at the outgoing request and URL seams. Every one was checked against reverted code — pre-change, any `/?…` visit rendered the landing page, so all of them fail. The signed-out→signed-in transition is covered too: removing the `isAuthenticated` dependency previously passed the whole suite, and now fails.

No component tests were added for `GameLogFilter` or `FilterOptions`, deliberately — their behaviour is observable at those seams, and asserting on the state model would couple tests to what #37 replaces.

Rebased onto #42 so the run is not exposed to the flake that was skipping E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
