### PR TITLE
Enter without a query, and retire the stored gate

### DIFF
--- a/e2e/specs/core-flows.spec.js
+++ b/e2e/specs/core-flows.spec.js
@@ -607,3 +607,78 @@ test('@critical removing every self filter clears its parameter', async ({
   await expect.poll(() => gameLogRequests.length).toBeGreaterThan(1);
   expect(gameLogRequests.at(-1).searchParams.has('self_filters[PTS]')).toBe(false);
 });
+
+test('@critical the escape hatch reaches a result with no language model', async ({
+  authenticatedPage: page,
+}) => {
+  const parserCalls = [];
+  page.on('request', (request) => {
+    if (new URL(request.url()).pathname === '/api/nl-query') parserCalls.push(request.url());
+  });
+  await page.goto('/');
+
+  await page.getByRole('button', { name: 'Browse without a query' }).click();
+  await expect(page).toHaveURL(/\?browse=1$/);
+  await expect(page.getByLabel('Player:')).toBeVisible();
+
+  await page.getByLabel('Player:').fill('LeBron');
+  await page.getByRole('option', { name: 'LeBron James' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
+  await expect(page.getByRole('cell', { name: '31', exact: true })).toBeVisible();
+  expect(parserCalls).toHaveLength(0);
+});
+
+test('@critical the manual entry control is present but disabled when signed out', async ({
+  page,
+}) => {
+  await installApiContract(page);
+  await page.goto('/');
+
+  // Rendered rather than hidden, so the page does not shift on sign-in and the
+  // capability is discoverable before you have an account.
+  const browse = page.getByRole('button', { name: 'Browse without a query' });
+  await expect(browse).toBeVisible();
+  await expect(browse).toBeDisabled();
+
+  await page.getByRole('button', { name: 'Sign in with Google' }).click();
+  await expect(browse).toBeEnabled();
+});
+
+test('an empty workspace is shareable, and the sentinel never reaches a request', async ({
+  authenticatedPage: page,
+}) => {
+  const gameLogRequests = [];
+  page.on('request', (request) => {
+    if (new URL(request.url()).pathname === '/api/games/game_logs') {
+      gameLogRequests.push(new URL(request.url()));
+    }
+  });
+
+  await page.goto('/?browse=1');
+  await expect(page.getByLabel('Player:')).toBeVisible();
+  expect(gameLogRequests).toHaveLength(0);
+
+  await page.getByLabel('Player:').fill('LeBron');
+  await page.getByRole('option', { name: 'LeBron James' }).click();
+
+  await expect.poll(() => gameLogRequests.length).toBeGreaterThan(0);
+  expect(gameLogRequests.at(-1).searchParams.has('browse')).toBe(false);
+
+  // Applying puts real filters in the URL, and the sentinel has stopped being
+  // true, so it goes.
+  await page.getByLabel('Last N games:').fill('5');
+  await page.getByRole('button', { name: 'Apply Filters' }).click();
+  await expect(page).toHaveURL(/game_filter=5/);
+  await expect(page).not.toHaveURL(/browse/);
+});
+
+test('the sentinel is dropped when it arrives alongside filters', async ({
+  authenticatedPage: page,
+}) => {
+  await page.goto('/?browse=1&player_name=LeBron+James');
+
+  await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
+  await expect(page).not.toHaveURL(/browse/);
+  await expect(page).toHaveURL(/player_name=LeBron\+James/);
+});

--- a/e2e/specs/core-flows.spec.js
+++ b/e2e/specs/core-flows.spec.js
@@ -682,3 +682,15 @@ test('the sentinel is dropped when it arrives alongside filters', async ({
   await expect(page).not.toHaveURL(/browse/);
   await expect(page).toHaveURL(/player_name=LeBron\+James/);
 });
+
+test('the sentinel is dropped without destroying a link we must refuse', async ({
+  authenticatedPage: page,
+}) => {
+  await page.goto('/?browse=1&game_filter=0');
+
+  // Dropping the sentinel must not take the offending parameter with it: a
+  // refusal that names nothing, on a bare route, is worse than no refusal.
+  await expect(page.getByRole('alert')).toContainText('game_filter');
+  await expect(page).toHaveURL(/game_filter=0/);
+  await expect(page).not.toHaveURL(/browse/);
+});

--- a/src/GameLogFilter.js
+++ b/src/GameLogFilter.js
@@ -233,10 +233,18 @@ const GameLogFilter = () => {
   // The sentinel only ever says "Workspace, no filters yet". Alongside filters
   // it is already untrue, so it is dropped rather than carried into a link
   // someone shares.
+  //
+  // Only the sentinel is removed, and the rest of the query string is left
+  // exactly as it arrived. Re-encoding the decoded Filter Set instead would
+  // erase a link we are refusing — the offending value withholds the whole
+  // Filter Set, so there would be nothing left to write and the refusal would
+  // be left naming a parameter no longer in the address bar.
   useEffect(() => {
     if (!hasBrowseSentinel || !hasUrlFilterSet) return;
-    setSearchParams(filterSetToSearchParams(urlFilters), { replace: true });
-  }, [hasBrowseSentinel, hasUrlFilterSet, setSearchParams, urlFilters]);
+    const withoutSentinel = new URLSearchParams(searchParams);
+    withoutSentinel.delete(BROWSE_PARAM);
+    setSearchParams(withoutSentinel, { replace: true });
+  }, [hasBrowseSentinel, hasUrlFilterSet, searchParams, setSearchParams]);
 
   // A URL carrying a Filter Set opens the Log Workspace with it applied, so a
   // view can be bookmarked, shared, and reloaded. Requests wait for auth rather
@@ -286,11 +294,17 @@ const GameLogFilter = () => {
     // panel and wait for the user to choose who to apply it to.
     if (!urlFilters.player_name || authLoading) return undefined;
 
+    // A sentinel still sitting beside filters is about to be dropped, which
+    // rewrites the URL and re-runs this effect. Let it, rather than firing a
+    // request only to abort it.
+    if (hasBrowseSentinel) return undefined;
+
     requestGameLogs(urlFilters, { includeInitial: true, updateSelectedTeam: true });
     return abortGameLogsRequest;
   }, [
     abortGameLogsRequest,
     authLoading,
+    hasBrowseSentinel,
     inWorkspace,
     isAuthenticated,
     requestGameLogs,

--- a/src/GameLogFilter.js
+++ b/src/GameLogFilter.js
@@ -15,8 +15,10 @@ import PlayerStatsCards from './PlayerStatsCards';
 import { useAuth } from './contexts/AuthContext';
 import { fetchGameLogsData, getRequestErrorMessage, isRequestCancelled } from './gameLogsApi';
 import {
+  BROWSE_PARAM,
   cleanFilterParams,
   filterSetFromSearchParams,
+  isWorkspaceSearch,
   filterSetToSearchParams,
   mergeFilterSet,
   toGameLogParams,
@@ -35,6 +37,8 @@ const GameLogFilter = () => {
     [searchParams],
   );
   const hasUrlFilterSet = Object.keys(urlFilters).length > 0 || urlInvalid.length > 0;
+  const inWorkspace = isWorkspaceSearch(searchParams);
+  const hasBrowseSentinel = searchParams.has(BROWSE_PARAM);
   const [selectedPlayer, setSelectedPlayer] = useState('None');
   const [displayPlayer, setDisplayPlayer] = useState('None'); // For UI display (includes NL queries)
   const [selectedTeam, setSelectedTeam] = useState('');
@@ -46,9 +50,7 @@ const GameLogFilter = () => {
   const [teams, setTeams] = useState([]);
   const [appliedFilters, setAppliedFilters] = useState({});
   const [initialGameLogs, setInitialGameLogs] = useState([]);
-  const [showLandingPage, setShowLandingPage] = useState(!hasUrlFilterSet);
   const [currentQuery, setCurrentQuery] = useState(''); // Track the current search query
-  const [resetToLanding, setResetToLanding] = useState(false); // Signal to reset NL component
   const [isGameLogsLoading, setIsGameLogsLoading] = useState(false); // Track game logs API loading
   const [gameLogsError, setGameLogsError] = useState(null);
   const [listsLoading, setListsLoading] = useState(false);
@@ -218,7 +220,6 @@ const GameLogFilter = () => {
 
   const returnToQueryPrompt = useCallback(() => {
     abortGameLogsRequest();
-    setShowLandingPage(true);
     setCurrentQuery('');
     setSelectedPlayer('None');
     setDisplayPlayer('None');
@@ -227,17 +228,22 @@ const GameLogFilter = () => {
     setInitialGameLogs([]);
     setAverages([]);
     setGameLogsError(null);
-    setResetToLanding(true);
-    // Reset the flag after a brief delay to allow the effect to trigger
-    setTimeout(() => setResetToLanding(false), 100);
   }, [abortGameLogsRequest]);
+
+  // The sentinel only ever says "Workspace, no filters yet". Alongside filters
+  // it is already untrue, so it is dropped rather than carried into a link
+  // someone shares.
+  useEffect(() => {
+    if (!hasBrowseSentinel || !hasUrlFilterSet) return;
+    setSearchParams(filterSetToSearchParams(urlFilters), { replace: true });
+  }, [hasBrowseSentinel, hasUrlFilterSet, setSearchParams, urlFilters]);
 
   // A URL carrying a Filter Set opens the Log Workspace with it applied, so a
   // view can be bookmarked, shared, and reloaded. Requests wait for auth rather
   // than firing and failing, and the requested URL is never rewritten.
   useEffect(() => {
-    if (!hasUrlFilterSet) {
-      // The URL no longer describes a Filter Set, so whatever workspace it
+    if (!inWorkspace) {
+      // The URL no longer opens a Workspace, so whatever workspace it
       // opened is over — however the user got here, including by pressing the
       // browser's own Back button. A mount on the bare route is not that
       // transition and must leave a seeded query alone.
@@ -247,7 +253,6 @@ const GameLogFilter = () => {
       return undefined;
     }
     wasInWorkspace.current = true;
-    setShowLandingPage(false);
 
     if (urlInvalid.length > 0) {
       abortGameLogsRequest();
@@ -286,7 +291,7 @@ const GameLogFilter = () => {
   }, [
     abortGameLogsRequest,
     authLoading,
-    hasUrlFilterSet,
+    inWorkspace,
     isAuthenticated,
     requestGameLogs,
     returnToQueryPrompt,
@@ -357,10 +362,7 @@ const GameLogFilter = () => {
     const playerName = convertedFilters.selectedPlayer;
     const apiFilters = toGameLogParams(convertedFilters);
     const finishNLRequest = (success) => {
-      if (success) {
-        if (playerName) setDisplayPlayer(playerName);
-        setShowLandingPage(false);
-      }
+      if (success && playerName) setDisplayPlayer(playerName);
       if (nlLoadingCallback) nlLoadingCallback(success);
     };
 
@@ -373,9 +375,8 @@ const GameLogFilter = () => {
       <NaturalLanguageQuery
         onFiltersApplied={handleNLQueryResults}
         onQueryUpdate={setCurrentQuery}
-        resetToLanding={resetToLanding}
         gameLogsLoading={isGameLogsLoading}
-        inWorkspace={!showLandingPage}
+        inWorkspace={inWorkspace}
       />
 
       {(authLoading || listsLoading) && (
@@ -394,13 +395,13 @@ const GameLogFilter = () => {
           {gameLogsError}
         </Alert>
       )}
-      {!showLandingPage && !authLoading && !isAuthenticated && (
+      {inWorkspace && !authLoading && !isAuthenticated && (
         <Alert variant="info" className="mx-3" role="status">
           Sign in to load these game logs. This link is kept as-is, so signing in opens exactly what
           it points at.
         </Alert>
       )}
-      {isGameLogsLoading && !showLandingPage && (
+      {isGameLogsLoading && inWorkspace && (
         <div className="text-center text-light py-2" role="status" aria-live="polite">
           <Spinner animation="border" size="sm" className="me-2" />
           Loading game logs…
@@ -408,7 +409,7 @@ const GameLogFilter = () => {
       )}
 
       {/* Player Stats Cards - positioned between search and main content */}
-      {!showLandingPage && (
+      {inWorkspace && (
         <Container fluid className="pt-2 pb-1">
           <div className="d-flex justify-content-between align-items-center mb-2">
             <button
@@ -437,7 +438,7 @@ const GameLogFilter = () => {
       )}
 
       {/* Only show main content after landing page */}
-      {!showLandingPage && (
+      {inWorkspace && (
         <Container fluid className="game-log-filter py-2">
           <Row className="mb-5">
             <Col md={8}>
@@ -448,7 +449,6 @@ const GameLogFilter = () => {
                     setSelectedPlayer={(player) => {
                       setSelectedPlayer(player);
                       setDisplayPlayer(player);
-                      setShowLandingPage(false); // Hide landing page on manual selection
                     }}
                     lineType={lineType}
                     setLineType={setLineType}

--- a/src/ModernSearch.css
+++ b/src/ModernSearch.css
@@ -1129,3 +1129,30 @@
 .compact-search-icon.loading {
   animation: pulse 1.5s ease-in-out infinite;
 }
+
+.prompt-browse {
+  display: flex;
+  justify-content: center;
+  margin: -12px 0 24px;
+}
+
+.prompt-browse-button {
+  background: none;
+  border: none;
+  border-bottom: 1px solid rgba(232, 163, 61, 0.45);
+  padding: 2px 0;
+  color: #c9c2b2;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.prompt-browse-button:hover:not(:disabled) {
+  color: #f6b950;
+}
+
+.prompt-browse-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}

--- a/src/NaturalLanguageQuery.js
+++ b/src/NaturalLanguageQuery.js
@@ -1,10 +1,10 @@
 import { useState, useRef, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { Form, Button } from 'react-bootstrap';
 import { Search, CheckCircle, AlertCircle, Brain } from 'lucide-react';
 import { apiClient, getApiUrl } from './config';
 import { useAuth } from './contexts/AuthContext';
-import { convertNLToFilters } from './filterUtils';
+import { BROWSE_PARAM, convertNLToFilters } from './filterUtils';
 import { getRequestErrorMessage, isRequestCancelled } from './gameLogsApi';
 import { NL_QUERY_TIMEOUT } from './apiSettings';
 import QueryLadder from './help/QueryLadder';
@@ -21,7 +21,6 @@ const sampleQueries = [
 const NaturalLanguageQuery = ({
   onFiltersApplied,
   onQueryUpdate,
-  resetToLanding,
   gameLogsLoading,
   inWorkspace = false,
 }) => {
@@ -30,9 +29,10 @@ const NaturalLanguageQuery = ({
   const [loading, setLoading] = useState(false);
   const [lastResult, setLastResult] = useState(null);
   const [error, setError] = useState('');
-  const [hasSearched, setHasSearched] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
   const location = useLocation();
+  const navigate = useNavigate();
+  const wasInWorkspace = useRef(inWorkspace);
 
   // Combined loading state: true if either NL query or game logs are loading
   const isLoading = loading || gameLogsLoading;
@@ -56,26 +56,30 @@ const NaturalLanguageQuery = ({
     };
   }, [isExpanded]);
 
-  // Reset to landing page when requested by parent
+  // Leaving the Log Workspace starts a fresh query. This watches the
+  // transition rather than a signal prop, so there is no flag to resynchronise
+  // and no timing workaround. A mount that merely lands on the Query Prompt —
+  // arriving from the reference page with a draft, say — is not that
+  // transition and must keep what it was seeded with.
   useEffect(() => {
-    if (resetToLanding) {
+    if (wasInWorkspace.current && !inWorkspace) {
       queryRequestRef.current.controller?.abort();
       queryRequestRef.current = { id: queryRequestRef.current.id + 1, controller: null };
       setLoading(false);
-      setHasSearched(false);
       setQuery('');
       setError('');
       setLastResult(null);
       setIsExpanded(false);
     }
-  }, [resetToLanding]);
+    wasInWorkspace.current = inWorkspace;
+  }, [inWorkspace]);
 
   // Close expanded search bar when transitioning to results page
   useEffect(() => {
-    if (hasSearched && !isLoading) {
+    if (inWorkspace && !isLoading) {
       setIsExpanded(false);
     }
-  }, [hasSearched, isLoading]);
+  }, [inWorkspace, isLoading]);
 
   // An example chosen on the query reference page arrives as router state.
   useEffect(() => {
@@ -87,12 +91,12 @@ const NaturalLanguageQuery = ({
   // query language demos itself before the user types anything.
   const [placeholderIdx, setPlaceholderIdx] = useState(0);
   useEffect(() => {
-    if (hasSearched || !isAuthenticated) return undefined;
+    if (inWorkspace || !isAuthenticated) return undefined;
     const id = setInterval(() => {
       setPlaceholderIdx((i) => (i + 1) % sampleQueries.length);
     }, 4000);
     return () => clearInterval(id);
-  }, [hasSearched, isAuthenticated]);
+  }, [inWorkspace, isAuthenticated]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -107,10 +111,9 @@ const NaturalLanguageQuery = ({
     const controller = new AbortController();
     queryRequestRef.current = { id: requestId, controller };
 
-    const finishLoading = (success) => {
+    const finishLoading = () => {
       if (queryRequestRef.current.id !== requestId) return;
       setLoading(false);
-      if (success) setHasSearched(true);
     };
 
     try {
@@ -136,7 +139,7 @@ const NaturalLanguageQuery = ({
         setError(
           'I could not find usable filters in that query. Please try a player or stat filter.',
         );
-        finishLoading(false);
+        finishLoading();
         return;
       }
 
@@ -149,18 +152,18 @@ const NaturalLanguageQuery = ({
         // embedders that return a promise but do not use the callback seam.
         if (application && typeof application.then === 'function') {
           application
-            .then((result) => {
+            .then(() => {
               if (
                 queryRequestRef.current.id === requestId &&
                 queryRequestRef.current.controller === controller
               ) {
-                finishLoading(result?.ok === true);
+                finishLoading();
               }
             })
-            .catch(() => finishLoading(false));
+            .catch(() => finishLoading());
         }
       } else {
-        finishLoading(true);
+        finishLoading();
       }
 
       // Update parent with the successful query
@@ -171,8 +174,8 @@ const NaturalLanguageQuery = ({
       if (isRequestCancelled(err) || queryRequestRef.current.id !== requestId) return;
       console.error('NL Query Error:', err.response?.status || err.message);
       setError(getRequestErrorMessage(err, 'Failed to process query. Please try again.'));
-      finishLoading(false);
-      // Don't set hasSearched to true on error - keep user on landing page to retry
+      finishLoading();
+      // Stay on the Query Prompt on error so the query can be retried.
     }
   };
 
@@ -188,8 +191,9 @@ const NaturalLanguageQuery = ({
     return <AlertCircle size={16} />;
   };
 
-  // Landing page interface (before first search)
-  if (!hasSearched && !inWorkspace) {
+  // The Query Prompt. Whether we are past it is the URL's business, not a flag
+  // this component keeps.
+  if (!inWorkspace) {
     return (
       <div className="landing-page">
         <svg className="court-lines" viewBox="0 0 1200 800" aria-hidden="true" focusable="false">
@@ -238,6 +242,20 @@ const NaturalLanguageQuery = ({
                 </Button>
               </div>
             </Form>
+          </div>
+
+          {/* The deterministic door. Disabled rather than hidden when signed
+              out, so the capability is discoverable and the page does not
+              reflow on sign-in. */}
+          <div className="prompt-browse">
+            <button
+              type="button"
+              className="prompt-browse-button"
+              disabled={isLoading || !isAuthenticated}
+              onClick={() => navigate(`/?${BROWSE_PARAM}=1`)}
+            >
+              Browse without a query
+            </button>
           </div>
 
           <QueryLadder

--- a/src/NaturalLanguageQuery.test.js
+++ b/src/NaturalLanguageQuery.test.js
@@ -109,7 +109,36 @@ describe('NaturalLanguageQuery', () => {
       secondFinishLoading(true);
       resolveSecondApplication({ ok: true });
     });
+    expect(input).not.toBeDisabled();
+  });
+
+  test('the Query Prompt gives way to the compact search on the URL alone', () => {
+    // Whether we are past the prompt is the URL's business. This component
+    // keeps no flag of its own, so a future entry path cannot be locked behind
+    // the language model the way the manual filter panel was.
+    const { rerender } = render(
+      <MemoryRouter>
+        <NaturalLanguageQuery onFiltersApplied={jest.fn()} inWorkspace={false} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole('heading', { name: 'CourtAI' })).toBeInTheDocument();
+
+    rerender(
+      <MemoryRouter>
+        <NaturalLanguageQuery onFiltersApplied={jest.fn()} inWorkspace />
+      </MemoryRouter>,
+    );
     expect(screen.getByRole('button', { name: /open search/i })).toBeInTheDocument();
+  });
+
+  test('offers a deterministic door beside the query prompt', () => {
+    render(
+      <MemoryRouter>
+        <NaturalLanguageQuery onFiltersApplied={jest.fn()} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('button', { name: /browse without a query/i })).toBeInTheDocument();
   });
 
   test('seeds the search box with an example chosen on the query reference page', () => {

--- a/src/filterUtils.js
+++ b/src/filterUtils.js
@@ -398,3 +398,27 @@ export const mergeFilterSet = (filters = {}, patch = {}) =>
     },
     { ...filters },
   );
+
+/**
+ * The only non-filter search parameter.
+ *
+ * Manual entry lands with an empty Filter Set, which is indistinguishable from
+ * a fresh visit, so the escape hatch navigates to this sentinel to declare
+ * intent to work in the Workspace without filters. It is never part of a Filter
+ * Set, so it never reaches a request, and it is dropped as soon as real filters
+ * exist — any URL carrying filters stays a pure API query string.
+ */
+export const BROWSE_PARAM = 'browse';
+
+/**
+ * The one place that decides whether the user is in the Log Workspace.
+ *
+ * Deriving this from the URL rather than storing it is what keeps a future
+ * entry path from being accidentally locked behind the language model, which is
+ * exactly what two separate stored flags did to the manual filter panel.
+ */
+export const isWorkspaceSearch = (searchParams) => {
+  if (searchParams.has(BROWSE_PARAM)) return true;
+  const { filters, invalid } = filterSetFromSearchParams(searchParams);
+  return Object.keys(filters).length > 0 || invalid.length > 0;
+};

--- a/src/filterUtils.test.js
+++ b/src/filterUtils.test.js
@@ -1,4 +1,6 @@
 import {
+  BROWSE_PARAM,
+  isWorkspaceSearch,
   filterSetFromSearchParams,
   filterSetToSearchParams,
   mergeFilterSet,
@@ -302,5 +304,42 @@ describe('mergeFilterSet', () => {
     const current = { player_name: 'LeBron James', minutes_filter: '20,40' };
 
     expect(mergeFilterSet(current, { player_name: 'LeBron James' })).toEqual(current);
+  });
+});
+
+describe('isWorkspaceSearch', () => {
+  const gate = (query) => isWorkspaceSearch(new URLSearchParams(query));
+
+  test('a bare route is the Query Prompt', () => {
+    expect(gate('')).toBe(false);
+  });
+
+  test('the sentinel alone opens an empty Log Workspace', () => {
+    // Manual entry lands with no filters, and an empty Filter Set is otherwise
+    // indistinguishable from a fresh visit.
+    expect(gate(`${BROWSE_PARAM}=1`)).toBe(true);
+  });
+
+  test('any Filter Set opens the Log Workspace', () => {
+    expect(gate('player_name=LeBron+James')).toBe(true);
+    expect(gate('game_filter=10')).toBe(true);
+  });
+
+  test('a link we must refuse still opens the Workspace, to say so', () => {
+    expect(gate('game_filter=0')).toBe(true);
+  });
+
+  test('a stray tracking parameter is not an entry', () => {
+    expect(gate('utm_source=newsletter')).toBe(false);
+  });
+
+  test('the sentinel is not a filter and never reaches a request', () => {
+    const { filters, invalid } = filterSetFromSearchParams(
+      new URLSearchParams(`player_name=LeBron+James&${BROWSE_PARAM}=1`),
+    );
+
+    expect(invalid).toEqual([]);
+    expect(filters).toEqual({ player_name: 'LeBron James' });
+    expect(filterSetToSearchParams(filters).has(BROWSE_PARAM)).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #37. Supersedes #45, which GitHub auto-closed when its stacked base branch (#44) was merged and deleted.

## What changed

Every route into game-log research ran through the language model. Knowing exactly which
player and filters you wanted did not help — you still had to phrase it as prose and hope
the parse agreed, and a parse failure was a dead end.

A **"Browse without a query"** control now sits beneath the search form and opens an empty
Log Workspace with the player selector ready and no model involved. Signed out it renders
disabled rather than hidden, so the capability is discoverable and the page does not shift
on sign-in.

**The stored gate is gone.** Two booleans in two components both meant "past the Query
Prompt" — which is exactly why the manual filter panel could never be reached without the
language model: one meant "has searched", and the panel rendered inside the other.
`showLandingPage`, `hasSearched`, the `resetToLanding` signal prop and its
`setTimeout(…, 100)` resynchronisation workaround are all deleted. `isWorkspaceSearch` is
now the single place that decides, and it reads the URL.

**The sentinel.** Manual entry lands with an empty Filter Set, which is indistinguishable
from a fresh visit, so the control navigates to `?browse=1`. It is the only non-filter
parameter, is never part of a Filter Set so it never reaches a request, and is dropped once
real filters exist or if it arrives beside them — any URL carrying filters stays a pure API
query string.

## Bug found under review

A cross-vendor review caught the drop-on-load path re-encoding the *decoded* Filter Set,
which is empty whenever a value is refused, since the decoder withholds the whole set so
nothing is partially applied. `?browse=1&game_filter=0` therefore rewrote the URL to the
bare route, closing the workspace, which cleared the refusal on its way out — the user
landed on the Query Prompt with no explanation and the offending parameter gone from
history. The withholding rule defeating itself. Only the sentinel is removed now, and a
browser test covers it.

## Deliberately deferred

Manual player selection still requests off-URL rather than writing the URL — that is #38,
and it is why the sentinel survives player selection but not an apply.

## Verification

`npm run lint`, `npm run format:check`, `npm run test:ci` (305), `npm run build`, and
`npm run test:e2e` (62) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

