### PR TITLE
Write the Filter Set back to the URL

### DIFF
--- a/e2e/specs/core-flows.spec.js
+++ b/e2e/specs/core-flows.spec.js
@@ -533,3 +533,43 @@ test('applying a playerless link asks for a player instead of sending a placehol
   await expect(page.getByRole('alert')).toContainText('Choose a player');
   expect(gameLogRequests).toHaveLength(0);
 });
+
+test('@critical clearing a control clears its parameter', async ({ authenticatedPage: page }) => {
+  const gameLogRequests = [];
+  page.on('request', (request) => {
+    if (new URL(request.url()).pathname === '/api/games/game_logs') {
+      gameLogRequests.push(new URL(request.url()));
+    }
+  });
+
+  await page.goto('/?player_name=LeBron+James&game_filter=10');
+  await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
+  await expect(page.getByLabel('Last N games:')).toHaveValue('10');
+
+  // Emptying a control is a decision, not silence. It has to be able to say so.
+  await page.getByLabel('Last N games:').fill('');
+  await page.getByRole('button', { name: 'Apply Filters' }).click();
+
+  await expect(page).not.toHaveURL(/game_filter/);
+  await expect.poll(() => gameLogRequests.length).toBeGreaterThan(1);
+  expect(gameLogRequests.at(-1).searchParams.has('game_filter')).toBe(false);
+  await expect(page.getByText('GAMES <= 10')).toHaveCount(0);
+});
+
+test('@critical Back out of the workspace returns to the Query Prompt', async ({
+  authenticatedPage: page,
+}) => {
+  await page.goto('/');
+  await page.getByRole('textbox').fill('LeBron James last 10 games');
+  await page.getByRole('textbox').press('Enter');
+  await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
+  await expect(page).toHaveURL(/player_name=/);
+
+  // The browser's own Back button has to leave the workspace, not strand it on
+  // a bare route that says something different from what is on screen.
+  await page.goBack();
+  await expect(page).toHaveURL(/\/$/);
+  await expect(page.getByRole('heading', { name: 'CourtAI' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toHaveCount(0);
+  await expect(page.getByRole('textbox')).toHaveValue('');
+});

--- a/e2e/specs/core-flows.spec.js
+++ b/e2e/specs/core-flows.spec.js
@@ -88,12 +88,100 @@ test('@critical natural-language search renders results and returns to search', 
 
   await expect(page.getByRole('heading', { name: 'LeBron James', exact: true })).toBeVisible();
   await expect(page.getByText(`"${query}"`)).toBeVisible();
-  await expect(page.getByRole('heading', { name: 'Game Logs' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
   await expect(page.getByRole('cell', { name: '31', exact: true })).toBeVisible();
 
+  // The prose was scaffolding. The Filter Set it resolved to is the artifact
+  // worth keeping, so it goes in the address bar; the prose does not.
+  await expect(page).toHaveURL(/player_name=LeBron\+James/);
+  await expect(page).toHaveURL(/game_filter=10/);
+  expect(new URL(page.url()).searchParams.has('query')).toBe(false);
+
   await page.getByRole('button', { name: 'Back to search' }).click();
+  await expect(page).toHaveURL(/\/$/);
   await expect(page.getByRole('heading', { name: 'CourtAI' })).toBeVisible();
   await expect(page.getByRole('textbox')).toHaveValue('');
+});
+
+test('@critical a shared link reproduces a prose query with no language model', async ({
+  authenticatedPage: page,
+}) => {
+  const parserCalls = [];
+  page.on('request', (request) => {
+    if (new URL(request.url()).pathname === '/api/nl-query') parserCalls.push(request.url());
+  });
+
+  await page.goto('/');
+  await page.getByRole('textbox').fill('LeBron James last 10 games');
+  await page.getByRole('textbox').press('Enter');
+  await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
+  await expect(page).toHaveURL(/player_name=/);
+
+  // What the sender is looking at, opened by someone else.
+  const shared = new URL(page.url());
+  await page.goto('/');
+  parserCalls.length = 0;
+  await page.goto(shared.pathname + shared.search);
+
+  await expect(page.getByRole('heading', { name: 'LeBron James', exact: true })).toBeVisible();
+  await expect(page.getByRole('cell', { name: '31', exact: true })).toBeVisible();
+  expect(parserCalls).toHaveLength(0);
+});
+
+test('@critical Back undoes the last filter change', async ({ authenticatedPage: page }) => {
+  await page.goto('/?player_name=LeBron+James');
+  await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
+
+  await page.getByLabel('Last N games:').fill('5');
+  await page.getByRole('button', { name: 'Apply Filters' }).click();
+  await expect(page).toHaveURL(/game_filter=5/);
+
+  await page.goBack();
+  await expect(page).not.toHaveURL(/game_filter/);
+  await expect(page).toHaveURL(/player_name=LeBron\+James/);
+});
+
+test('@critical leaving is one action however many filters were applied', async ({
+  authenticatedPage: page,
+}) => {
+  await page.goto('/?player_name=LeBron+James');
+  await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
+
+  for (const games of ['9', '8', '7']) {
+    await page.getByLabel('Last N games:').fill(games);
+    await page.getByRole('button', { name: 'Apply Filters' }).click();
+    await expect(page).toHaveURL(new RegExp(`game_filter=${games}`));
+  }
+
+  await page.getByRole('button', { name: 'Back to search' }).click();
+  await expect(page).toHaveURL(/\/$/);
+  await expect(page.getByRole('heading', { name: 'CourtAI' })).toBeVisible();
+});
+
+test('a season the panel cannot express survives an unrelated apply', async ({
+  authenticatedPage: page,
+}) => {
+  const gameLogRequests = [];
+  page.on('request', (request) => {
+    if (new URL(request.url()).pathname === '/api/games/game_logs') {
+      gameLogRequests.push(request.url());
+    }
+  });
+
+  await page.goto('/?player_name=LeBron+James&season_filter=2023-24');
+  await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
+
+  await page.getByLabel('Last N games:').fill('5');
+  await page.getByRole('button', { name: 'Apply Filters' }).click();
+
+  await expect(page).toHaveURL(/season_filter=2023-24/);
+  await expect.poll(() => gameLogRequests.length).toBeGreaterThan(1);
+  const latest = new URL(gameLogRequests.at(-1));
+  expect(latest.searchParams.get('season_filter')).toBe('2023-24');
+  expect(latest.searchParams.get('game_filter')).toBe('5');
+  // Untouched controls stay absent so the API applies its own defaults.
+  expect(latest.searchParams.has('minutes_filter')).toBe(false);
+  expect(latest.searchParams.has('location_filter')).toBe(false);
 });
 
 test('@critical the query reference is linkable and hands an example back to search', async ({
@@ -188,7 +276,7 @@ test('@critical structured filters serialize through the game-log request seam',
   await page.goto('/');
   await page.getByRole('textbox').fill('LeBron James last 10 games');
   await page.getByRole('textbox').press('Enter');
-  await expect(page.getByRole('heading', { name: 'Game Logs' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
 
   await page.getByLabel('Last N games:').fill('5');
   await page.getByRole('button', { name: 'Apply Filters' }).click();
@@ -210,7 +298,7 @@ test('@critical a manual defensive filter reaches the game-log request seam', as
   await page.goto('/');
   await page.getByRole('textbox').fill('LeBron James last 10 games');
   await page.getByRole('textbox').press('Enter');
-  await expect(page.getByRole('heading', { name: 'Game Logs' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
 
   const defensiveFilter = page.getByPlaceholder('Number').locator('xpath=..');
   await defensiveFilter.getByRole('combobox').selectOption('Isolation');
@@ -261,7 +349,7 @@ test('@critical applying an untouched panel emits only the controls the user mov
   await page.goto('/');
   await page.getByRole('textbox').fill('LeBron James last 10 games');
   await page.getByRole('textbox').press('Enter');
-  await expect(page.getByRole('heading', { name: 'Game Logs' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
 
   await page.getByLabel('Last N games:').fill('5');
   await page.getByRole('button', { name: 'Apply Filters' }).click();
@@ -305,7 +393,7 @@ test('@critical a link carrying a Filter Set opens the workspace and survives re
   await page.goto('/?player_name=LeBron+James&game_filter=10&location_filter=Home');
 
   // No prose was typed and no parser was called, yet the workspace is open.
-  await expect(page.getByRole('heading', { name: 'Game Logs' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
   await expect.poll(() => gameLogRequests.length).toBeGreaterThan(0);
   const requested = new URL(gameLogRequests.at(-1));
   expect(requested.searchParams.get('player_name')).toBe('LeBron James');
@@ -313,7 +401,7 @@ test('@critical a link carrying a Filter Set opens the workspace and survives re
   expect(requested.searchParams.get('location_filter')).toBe('Home');
 
   await page.reload();
-  await expect(page.getByRole('heading', { name: 'Game Logs' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
   expect(page.url()).toContain('player_name=LeBron+James');
 });
 
@@ -363,7 +451,7 @@ test('a link keeps working when it carries an unrecognised parameter', async ({
 
   await page.goto('/?player_name=LeBron+James&utm_source=twitter');
 
-  await expect(page.getByRole('heading', { name: 'Game Logs' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
   await expect.poll(() => gameLogRequests.length).toBeGreaterThan(0);
   const requested = new URL(gameLogRequests.at(-1));
   expect(requested.searchParams.get('player_name')).toBe('LeBron James');
@@ -391,7 +479,7 @@ test('@critical a signed-out visitor keeps the link they followed', async ({ pag
 
   // Signing in fires the held Filter Set exactly once, without a second visit.
   await page.getByRole('button', { name: 'Sign in with Google' }).click();
-  await expect(page.getByRole('heading', { name: 'Game Logs' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
   await expect.poll(() => gameLogRequests.length).toBe(1);
   const requested = new URL(gameLogRequests[0]);
   expect(requested.searchParams.get('player_name')).toBe('LeBron James');
@@ -411,16 +499,20 @@ test('a bound the link arrived with survives a later apply', async ({
   // 0 is the API's own lower playstyle bound, so the panel must be able to hold
   // it. A falsy check here would drop the bound the link arrived with.
   await page.goto('/?player_name=LeBron+James&playstyle_RTG_min=0&playstyle_RTG_max=80');
-  await expect(page.getByRole('heading', { name: 'Game Logs' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
   await expect.poll(() => gameLogRequests.length).toBeGreaterThan(0);
 
   const arrivedCount = gameLogRequests.length;
+  // Touch an unrelated control, so the apply is a real change rather than a
+  // rewrite of the Filter Set already in the address bar.
+  await page.getByLabel('Last N games:').fill('5');
   await page.getByRole('button', { name: 'Apply Filters' }).click();
   await expect.poll(() => gameLogRequests.length).toBeGreaterThan(arrivedCount);
 
   const reapplied = new URL(gameLogRequests.at(-1));
   expect(reapplied.searchParams.get('playstyle_RTG_min')).toBe('0');
   expect(reapplied.searchParams.get('playstyle_RTG_max')).toBe('80');
+  await expect(page).toHaveURL(/playstyle_RTG_min=0/);
 });
 
 test('applying a playerless link asks for a player instead of sending a placeholder', async ({

--- a/e2e/specs/core-flows.spec.js
+++ b/e2e/specs/core-flows.spec.js
@@ -129,16 +129,28 @@ test('@critical a shared link reproduces a prose query with no language model', 
 });
 
 test('@critical Back undoes the last filter change', async ({ authenticatedPage: page }) => {
+  const gameLogRequests = [];
+  page.on('request', (request) => {
+    if (new URL(request.url()).pathname === '/api/games/game_logs') {
+      gameLogRequests.push(new URL(request.url()));
+    }
+  });
+
   await page.goto('/?player_name=LeBron+James');
   await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
 
   await page.getByLabel('Last N games:').fill('5');
   await page.getByRole('button', { name: 'Apply Filters' }).click();
   await expect(page).toHaveURL(/game_filter=5/);
+  await expect(page.getByText('GAMES <= 5').first()).toBeVisible();
 
   await page.goBack();
   await expect(page).not.toHaveURL(/game_filter/);
   await expect(page).toHaveURL(/player_name=LeBron\+James/);
+  // Undoing has to undo the view, not just the address bar.
+  await expect.poll(() => gameLogRequests.length).toBeGreaterThan(2);
+  expect(gameLogRequests.at(-1).searchParams.has('game_filter')).toBe(false);
+  await expect(page.getByText('GAMES <= 5')).toHaveCount(0);
 });
 
 test('@critical leaving is one action however many filters were applied', async ({
@@ -572,4 +584,26 @@ test('@critical Back out of the workspace returns to the Query Prompt', async ({
   await expect(page.getByRole('heading', { name: 'CourtAI' })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toHaveCount(0);
   await expect(page.getByRole('textbox')).toHaveValue('');
+});
+
+test('@critical removing every self filter clears its parameter', async ({
+  authenticatedPage: page,
+}) => {
+  const gameLogRequests = [];
+  page.on('request', (request) => {
+    if (new URL(request.url()).pathname === '/api/games/game_logs') {
+      gameLogRequests.push(new URL(request.url()));
+    }
+  });
+
+  await page.goto('/?player_name=LeBron+James&self_filters%5BPTS%5D=20%2C60');
+  await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Remove PTS filter' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Remove PTS filter' }).click();
+  await page.getByRole('button', { name: 'Apply Filters' }).click();
+
+  await expect(page).not.toHaveURL(/self_filters/);
+  await expect.poll(() => gameLogRequests.length).toBeGreaterThan(1);
+  expect(gameLogRequests.at(-1).searchParams.has('self_filters[PTS]')).toBe(false);
 });

--- a/src/FilterOptions.js
+++ b/src/FilterOptions.js
@@ -360,8 +360,12 @@ const FilterOptions = ({
       filterParams.minutes_filter = `${minutesFilter[0]},${minutesFilter[1]}`;
     }
     if (touchedControls.has('players')) {
-      filterParams.players_on = activePlayers.filter((p) => p.status === 'on').map((p) => p.name);
-      filterParams.players_off = activePlayers.filter((p) => p.status === 'off').map((p) => p.name);
+      filterParams['players_on[]'] = activePlayers
+        .filter((p) => p.status === 'on')
+        .map((p) => p.name);
+      filterParams['players_off[]'] = activePlayers
+        .filter((p) => p.status === 'off')
+        .map((p) => p.name);
     }
     if (touchedControls.has('date_filter')) {
       filterParams.date_filter = dateFilter || null;

--- a/src/FilterOptions.js
+++ b/src/FilterOptions.js
@@ -154,19 +154,16 @@ const FilterOptions = ({
       // Pre-populate players on/off
       const playersToAdd = [];
       // Check for both possible key formats
-      const playersOnKey = appliedFilters['players_on[]'] ? 'players_on[]' : 'players_on';
-      const playersOffKey = appliedFilters['players_off[]'] ? 'players_off[]' : 'players_off';
-
-      if (appliedFilters[playersOnKey]) {
-        const playersOn = Array.isArray(appliedFilters[playersOnKey])
-          ? appliedFilters[playersOnKey]
-          : [appliedFilters[playersOnKey]];
+      if (appliedFilters['players_on[]']) {
+        const playersOn = Array.isArray(appliedFilters['players_on[]'])
+          ? appliedFilters['players_on[]']
+          : [appliedFilters['players_on[]']];
         playersOn.forEach((player) => playersToAdd.push({ name: player, status: 'on' }));
       }
-      if (appliedFilters[playersOffKey]) {
-        const playersOff = Array.isArray(appliedFilters[playersOffKey])
-          ? appliedFilters[playersOffKey]
-          : [appliedFilters[playersOffKey]];
+      if (appliedFilters['players_off[]']) {
+        const playersOff = Array.isArray(appliedFilters['players_off[]'])
+          ? appliedFilters['players_off[]']
+          : [appliedFilters['players_off[]']];
         playersOff.forEach((player) => playersToAdd.push({ name: player, status: 'off' }));
       }
       if (playersToAdd.length > 0) {
@@ -348,6 +345,7 @@ const FilterOptions = ({
 
   const handleRemoveSelfFilter = (index) => {
     setActiveSelfFilters(activeSelfFilters.filter((_, i) => i !== index));
+    markControlTouched('self_filters');
   };
 
   const handleApplyFilters = () => {
@@ -385,6 +383,11 @@ const FilterOptions = ({
       filterParams.playstyle_RTG_max = playstyleMatchupRating[1];
     }
     if (touchedControls.has('self_filters')) {
+      Object.keys(appliedFilters || {})
+        .filter((key) => key.startsWith('self_filters['))
+        .forEach((key) => {
+          filterParams[key] = null;
+        });
       activeSelfFilters.forEach((filter) => {
         filterParams[`self_filters[${filter.column}]`] = filter.range.join(',');
       });

--- a/src/GameLogFilter.js
+++ b/src/GameLogFilter.js
@@ -56,6 +56,7 @@ const GameLogFilter = () => {
   const listRequestRef = useRef({ id: 0, controller: null });
   const gameLogsRequestRef = useRef({ id: 0, controller: null });
   const teamsRef = useRef([]);
+  const wasInWorkspace = useRef(false);
 
   useEffect(() => {
     teamsRef.current = teams;
@@ -215,11 +216,37 @@ const GameLogFilter = () => {
     return undefined;
   }, [abortGameLogsRequest, requestGameLogs, selectedPlayer]);
 
+  const returnToQueryPrompt = useCallback(() => {
+    abortGameLogsRequest();
+    setShowLandingPage(true);
+    setCurrentQuery('');
+    setSelectedPlayer('None');
+    setDisplayPlayer('None');
+    setAppliedFilters({});
+    setGameLogs([]);
+    setInitialGameLogs([]);
+    setAverages([]);
+    setGameLogsError(null);
+    setResetToLanding(true);
+    // Reset the flag after a brief delay to allow the effect to trigger
+    setTimeout(() => setResetToLanding(false), 100);
+  }, [abortGameLogsRequest]);
+
   // A URL carrying a Filter Set opens the Log Workspace with it applied, so a
   // view can be bookmarked, shared, and reloaded. Requests wait for auth rather
   // than firing and failing, and the requested URL is never rewritten.
   useEffect(() => {
-    if (!hasUrlFilterSet) return undefined;
+    if (!hasUrlFilterSet) {
+      // The URL no longer describes a Filter Set, so whatever workspace it
+      // opened is over — however the user got here, including by pressing the
+      // browser's own Back button. A mount on the bare route is not that
+      // transition and must leave a seeded query alone.
+      if (!wasInWorkspace.current) return undefined;
+      wasInWorkspace.current = false;
+      returnToQueryPrompt();
+      return undefined;
+    }
+    wasInWorkspace.current = true;
     setShowLandingPage(false);
 
     if (urlInvalid.length > 0) {
@@ -262,6 +289,7 @@ const GameLogFilter = () => {
     hasUrlFilterSet,
     isAuthenticated,
     requestGameLogs,
+    returnToQueryPrompt,
     urlFilters,
     urlInvalid,
   ]);
@@ -276,9 +304,18 @@ const GameLogFilter = () => {
    * arrived from a Parsed Query — survives an apply instead of being dropped.
    */
   const handleApplyFilters = (filterParams, isFromNL = false, nlLoadingCallback = null) => {
-    const cleanedFilters = cleanFilterParams(filterParams);
+    // A Parsed Query resolves to a whole Filter Set, so it replaces; the panel
+    // only ever describes part of one, so it patches.
+    //
+    // The panel's patch is deliberately not cleaned first: a control the user
+    // emptied arrives as a blank value, and that blank is the instruction to
+    // drop the parameter. Cleaning it away would make clearing a control
+    // indistinguishable from never touching it, and the old value would stand.
+    const nextFilters = isFromNL
+      ? cleanFilterParams(filterParams)
+      : mergeFilterSet(urlFilters, filterParams);
 
-    if (Object.keys(cleanedFilters).length === 0) {
+    if (Object.keys(nextFilters).length === 0) {
       setGameLogsError('Add at least one filter before loading game logs.');
       if (isFromNL && nlLoadingCallback) nlLoadingCallback(false);
       return Promise.resolve({ ok: false, empty: true });
@@ -287,17 +324,20 @@ const GameLogFilter = () => {
     // Arriving on a link that carries filters but no player leaves the panel
     // holding a Filter Set with nobody to apply it to. Say so, rather than
     // sending the placeholder and reporting a player the user never named.
-    if (!cleanedFilters.player_name || cleanedFilters.player_name === 'None') {
+    if (!nextFilters.player_name || nextFilters.player_name === 'None') {
       setGameLogsError('Choose a player before applying these filters.');
       if (isFromNL && nlLoadingCallback) nlLoadingCallback(false);
       return Promise.resolve({ ok: false, empty: true });
     }
 
-    // A Parsed Query resolves to a whole Filter Set, so it replaces; the panel
-    // only ever describes part of one, so it patches.
-    const nextFilters = isFromNL ? cleanedFilters : mergeFilterSet(urlFilters, cleanedFilters);
+    const nextSearch = filterSetToSearchParams(nextFilters);
+    // An apply that changes nothing is not a place to come back to.
+    if (nextSearch.toString() === searchParams.toString()) {
+      if (nlLoadingCallback) nlLoadingCallback(true);
+      return undefined;
+    }
     // Pushed, not replaced, so Back undoes the last filter change.
-    setSearchParams(filterSetToSearchParams(nextFilters), { replace: false });
+    setSearchParams(nextSearch, { replace: false });
 
     // The Filter Set is now recorded, which is all a Parsed Query was for. The
     // game-log request that follows reports itself through gameLogsLoading and
@@ -372,19 +412,10 @@ const GameLogFilter = () => {
         <Container fluid className="pt-2 pb-1">
           <div className="d-flex justify-content-between align-items-center mb-2">
             <button
-              onClick={() => {
-                abortGameLogsRequest();
-                setSearchParams(new URLSearchParams(), { replace: false });
-                setShowLandingPage(true);
-                setAppliedFilters({});
-                setCurrentQuery('');
-                setSelectedPlayer('None');
-                setDisplayPlayer('None');
-                setGameLogsError(null);
-                setResetToLanding(true);
-                // Reset the flag after a brief delay to allow the effect to trigger
-                setTimeout(() => setResetToLanding(false), 100);
-              }}
+              // Navigating to the bare route is the whole action: the effect
+              // watching the URL is what closes the workspace, so leaving by
+              // this button and leaving by the browser's Back button agree.
+              onClick={() => setSearchParams(new URLSearchParams(), { replace: false })}
               className="btn btn-back-to-search d-flex align-items-center"
               aria-label="Back to search"
             >

--- a/src/GameLogFilter.js
+++ b/src/GameLogFilter.js
@@ -17,7 +17,8 @@ import { fetchGameLogsData, getRequestErrorMessage, isRequestCancelled } from '.
 import {
   cleanFilterParams,
   filterSetFromSearchParams,
-  filtersForDisplay,
+  filterSetToSearchParams,
+  mergeFilterSet,
   toGameLogParams,
 } from './filterUtils';
 
@@ -26,7 +27,7 @@ const listNames = (names) =>
 
 const GameLogFilter = () => {
   const { isAuthenticated, loading: authLoading } = useAuth();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   // The URL is the game-log API's own query string, so a link is readable
   // against the API documentation and needs no alias vocabulary.
   const { filters: urlFilters, invalid: urlInvalid } = useMemo(
@@ -265,10 +266,17 @@ const GameLogFilter = () => {
     urlInvalid,
   ]);
 
+  /*
+   * Applying writes the Filter Set to the URL and stops there. The URL effect
+   * above owns the request, so there is one path from "what the user asked
+   * for" to "what the API is sent", and it runs through the address bar.
+   *
+   * The write patches rather than replaces: the panel emits only the controls
+   * the user touched, so a parameter it has no control for — a season that
+   * arrived from a Parsed Query — survives an apply instead of being dropped.
+   */
   const handleApplyFilters = (filterParams, isFromNL = false, nlLoadingCallback = null) => {
     const cleanedFilters = cleanFilterParams(filterParams);
-    const appliedFilters = filtersForDisplay(filterParams, { naturalLanguage: isFromNL });
-    setAppliedFilters(appliedFilters);
 
     if (Object.keys(cleanedFilters).length === 0) {
       setGameLogsError('Add at least one filter before loading game logs.');
@@ -285,22 +293,17 @@ const GameLogFilter = () => {
       return Promise.resolve({ ok: false, empty: true });
     }
 
-    const request = requestGameLogs(cleanedFilters, {
-      includeInitial: isFromNL,
-      updateSelectedTeam: true,
-    });
+    // A Parsed Query resolves to a whole Filter Set, so it replaces; the panel
+    // only ever describes part of one, so it patches.
+    const nextFilters = isFromNL ? cleanedFilters : mergeFilterSet(urlFilters, cleanedFilters);
+    // Pushed, not replaced, so Back undoes the last filter change.
+    setSearchParams(filterSetToSearchParams(nextFilters), { replace: false });
 
-    if (!isFromNL) return request;
-
-    return request.then((result) => {
-      // Each callback is scoped to the NL query that created it. The callback
-      // itself guards against clearing a newer query, so stale/cancelled game
-      // log requests still settle their own loading state.
-      if (nlLoadingCallback) {
-        nlLoadingCallback(result.ok === true);
-      }
-      return result;
-    });
+    // The Filter Set is now recorded, which is all a Parsed Query was for. The
+    // game-log request that follows reports itself through gameLogsLoading and
+    // the error alert.
+    if (nlLoadingCallback) nlLoadingCallback(true);
+    return undefined;
   };
 
   // Handler for natural language query results
@@ -371,7 +374,9 @@ const GameLogFilter = () => {
             <button
               onClick={() => {
                 abortGameLogsRequest();
+                setSearchParams(new URLSearchParams(), { replace: false });
                 setShowLandingPage(true);
+                setAppliedFilters({});
                 setCurrentQuery('');
                 setSelectedPlayer('None');
                 setDisplayPlayer('None');

--- a/src/filterUtils.js
+++ b/src/filterUtils.js
@@ -176,22 +176,6 @@ export const convertNLToFilters = (nlResult = {}) => {
   return cleanFilterParams(filters);
 };
 
-/** Keep default playstyle bounds out of the applied-filter badges for NL. */
-export const filtersForDisplay = (filters = {}, { naturalLanguage = false } = {}) => {
-  const cleaned = cleanFilterParams(filters);
-  if (!naturalLanguage) return cleaned;
-
-  const hasExplicitPlaystyleRange =
-    hasValue(filters.playstyle_RTG_min) && hasValue(filters.playstyle_RTG_max);
-
-  if (!hasExplicitPlaystyleRange) {
-    delete cleaned.playstyle_RTG_min;
-    delete cleaned.playstyle_RTG_max;
-  }
-
-  return cleaned;
-};
-
 /**
  * URL decoding.
  *

--- a/src/filterUtils.js
+++ b/src/filterUtils.js
@@ -348,3 +348,69 @@ export const filterSetFromSearchParams = (searchParams) => {
   // match what the URL says, so one bad value withholds the whole Filter Set.
   return invalid.length > 0 ? { filters: {}, invalid } : { filters, invalid };
 };
+
+/*
+ * The encode direction. A Filter Set becomes the query string the API would
+ * have received, so what is in the address bar and what goes on the wire are
+ * the same thing, and `filterSetFromSearchParams` reads back what this wrote.
+ */
+
+const SCALAR_FILTER_NAMES = [
+  'player_name',
+  'season_filter',
+  'minutes_filter',
+  'date_filter',
+  'location_filter',
+  'game_filter',
+  'playstyle_RTG_min',
+  'playstyle_RTG_max',
+];
+
+const REPEATED_FILTER_NAMES = ['players_on[]', 'players_off[]', 'teams_against[]', 'rank_filter[]'];
+
+/**
+ * Encode a Filter Set as game-log query parameters, in a stable order.
+ *
+ * Only the API's own vocabulary is written. A key outside it — the prose of a
+ * query, or the frontend-only `selectedPlayer` — is dropped rather than
+ * published, because a parameter nobody re-parses becomes untrue as soon as
+ * someone hand-edits the URL.
+ */
+export const filterSetToSearchParams = (filters = {}) => {
+  const cleaned = cleanFilterParams(filters);
+  const searchParams = new URLSearchParams();
+
+  SCALAR_FILTER_NAMES.forEach((name) => {
+    if (hasValue(cleaned[name])) searchParams.set(name, String(cleaned[name]));
+  });
+
+  REPEATED_FILTER_NAMES.forEach((name) => {
+    [].concat(cleaned[name] || []).forEach((value) => searchParams.append(name, String(value)));
+  });
+
+  Object.keys(cleaned)
+    .filter((name) => SELF_FILTER_KEY.test(name))
+    .sort()
+    .forEach((name) => searchParams.set(name, String(cleaned[name])));
+
+  return searchParams;
+};
+
+/**
+ * Apply a patch to a Filter Set, replacing only the parameters it names.
+ *
+ * The panel emits the controls the user touched, so everything it stays silent
+ * about survives — including parameters it has no control for at all, such as a
+ * season that arrived from a Parsed Query. A blank patch value clears its
+ * parameter, which is how a control that was emptied differs from one that was
+ * never touched.
+ */
+export const mergeFilterSet = (filters = {}, patch = {}) =>
+  Object.entries(patch).reduce(
+    (merged, [name, value]) => {
+      if (isEmptyFilterValue(value)) delete merged[name];
+      else merged[name] = value;
+      return merged;
+    },
+    { ...filters },
+  );

--- a/src/filterUtils.test.js
+++ b/src/filterUtils.test.js
@@ -1,5 +1,7 @@
 import {
   filterSetFromSearchParams,
+  filterSetToSearchParams,
+  mergeFilterSet,
   cleanFilterParams,
   convertNLToFilters,
   filtersForDisplay,
@@ -222,5 +224,94 @@ describe('filterSetFromSearchParams', () => {
 
     expect(invalid).toEqual(['game_filter']);
     expect(filters).toEqual({});
+  });
+});
+
+describe('filterSetToSearchParams', () => {
+  const roundTrip = (filters) =>
+    filterSetFromSearchParams(filterSetToSearchParams(filters)).filters;
+
+  test('round-trips every recognised parameter through the decode direction', () => {
+    const filters = {
+      player_name: 'LeBron James',
+      season_filter: '2023-24',
+      minutes_filter: '20,40',
+      date_filter: '2026-01-09',
+      location_filter: 'Home',
+      game_filter: 10,
+      playstyle_RTG_min: 80,
+      playstyle_RTG_max: 120,
+      'players_on[]': ['Anthony Davis'],
+      'players_off[]': ['Austin Reaves'],
+      'teams_against[]': ['Isolation', 'Transition'],
+      'rank_filter[]': [5, -8],
+      'self_filters[PTS]': '20,60',
+    };
+
+    expect(roundTrip(filters)).toEqual(filters);
+  });
+
+  test('writes repeated parameters under the names the API reads', () => {
+    const search = filterSetToSearchParams({
+      'players_on[]': ['A', 'B'],
+      'teams_against[]': ['Isolation'],
+      'rank_filter[]': [5],
+    });
+
+    expect(search.getAll('players_on[]')).toEqual(['A', 'B']);
+    expect(search.getAll('teams_against[]')).toEqual(['Isolation']);
+    expect(search.getAll('rank_filter[]')).toEqual(['5']);
+  });
+
+  test('omits blank values rather than writing parameters nobody chose', () => {
+    const search = filterSetToSearchParams({
+      player_name: 'LeBron James',
+      date_filter: null,
+      game_filter: '',
+      'players_on[]': [],
+    });
+
+    expect(search.toString()).toBe('player_name=LeBron+James');
+  });
+
+  test('writes nothing for a key outside the API vocabulary', () => {
+    // Prose is scaffolding, not part of the Filter Set, and the frontend-only
+    // player key never reaches the wire either.
+    const search = filterSetToSearchParams({
+      player_name: 'LeBron James',
+      selectedPlayer: 'LeBron James',
+      query: 'LeBron last 10 games',
+    });
+
+    expect(search.toString()).toBe('player_name=LeBron+James');
+  });
+
+  test('an empty Filter Set writes an empty query string', () => {
+    expect(filterSetToSearchParams({}).toString()).toBe('');
+  });
+});
+
+describe('mergeFilterSet', () => {
+  test('patches only the parameters the panel named', () => {
+    // A season arrives from a Parsed Query and no panel control can express it,
+    // so adjusting an unrelated filter must not drop it.
+    expect(
+      mergeFilterSet(
+        { player_name: 'LeBron James', season_filter: '2023-24', game_filter: 10 },
+        { player_name: 'LeBron James', game_filter: 5 },
+      ),
+    ).toEqual({ player_name: 'LeBron James', season_filter: '2023-24', game_filter: 5 });
+  });
+
+  test('a blank patch value clears its parameter', () => {
+    expect(
+      mergeFilterSet({ game_filter: 10, date_filter: '2026-01-09' }, { date_filter: null }),
+    ).toEqual({ game_filter: 10 });
+  });
+
+  test('an untouched control leaves its parameter exactly as it was', () => {
+    const current = { player_name: 'LeBron James', minutes_filter: '20,40' };
+
+    expect(mergeFilterSet(current, { player_name: 'LeBron James' })).toEqual(current);
   });
 });

--- a/src/filterUtils.test.js
+++ b/src/filterUtils.test.js
@@ -4,7 +4,6 @@ import {
   mergeFilterSet,
   cleanFilterParams,
   convertNLToFilters,
-  filtersForDisplay,
   toGameLogParams,
 } from './filterUtils';
 
@@ -47,16 +46,6 @@ describe('filterUtils', () => {
       player_name: 'A player',
       game_filter: 0,
     });
-  });
-
-  test('hides incomplete NL playstyle defaults from display filters', () => {
-    expect(filtersForDisplay({ playstyle_RTG_min: 75 }, { naturalLanguage: true })).toEqual({});
-    expect(
-      filtersForDisplay(
-        { playstyle_RTG_min: 80, playstyle_RTG_max: 120 },
-        { naturalLanguage: true },
-      ),
-    ).toEqual({ playstyle_RTG_min: 80, playstyle_RTG_max: 120 });
   });
 });
 


### PR DESCRIPTION
Closes #36.

Filter Sets could be read from a URL but nothing produced one, so the deep link was
write-only: nobody could share what they were looking at.

## What changed

`filterSetToSearchParams` and `mergeFilterSet` join the decoder in `src/filterUtils.js`,
round-tripping against it under unit test. `handleApplyFilters` now writes the Filter Set
to the address bar and stops — the effect watching the decoded URL owns the request. There
is one path from what the user asked for to what the API is sent, and it runs through the
address bar, which is what makes a prose query reproducible by someone else with no model
call at all.

Applying patches rather than replaces, so a parameter the panel has no control for — a
season that arrived from a Parsed Query — survives an apply. Applying pushes a history
entry so Back undoes the last filter change; returning to the prompt navigates to the bare
route, so leaving is one action however many filters deep the session went. Prose is not
written: a parameter that is displayed but never re-parsed becomes untrue the moment
anyone hand-edits a filter.

## Bugs found and fixed under review

Two cross-vendor review passes ran against this branch, and each found real defects:

- **A cleared control could not clear its parameter.** The panel's patch was cleaned before
  merging, which strips exactly the spellings the panel uses to say "cleared". Clearing a
  control and never touching it became the same instruction, and because the resulting URL
  was identical to the current one the apply was a silent no-op.
- **Removing every self filter did nothing**, for the same reason one control over: self
  filters are keyed per stat, so silence about a stat could not mean "drop it" the way an
  empty list does for players and opponents. Removal also never marked the control touched.
- **Browser Back stranded a zombie workspace** on the bare route. Leaving is now one thing
  the URL effect owns, so the Back button and the back-to-search control cannot disagree.

Each has a `@critical` browser test. Also fixed: a latent dialect bug where the panel emitted
`players_on` while the API reads `players_on[]` — axios normalised it on the wire, but a
shared link would have silently lost both player filters.

## Deliberately deferred

Routing every apply through the URL effect means the Self Filters stat ranges recompute from
the filtered result set, where a manual apply used to leave them alone. That value already
carries two meanings depending on entry path and #39 exists to redefine it; narrowing it here
would empty the stat list for deep links.

## Verification

`npm run lint`, `npm run format:check`, `npm run test:ci` (297), `npm run build`, and
`npm run test:e2e` (57) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)