### PR TITLE
Base Self Filters ranges on the player's unfiltered season

### DIFF
--- a/e2e/fixtures/courtai.js
+++ b/e2e/fixtures/courtai.js
@@ -939,6 +939,18 @@ const mutationContract = [
   },
 ];
 
+// Two players whose seasons cannot be confused for one another: ranges taken
+// from the wrong player's season are only detectable if the seasons differ.
+export const curryGameLogs = gameLogs.map((log, index) => ({
+  ...log,
+  MATCHUP: log.MATCHUP.replace('LAL', 'GSW'),
+  PTS: index === 0 ? 42 : 18,
+}));
+
+const seasonsByPlayer = {
+  'Stephen Curry': curryGameLogs,
+};
+
 // The real endpoint narrows the season by the self filters it is sent. The
 // contract has to narrow too, or a test cannot tell a filtered result set from
 // the unfiltered season the Self Filters ranges are supposed to come from.
@@ -1043,7 +1055,10 @@ export const installApiContract = async (page, overrides = {}) => {
     if (url.pathname === '/api/games/game_logs') {
       await route.fulfill({
         json: {
-          game_logs: applySelfFilters(gameLogs, url),
+          game_logs: applySelfFilters(
+            seasonsByPlayer[url.searchParams.get('player_name')] || gameLogs,
+            url,
+          ),
           averages: [averages],
           season_averages: [{ ...averages, PTS: 27, AST: 8 }],
           next_game: 'Atlanta Hawks',

--- a/e2e/fixtures/courtai.js
+++ b/e2e/fixtures/courtai.js
@@ -939,6 +939,17 @@ const mutationContract = [
   },
 ];
 
+// The real endpoint narrows the season by the self filters it is sent. The
+// contract has to narrow too, or a test cannot tell a filtered result set from
+// the unfiltered season the Self Filters ranges are supposed to come from.
+const applySelfFilters = (logs, url) =>
+  [...url.searchParams].reduce((remaining, [key, value]) => {
+    const stat = key.match(/^self_filters\[(.+)\]$/)?.[1];
+    if (!stat) return remaining;
+    const [min, max] = value.split(',').map(Number);
+    return remaining.filter((log) => log[stat] >= min && log[stat] <= max);
+  }, logs);
+
 export const installApiContract = async (page, overrides = {}) => {
   const operationsJobs = [...operationsPayload.jobs];
   await page.route('**/api/**', async (route) => {
@@ -1032,7 +1043,7 @@ export const installApiContract = async (page, overrides = {}) => {
     if (url.pathname === '/api/games/game_logs') {
       await route.fulfill({
         json: {
-          game_logs: gameLogs,
+          game_logs: applySelfFilters(gameLogs, url),
           averages: [averages],
           season_averages: [{ ...averages, PTS: 27, AST: 8 }],
           next_game: 'Atlanta Hawks',

--- a/e2e/specs/core-flows.spec.js
+++ b/e2e/specs/core-flows.spec.js
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import {
   averages,
+  curryGameLogs,
   E2E_AUTH_STORAGE_KEY,
   expect,
   gameLogs,
@@ -670,11 +671,102 @@ test('an open Self Filters control follows a player change to that season', asyn
 
   await page.getByRole('button', { name: 'Self Filters' }).click();
   await expect.poll(() => seasonRequests).toEqual(['LeBron James']);
+  await page.getByLabel('Self filter stat').selectOption('PTS');
+  await expect(page.getByText('PTS: 27.0 - 31.0')).toBeVisible();
 
   await page.getByLabel('Player:').fill('Stephen');
   await page.getByRole('option', { name: 'Stephen Curry' }).click();
 
   await expect.poll(() => seasonRequests).toEqual(['LeBron James', 'Stephen Curry']);
+  // The ranges on offer are this player's, not the one we arrived on.
+  await page.getByLabel('Self filter stat').selectOption('PTS');
+  await expect(page.getByText('PTS: 18.0 - 42.0')).toBeVisible();
+});
+
+test('a superseded season never bounds the player on screen', async ({
+  authenticatedPage: page,
+}) => {
+  let release;
+  const held = new Promise((resolve) => {
+    release = resolve;
+  });
+  await page.route('**/api/games/game_logs**', async (route) => {
+    const url = new URL(route.request().url());
+    const player = url.searchParams.get('player_name');
+    const isSeason = [...url.searchParams.keys()].join() === 'player_name';
+    if (isSeason && player === 'LeBron James') await held;
+    try {
+      await route.fulfill({
+        json: {
+          game_logs: player === 'Stephen Curry' ? curryGameLogs : gameLogs,
+          averages: [averages],
+          season_averages: [averages],
+          next_game: 'Atlanta Hawks',
+        },
+      });
+    } catch {
+      // The browser gave up on this request while it was held. Nothing to send.
+    }
+  });
+
+  await page.goto('/?player_name=LeBron+James&game_filter=10');
+  await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Self Filters' }).click();
+  await page.getByLabel('Player:').fill('Stephen');
+  await page.getByRole('option', { name: 'Stephen Curry' }).click();
+
+  await page.getByLabel('Self filter stat').selectOption('PTS');
+  await expect(page.getByText('PTS: 18.0 - 42.0')).toBeVisible();
+
+  // The season asked for before the player changed arrives late. It belongs to
+  // nobody on screen, so it must change nothing.
+  release();
+  await expect(page.getByText('PTS: 27.0 - 31.0')).toHaveCount(0);
+  await expect(page.getByText('PTS: 18.0 - 42.0')).toBeVisible();
+});
+
+test('a season that fails to load says so and is retried on re-opening', async ({
+  authenticatedPage: page,
+}) => {
+  const seasonRequests = [];
+  page.on('request', (request) => {
+    const url = new URL(request.url());
+    if (
+      url.pathname === '/api/games/game_logs' &&
+      [...url.searchParams.keys()].join() === 'player_name'
+    ) {
+      seasonRequests.push(url.searchParams.get('player_name'));
+    }
+  });
+  await installApiContract(page, {
+    '/api/games/game_logs': (request) => {
+      const url = new URL(request.url());
+      if ([...url.searchParams.keys()].join() === 'player_name') {
+        return { status: 500, body: { error: 'The season could not be loaded.' } };
+      }
+      return {
+        body: {
+          game_logs: gameLogs,
+          averages: [averages],
+          season_averages: [averages],
+          next_game: 'Atlanta Hawks',
+        },
+      };
+    },
+  });
+
+  await page.goto('/?player_name=LeBron+James&game_filter=10');
+  await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Self Filters' }).click();
+  // An empty stat list with no explanation is indistinguishable from a player
+  // with no stats.
+  await expect(page.getByText('could not be loaded')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Self Filters' }).click();
+  await page.getByRole('button', { name: 'Self Filters' }).click();
+  await expect.poll(() => seasonRequests).toEqual(['LeBron James', 'LeBron James']);
 });
 
 test('a session that never opens Self Filters pays for no extra request', async ({

--- a/e2e/specs/core-flows.spec.js
+++ b/e2e/specs/core-flows.spec.js
@@ -642,6 +642,16 @@ test('@critical Self Filters ranges are the player unfiltered season', async ({
   await page.getByLabel('Self filter stat').selectOption('PTS');
   await expect(page.getByText('PTS: 27.0 - 31.0')).toBeVisible();
 
+  // Everything the disclosure hides sits inside the region it says it controls,
+  // both ends of the range included.
+  const disclosure = page.getByRole('button', { name: 'Self Filters' });
+  await expect(disclosure).toHaveAttribute('aria-expanded', 'true');
+  await expect(disclosure).toHaveAttribute('aria-controls', 'self-filter-controls');
+  const selfFilterControls = page.locator('#self-filter-controls');
+  await expect(selfFilterControls.getByLabel('Self filter stat')).toBeVisible();
+  await expect(selfFilterControls.getByLabel('Lower thumb')).toBeVisible();
+  await expect(selfFilterControls.getByLabel('Upper thumb')).toBeVisible();
+
   // The season bounds the slider, so the filter the user arrived with can be
   // widened back out again.
   await page.getByRole('button', { name: 'Add self filter' }).click();
@@ -650,6 +660,14 @@ test('@critical Self Filters ranges are the player unfiltered season', async ({
   await expect.poll(() => gameLogRequests.length).toBe(3);
   expect(gameLogRequests.at(-1).searchParams.get('self_filters[PTS]')).toBe('27,31');
   await expect(page.getByRole('cell', { name: '27', exact: true })).toBeVisible();
+
+  // Closed, the control is gone but what it already applied is not: a filter
+  // that arrived on a link stays readable and removable without opening it.
+  await disclosure.click();
+  await expect(disclosure).toHaveAttribute('aria-expanded', 'false');
+  await expect(selfFilterControls).toHaveCount(0);
+  const appliedSelfFilters = page.getByRole('group', { name: 'Applied self filters' });
+  await expect(appliedSelfFilters.getByRole('button', { name: 'Remove PTS filter' })).toBeVisible();
 });
 
 test('an open Self Filters control follows a player change to that season', async ({
@@ -726,7 +744,131 @@ test('a superseded season never bounds the player on screen', async ({
   await expect(page.getByText('PTS: 18.0 - 42.0')).toBeVisible();
 });
 
-test('a season that fails to load says so and is retried on re-opening', async ({
+test('a player left and returned to gets a fresh season request', async ({
+  authenticatedPage: page,
+}) => {
+  const seasonRequests = [];
+  const cancelledSeasonRequests = [];
+  const isSeasonUrl = (url) =>
+    url.pathname === '/api/games/game_logs' &&
+    [...url.searchParams.keys()].join() === 'player_name';
+
+  page.on('request', (request) => {
+    const url = new URL(request.url());
+    if (isSeasonUrl(url)) seasonRequests.push(url.searchParams.get('player_name'));
+  });
+  page.on('requestfailed', (request) => {
+    const url = new URL(request.url());
+    if (isSeasonUrl(url)) cancelledSeasonRequests.push(url.searchParams.get('player_name'));
+  });
+
+  let release;
+  const held = new Promise((resolve) => {
+    release = resolve;
+  });
+  let leBronSeasonCount = 0;
+  await page.route('**/api/games/game_logs**', async (route) => {
+    const url = new URL(route.request().url());
+    const player = url.searchParams.get('player_name');
+    if (isSeasonUrl(url) && player === 'LeBron James') {
+      leBronSeasonCount += 1;
+      // Only the first one waits, so the request that answers the return is
+      // deterministically the second.
+      if (leBronSeasonCount === 1) await held;
+    }
+    try {
+      await route.fulfill({
+        json: {
+          game_logs: player === 'Stephen Curry' ? curryGameLogs : gameLogs,
+          averages: [averages],
+          season_averages: [averages],
+          next_game: 'Atlanta Hawks',
+        },
+      });
+    } catch {
+      // The browser gave up on this request while it was held. Nothing to send.
+    }
+  });
+
+  await page.goto('/?player_name=LeBron+James&game_filter=10');
+  await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Self Filters' }).click();
+  await expect.poll(() => seasonRequests).toEqual(['LeBron James']);
+
+  await page.getByLabel('Player:').fill('Stephen');
+  await page.getByRole('option', { name: 'Stephen Curry' }).click();
+  await page.getByLabel('Self filter stat').selectOption('PTS');
+  await expect(page.getByText('PTS: 18.0 - 42.0')).toBeVisible();
+
+  // Back to the player we started on. The first request for them was abandoned
+  // on the way out, so returning has to ask again rather than wait on it.
+  await page.getByLabel('Player:').fill('LeBron');
+  await page.getByRole('option', { name: 'LeBron James' }).click();
+  await expect
+    .poll(() => seasonRequests)
+    .toEqual(['LeBron James', 'Stephen Curry', 'LeBron James']);
+  await page.getByLabel('Self filter stat').selectOption('PTS');
+  await expect(page.getByText('PTS: 27.0 - 31.0')).toBeVisible();
+
+  // The abandoned first request answers at last, for the player now on screen.
+  // It is not the request anyone is waiting on, so it changes nothing.
+  release();
+  await expect(page.getByText('PTS: 18.0 - 42.0')).toHaveCount(0);
+  await expect(page.getByText('PTS: 27.0 - 31.0')).toBeVisible();
+  expect(cancelledSeasonRequests).toEqual(['LeBron James']);
+});
+
+test('leaving the Workspace cancels a season still in flight', async ({
+  authenticatedPage: page,
+}) => {
+  const cancelledSeasonRequests = [];
+  page.on('requestfailed', (request) => {
+    const url = new URL(request.url());
+    if (
+      url.pathname === '/api/games/game_logs' &&
+      [...url.searchParams.keys()].join() === 'player_name'
+    ) {
+      cancelledSeasonRequests.push(url.searchParams.get('player_name'));
+    }
+  });
+
+  let release;
+  const held = new Promise((resolve) => {
+    release = resolve;
+  });
+  await page.route('**/api/games/game_logs**', async (route) => {
+    const url = new URL(route.request().url());
+    if ([...url.searchParams.keys()].join() === 'player_name') await held;
+    try {
+      await route.fulfill({
+        json: {
+          game_logs: gameLogs,
+          averages: [averages],
+          season_averages: [averages],
+          next_game: 'Atlanta Hawks',
+        },
+      });
+    } catch {
+      // The browser gave up on this request while it was held. Nothing to send.
+    }
+  });
+
+  await page.goto('/?player_name=LeBron+James&game_filter=10');
+  await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Self Filters' }).click();
+  await expect(page.getByText('Loading the season for this player…')).toBeVisible();
+
+  // The slowest endpoint in the application does not keep working for a
+  // workspace nobody is in any more.
+  await page.getByRole('button', { name: 'Back to search' }).click();
+  await expect(page.getByRole('textbox')).toBeVisible();
+  await expect.poll(() => cancelledSeasonRequests).toEqual(['LeBron James']);
+  release();
+});
+
+test('a season that fails to load says so, and loads on re-opening', async ({
   authenticatedPage: page,
 }) => {
   const seasonRequests = [];
@@ -739,11 +881,17 @@ test('a season that fails to load says so and is retried on re-opening', async (
       seasonRequests.push(url.searchParams.get('player_name'));
     }
   });
+  let seasonAttempts = 0;
   await installApiContract(page, {
     '/api/games/game_logs': (request) => {
       const url = new URL(request.url());
       if ([...url.searchParams.keys()].join() === 'player_name') {
-        return { status: 500, body: { error: 'The season could not be loaded.' } };
+        seasonAttempts += 1;
+        // The first attempt fails, the retry succeeds, so the message has to
+        // both appear and go away.
+        if (seasonAttempts === 1) {
+          return { status: 500, body: { error: 'The season could not be loaded.' } };
+        }
       }
       return {
         body: {
@@ -762,11 +910,16 @@ test('a season that fails to load says so and is retried on re-opening', async (
   await page.getByRole('button', { name: 'Self Filters' }).click();
   // An empty stat list with no explanation is indistinguishable from a player
   // with no stats.
-  await expect(page.getByText('could not be loaded')).toBeVisible();
+  const failure = page.getByRole('status').filter({ hasText: 'could not be loaded' });
+  await expect(failure).toBeVisible();
 
   await page.getByRole('button', { name: 'Self Filters' }).click();
   await page.getByRole('button', { name: 'Self Filters' }).click();
+
   await expect.poll(() => seasonRequests).toEqual(['LeBron James', 'LeBron James']);
+  await expect(failure).toHaveCount(0);
+  await page.getByLabel('Self filter stat').selectOption('PTS');
+  await expect(page.getByText('PTS: 27.0 - 31.0')).toBeVisible();
 });
 
 test('a session that never opens Self Filters pays for no extra request', async ({

--- a/e2e/specs/core-flows.spec.js
+++ b/e2e/specs/core-flows.spec.js
@@ -614,6 +614,91 @@ test('@critical removing every self filter clears its parameter', async ({
   expect(gameLogRequests.at(-1).searchParams.has('self_filters[PTS]')).toBe(false);
 });
 
+test('@critical Self Filters ranges are the player unfiltered season', async ({
+  authenticatedPage: page,
+}) => {
+  const gameLogRequests = [];
+  page.on('request', (request) => {
+    const url = new URL(request.url());
+    if (url.pathname === '/api/games/game_logs') gameLogRequests.push(url);
+  });
+
+  // Entered already narrowed. The result set on screen holds only the 31-point
+  // game, so ranges taken from it could never be widened back out.
+  await page.goto('/?player_name=LeBron+James&self_filters%5BPTS%5D=30%2C60');
+  await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
+  await expect(page.getByRole('cell', { name: '31', exact: true })).toBeVisible();
+  await expect(page.getByRole('cell', { name: '27', exact: true })).toHaveCount(0);
+  expect(gameLogRequests).toHaveLength(1);
+
+  await page.getByRole('button', { name: 'Self Filters' }).click();
+
+  await expect.poll(() => gameLogRequests.length).toBe(2);
+  expect([...gameLogRequests.at(-1).searchParams.entries()]).toEqual([
+    ['player_name', 'LeBron James'],
+  ]);
+
+  await page.getByLabel('Self filter stat').selectOption('PTS');
+  await expect(page.getByText('PTS: 27.0 - 31.0')).toBeVisible();
+
+  // The season bounds the slider, so the filter the user arrived with can be
+  // widened back out again.
+  await page.getByRole('button', { name: 'Add self filter' }).click();
+  await page.getByRole('button', { name: 'Apply Filters' }).click();
+
+  await expect.poll(() => gameLogRequests.length).toBe(3);
+  expect(gameLogRequests.at(-1).searchParams.get('self_filters[PTS]')).toBe('27,31');
+  await expect(page.getByRole('cell', { name: '27', exact: true })).toBeVisible();
+});
+
+test('an open Self Filters control follows a player change to that season', async ({
+  authenticatedPage: page,
+}) => {
+  const seasonRequests = [];
+  page.on('request', (request) => {
+    const url = new URL(request.url());
+    if (
+      url.pathname === '/api/games/game_logs' &&
+      [...url.searchParams.keys()].join() === 'player_name'
+    ) {
+      seasonRequests.push(url.searchParams.get('player_name'));
+    }
+  });
+
+  await page.goto('/?player_name=LeBron+James&game_filter=10');
+  await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Self Filters' }).click();
+  await expect.poll(() => seasonRequests).toEqual(['LeBron James']);
+
+  await page.getByLabel('Player:').fill('Stephen');
+  await page.getByRole('option', { name: 'Stephen Curry' }).click();
+
+  await expect.poll(() => seasonRequests).toEqual(['LeBron James', 'Stephen Curry']);
+});
+
+test('a session that never opens Self Filters pays for no extra request', async ({
+  authenticatedPage: page,
+}) => {
+  const gameLogRequests = [];
+  page.on('request', (request) => {
+    const url = new URL(request.url());
+    if (url.pathname === '/api/games/game_logs') gameLogRequests.push(url);
+  });
+
+  await page.goto('/?player_name=LeBron+James&game_filter=10');
+  await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
+  await expect(page.getByRole('cell', { name: '31', exact: true })).toBeVisible();
+
+  await page.getByLabel('Last N games:').fill('5');
+  await page.getByRole('button', { name: 'Apply Filters' }).click();
+
+  await expect.poll(() => gameLogRequests.length).toBe(2);
+  // The slowest endpoint in the application is only asked for the season when
+  // the control that needs it is opened.
+  expect(gameLogRequests.every((url) => url.searchParams.has('game_filter'))).toBe(true);
+});
+
 test('@critical the escape hatch reaches a result with no language model', async ({
   authenticatedPage: page,
 }) => {

--- a/src/FilterOptions.js
+++ b/src/FilterOptions.js
@@ -24,6 +24,7 @@ const FilterOptions = ({
   selectedPlayer,
   seasonGameLogs,
   seasonGameLogsLoading,
+  seasonGameLogsFailed,
   onOpenSelfFilters,
   appliedFilters,
 }) => {
@@ -746,52 +747,63 @@ const FilterOptions = ({
                   Loading the season for this player…
                 </div>
               )}
+              {seasonGameLogsFailed && (
+                <div className="mt-2" role="status" aria-live="polite">
+                  This player's season could not be loaded, so there are no stat ranges to offer.
+                  Close and re-open Self Filters to try again.
+                </div>
+              )}
+              {selectedSelfFilter && columnRanges[selectedSelfFilter] && (
+                <div className="mt-2">
+                  <Form.Label>
+                    {selectedSelfFilter}: {formatNumber(selfFilterRange[0], 1)} -{' '}
+                    {formatNumber(selfFilterRange[1], 1)}
+                  </Form.Label>
+                  <ReactSlider
+                    className="horizontal-slider"
+                    thumbClassName="thumb"
+                    trackClassName="track"
+                    value={selfFilterRange}
+                    ariaLabel={['Lower thumb', 'Upper thumb']}
+                    ariaValuetext={(state) => `Thumb value ${state.valueNow}`}
+                    renderThumb={(props, state) => (
+                      <div {...props}>{formatNumber(state.valueNow, 1)}</div>
+                    )}
+                    pearling
+                    minDistance={0.1}
+                    step={0.1}
+                    min={columnRanges[selectedSelfFilter].min}
+                    max={columnRanges[selectedSelfFilter].max}
+                    onChange={handleSelfFilterRangeChange}
+                  />
+                </div>
+              )}
             </div>
           )}
-          {selfFiltersOpen && selectedSelfFilter && columnRanges[selectedSelfFilter] && (
-            <div className="mt-2">
-              <Form.Label>
-                {selectedSelfFilter}: {formatNumber(selfFilterRange[0], 1)} -{' '}
-                {formatNumber(selfFilterRange[1], 1)}
-              </Form.Label>
-              <ReactSlider
-                className="horizontal-slider"
-                thumbClassName="thumb"
-                trackClassName="track"
-                value={selfFilterRange}
-                ariaLabel={['Lower thumb', 'Upper thumb']}
-                ariaValuetext={(state) => `Thumb value ${state.valueNow}`}
-                renderThumb={(props, state) => (
-                  <div {...props}>{formatNumber(state.valueNow, 1)}</div>
-                )}
-                pearling
-                minDistance={0.1}
-                step={0.1}
-                min={columnRanges[selectedSelfFilter].min}
-                max={columnRanges[selectedSelfFilter].max}
-                onChange={handleSelfFilterRangeChange}
-              />
+          {/* The self filters already applied are a summary of the Filter Set,
+              not part of the control, so they stay readable and removable while
+              the control that builds new ones is closed. */}
+          {activeSelfFilters.length > 0 && (
+            <div className="mt-2" role="group" aria-label="Applied self filters">
+              {activeSelfFilters.map((filter, index) => (
+                <Badge key={index} bg="primary" className="me-1 mb-1 p-2">
+                  {filter.column}: {formatNumber(filter.range[0], 1)} -{' '}
+                  {formatNumber(filter.range[1], 1)}
+                  <Button
+                    type="button"
+                    aria-label={`Remove ${filter.column} filter`}
+                    title="Remove filter"
+                    variant="link"
+                    size="sm"
+                    className="text-light p-0 ms-2"
+                    onClick={() => handleRemoveSelfFilter(index)}
+                  >
+                    ×
+                  </Button>
+                </Badge>
+              ))}
             </div>
           )}
-          <div className="mt-2">
-            {activeSelfFilters.map((filter, index) => (
-              <Badge key={index} bg="primary" className="me-1 mb-1 p-2">
-                {filter.column}: {formatNumber(filter.range[0], 1)} -{' '}
-                {formatNumber(filter.range[1], 1)}
-                <Button
-                  type="button"
-                  aria-label={`Remove ${filter.column} filter`}
-                  title="Remove filter"
-                  variant="link"
-                  size="sm"
-                  className="text-light p-0 ms-2"
-                  onClick={() => handleRemoveSelfFilter(index)}
-                >
-                  ×
-                </Button>
-              </Badge>
-            ))}
-          </div>
         </Form.Group>
 
         <Button type="button" variant="primary" className="w-100" onClick={handleApplyFilters}>

--- a/src/FilterOptions.js
+++ b/src/FilterOptions.js
@@ -22,7 +22,9 @@ const FilterOptions = ({
   playerList,
   onApplyFilters,
   selectedPlayer,
-  initialGameLogs,
+  seasonGameLogs,
+  seasonGameLogsLoading,
+  onOpenSelfFilters,
   appliedFilters,
 }) => {
   const [selectedDefensiveFilter, setSelectedDefensiveFilter] = useState('None');
@@ -43,6 +45,7 @@ const FilterOptions = ({
   const [selfFilterRange, setSelfFilterRange] = useState([0, 0]);
   const [activeSelfFilters, setActiveSelfFilters] = useState([]);
   const [columnRanges, setColumnRanges] = useState({});
+  const [selfFiltersOpen, setSelfFiltersOpen] = useState(false);
   // Only controls the user touched are emitted, so the API applies its own
   // defaults to the rest. Touched-ness is tracked rather than compared against
   // a copy of those defaults, which would drift from the API.
@@ -57,30 +60,44 @@ const FilterOptions = ({
     });
   };
 
+  // The stats on offer and the bounds of their sliders describe the player's
+  // whole season, so a filter narrowed to it can always be widened out again.
   useEffect(() => {
-    if (initialGameLogs && initialGameLogs.length > 0) {
-      const columns = Object.keys(initialGameLogs[0]).filter(
-        (col) =>
-          typeof initialGameLogs[0][col] === 'number' &&
-          !['GAME_ID', 'GAME_DATE', 'MIN'].includes(col),
-      );
-      setSelfFilterColumns(columns);
-
-      const ranges = columns.reduce((acc, col) => {
-        const values = initialGameLogs
-          .map((log) => toFiniteNumber(log[col]))
-          .filter((value) => value !== null);
-        if (values.length > 0) {
-          acc[col] = {
-            min: Math.min(...values),
-            max: Math.max(...values),
-          };
-        }
-        return acc;
-      }, {});
-      setColumnRanges(ranges);
+    if (!seasonGameLogs || seasonGameLogs.length === 0) {
+      setSelfFilterColumns([]);
+      setColumnRanges({});
+      return;
     }
-  }, [initialGameLogs]);
+
+    const columns = Object.keys(seasonGameLogs[0]).filter(
+      (col) =>
+        typeof seasonGameLogs[0][col] === 'number' &&
+        !['GAME_ID', 'GAME_DATE', 'MIN'].includes(col),
+    );
+    setSelfFilterColumns(columns);
+
+    const ranges = columns.reduce((acc, col) => {
+      const values = seasonGameLogs
+        .map((log) => toFiniteNumber(log[col]))
+        .filter((value) => value !== null);
+      if (values.length > 0) {
+        acc[col] = {
+          min: Math.min(...values),
+          max: Math.max(...values),
+        };
+      }
+      return acc;
+    }, {});
+    setColumnRanges(ranges);
+  }, [seasonGameLogs]);
+
+  // The season is asked for when the control that needs it is opened, and an
+  // open control follows a player change onto that player's season. A control
+  // never opened asks for nothing at all.
+  useEffect(() => {
+    if (!selfFiltersOpen) return;
+    onOpenSelfFilters();
+  }, [onOpenSelfFilters, selfFiltersOpen]);
 
   // Reset all filters to defaults and then pre-populate with new query filters
   useEffect(() => {
@@ -690,24 +707,48 @@ const FilterOptions = ({
           </div>
         </Form.Group>
         <Form.Group className="mb-4">
-          <Form.Label>Self Filters:</Form.Label>
-          <InputGroup>
-            <Form.Select
-              value={selectedSelfFilter}
-              onChange={(e) => handleSelfFilterSelect(e.target.value)}
-            >
-              <option value="">Select Stat</option>
-              {selfFilterColumns.map((column) => (
-                <option key={column} value={column}>
-                  {column}
-                </option>
-              ))}
-            </Form.Select>
-            <Button type="button" variant="outline-primary" onClick={handleAddSelfFilter}>
-              Add
-            </Button>
-          </InputGroup>
-          {selectedSelfFilter && columnRanges[selectedSelfFilter] && (
+          <Button
+            type="button"
+            variant="link"
+            className="p-0 text-decoration-none form-label"
+            aria-expanded={selfFiltersOpen}
+            aria-controls="self-filter-controls"
+            onClick={() => setSelfFiltersOpen(!selfFiltersOpen)}
+          >
+            Self Filters:
+          </Button>
+          {selfFiltersOpen && (
+            <div id="self-filter-controls">
+              <InputGroup>
+                <Form.Select
+                  aria-label="Self filter stat"
+                  value={selectedSelfFilter}
+                  onChange={(e) => handleSelfFilterSelect(e.target.value)}
+                >
+                  <option value="">Select Stat</option>
+                  {selfFilterColumns.map((column) => (
+                    <option key={column} value={column}>
+                      {column}
+                    </option>
+                  ))}
+                </Form.Select>
+                <Button
+                  type="button"
+                  aria-label="Add self filter"
+                  variant="outline-primary"
+                  onClick={handleAddSelfFilter}
+                >
+                  Add
+                </Button>
+              </InputGroup>
+              {seasonGameLogsLoading && (
+                <div className="mt-2" role="status" aria-live="polite">
+                  Loading the season for this player…
+                </div>
+              )}
+            </div>
+          )}
+          {selfFiltersOpen && selectedSelfFilter && columnRanges[selectedSelfFilter] && (
             <div className="mt-2">
               <Form.Label>
                 {selectedSelfFilter}: {formatNumber(selfFilterRange[0], 1)} -{' '}

--- a/src/GameLogFilter.js
+++ b/src/GameLogFilter.js
@@ -59,6 +59,7 @@ const GameLogFilter = () => {
   // result set: ranges taken from one cannot be widened back out.
   const [seasonGameLogs, setSeasonGameLogs] = useState({ player: null, gameLogs: [] });
   const [seasonGameLogsLoading, setSeasonGameLogsLoading] = useState(false);
+  const [seasonGameLogsFailed, setSeasonGameLogsFailed] = useState(false);
   const [currentQuery, setCurrentQuery] = useState(''); // Track the current search query
   const [isGameLogsLoading, setIsGameLogsLoading] = useState(false); // Track game logs API loading
   const [gameLogsError, setGameLogsError] = useState(null);
@@ -166,8 +167,12 @@ const GameLogFilter = () => {
     seasonRequestRef.current.controller?.abort();
     seasonRequestRef.current = { player: null, controller: null };
     setSeasonGameLogsLoading(false);
+    setSeasonGameLogsFailed(false);
     setSeasonGameLogs({ player: null, gameLogs: [] });
   }, []);
+
+  // Nothing in flight outlives the workspace.
+  useEffect(() => clearSeasonGameLogs, [clearSeasonGameLogs]);
 
   /*
    * The game-log endpoint is the slowest in the application and most sessions
@@ -185,19 +190,28 @@ const GameLogFilter = () => {
     const controller = new AbortController();
     seasonRequestRef.current = { player, controller };
     setSeasonGameLogsLoading(true);
+    setSeasonGameLogsFailed(false);
+
+    // Only the request still on the ref may report anything. Comparing the
+    // controller rather than the player is what makes that true whatever order
+    // a superseded request settles in, including a second request for the same
+    // player after a change away and back.
+    const isCurrentRequest = () => seasonRequestRef.current.controller === controller;
 
     fetchGameLogsData({ player_name: player }, { signal: controller.signal })
       .then((data) => {
-        if (seasonRequestRef.current.player !== player) return;
+        if (!isCurrentRequest()) return;
         setSeasonGameLogsLoading(false);
         setSeasonGameLogs({ player, gameLogs: data.gameLogs });
       })
-      .catch(() => {
-        // There are no ranges to offer. Forget the attempt so that re-opening
-        // the control asks again rather than offering nothing forever.
-        if (seasonRequestRef.current.player !== player) return;
+      .catch((error) => {
+        if (!isCurrentRequest()) return;
+        // Forget the attempt so that re-opening the control asks again rather
+        // than offering nothing forever. A cancelled request was superseded
+        // deliberately and has nothing to report.
         seasonRequestRef.current = { player: null, controller: null };
         setSeasonGameLogsLoading(false);
+        setSeasonGameLogsFailed(!isRequestCancelled(error));
       });
   }, [authLoading, isAuthenticated, urlFilters.player_name]);
 
@@ -551,6 +565,7 @@ const GameLogFilter = () => {
                 selectedPlayer={selectedPlayer}
                 seasonGameLogs={playerSeasonGameLogs}
                 seasonGameLogsLoading={seasonGameLogsLoading}
+                seasonGameLogsFailed={seasonGameLogsFailed}
                 onOpenSelfFilters={loadSeasonGameLogs}
                 appliedFilters={appliedFilters}
               />

--- a/src/GameLogFilter.js
+++ b/src/GameLogFilter.js
@@ -54,7 +54,11 @@ const GameLogFilter = () => {
   const [playerList, setPlayerList] = useState([]);
   const [teams, setTeams] = useState([]);
   const [appliedFilters, setAppliedFilters] = useState({});
-  const [initialGameLogs, setInitialGameLogs] = useState([]);
+  // The player's season with no filter applied. It is what the Self Filters
+  // controls offer stats and slider bounds from, so it must never be a filtered
+  // result set: ranges taken from one cannot be widened back out.
+  const [seasonGameLogs, setSeasonGameLogs] = useState({ player: null, gameLogs: [] });
+  const [seasonGameLogsLoading, setSeasonGameLogsLoading] = useState(false);
   const [currentQuery, setCurrentQuery] = useState(''); // Track the current search query
   const [isGameLogsLoading, setIsGameLogsLoading] = useState(false); // Track game logs API loading
   const [gameLogsError, setGameLogsError] = useState(null);
@@ -156,70 +160,113 @@ const GameLogFilter = () => {
     setIsGameLogsLoading(false);
   }, []);
 
+  const seasonRequestRef = useRef({ player: null, controller: null });
+
+  const clearSeasonGameLogs = useCallback(() => {
+    seasonRequestRef.current.controller?.abort();
+    seasonRequestRef.current = { player: null, controller: null };
+    setSeasonGameLogsLoading(false);
+    setSeasonGameLogs({ player: null, gameLogs: [] });
+  }, []);
+
+  /*
+   * The game-log endpoint is the slowest in the application and most sessions
+   * never touch Self Filters, so the season is asked for only when that control
+   * is opened, and only once per player. It is its own request rather than a
+   * by-product of the filtered one, because the whole point of it is that no
+   * filter is applied.
+   */
+  const loadSeasonGameLogs = useCallback(() => {
+    const player = urlFilters.player_name;
+    if (!player || authLoading || !isAuthenticated) return;
+    if (seasonRequestRef.current.player === player) return;
+
+    seasonRequestRef.current.controller?.abort();
+    const controller = new AbortController();
+    seasonRequestRef.current = { player, controller };
+    setSeasonGameLogsLoading(true);
+
+    fetchGameLogsData({ player_name: player }, { signal: controller.signal })
+      .then((data) => {
+        if (seasonRequestRef.current.player !== player) return;
+        setSeasonGameLogsLoading(false);
+        setSeasonGameLogs({ player, gameLogs: data.gameLogs });
+      })
+      .catch(() => {
+        // There are no ranges to offer. Forget the attempt so that re-opening
+        // the control asks again rather than offering nothing forever.
+        if (seasonRequestRef.current.player !== player) return;
+        seasonRequestRef.current = { player: null, controller: null };
+        setSeasonGameLogsLoading(false);
+      });
+  }, [authLoading, isAuthenticated, urlFilters.player_name]);
+
+  // One player's season must never bound another player's sliders.
+  const playerSeasonGameLogs = useMemo(
+    () => (seasonGameLogs.player === selectedPlayer ? seasonGameLogs.gameLogs : []),
+    [seasonGameLogs, selectedPlayer],
+  );
+
   // One request seam owns game-log state transitions. A request may only
   // publish data if it is still the latest request; older requests are
   // cancelled and ignored when their promises settle.
-  const requestGameLogs = useCallback(
-    (params, { includeInitial = false, updateSelectedTeam = true } = {}) => {
-      const previousRequest = gameLogsRequestRef.current;
-      previousRequest.controller?.abort();
+  const requestGameLogs = useCallback((params, { updateSelectedTeam = true } = {}) => {
+    const previousRequest = gameLogsRequestRef.current;
+    previousRequest.controller?.abort();
 
-      const requestId = previousRequest.id + 1;
-      const controller = new AbortController();
-      gameLogsRequestRef.current = { id: requestId, controller };
-      setIsGameLogsLoading(true);
-      setGameLogsError(null);
-      // The badges above the table already describe the Filter Set just
-      // requested, so whatever is still on screen belongs to nobody. Clearing
-      // at the start is what keeps that true while the request is in flight and
-      // if it never arrives, rather than only once it does.
-      setGameLogs([]);
-      setAverages([]);
+    const requestId = previousRequest.id + 1;
+    const controller = new AbortController();
+    gameLogsRequestRef.current = { id: requestId, controller };
+    setIsGameLogsLoading(true);
+    setGameLogsError(null);
+    // The badges above the table already describe the Filter Set just
+    // requested, so whatever is still on screen belongs to nobody. Clearing
+    // at the start is what keeps that true while the request is in flight and
+    // if it never arrives, rather than only once it does.
+    setGameLogs([]);
+    setAverages([]);
 
-      return fetchGameLogsData(params, { signal: controller.signal })
-        .then((data) => {
-          if (gameLogsRequestRef.current.id !== requestId) {
-            return { stale: true };
-          }
+    return fetchGameLogsData(params, { signal: controller.signal })
+      .then((data) => {
+        if (gameLogsRequestRef.current.id !== requestId) {
+          return { stale: true };
+        }
 
-          setGameLogs(data.gameLogs);
-          setAverages(data.averages);
-          if (includeInitial) setInitialGameLogs(data.gameLogs);
-          if (updateSelectedTeam) {
-            setSelectedTeam(data.nextGame || teamsRef.current[0] || 'Atlanta Hawks');
-          }
-          return { ok: true, data };
-        })
-        .catch((error) => {
-          const stale = gameLogsRequestRef.current.id !== requestId;
-          if (stale || isRequestCancelled(error)) {
-            return { stale, cancelled: true };
-          }
+        setGameLogs(data.gameLogs);
+        setAverages(data.averages);
+        if (updateSelectedTeam) {
+          setSelectedTeam(data.nextGame || teamsRef.current[0] || 'Atlanta Hawks');
+        }
+        return { ok: true, data };
+      })
+      .catch((error) => {
+        const stale = gameLogsRequestRef.current.id !== requestId;
+        if (stale || isRequestCancelled(error)) {
+          return { stale, cancelled: true };
+        }
 
-          setGameLogsError(
-            getRequestErrorMessage(error, 'Unable to load game logs. Please try again.'),
-          );
-          return { ok: false, error };
-        })
-        .finally(() => {
-          if (gameLogsRequestRef.current.id === requestId) {
-            setIsGameLogsLoading(false);
-          }
-        });
-    },
-    [],
-  );
+        setGameLogsError(
+          getRequestErrorMessage(error, 'Unable to load game logs. Please try again.'),
+        );
+        return { ok: false, error };
+      })
+      .finally(() => {
+        if (gameLogsRequestRef.current.id === requestId) {
+          setIsGameLogsLoading(false);
+        }
+      });
+  }, []);
 
   const returnToQueryPrompt = useCallback(() => {
     abortGameLogsRequest();
     setCurrentQuery('');
     setAppliedFilters({});
     setGameLogs([]);
-    setInitialGameLogs([]);
+    clearSeasonGameLogs();
     setAverages([]);
     setSelectedTeam('');
     setGameLogsError(null);
-  }, [abortGameLogsRequest]);
+  }, [abortGameLogsRequest, clearSeasonGameLogs]);
 
   // The sentinel only ever says "Workspace, no filters yet". Alongside filters
   // it is already untrue, so it is dropped rather than carried into a link
@@ -256,7 +303,7 @@ const GameLogFilter = () => {
     if (urlInvalid.length > 0) {
       abortGameLogsRequest();
       setGameLogs([]);
-      setInitialGameLogs([]);
+      clearSeasonGameLogs();
       setAverages([]);
       setAppliedFilters({});
       setGameLogsError(
@@ -275,7 +322,7 @@ const GameLogFilter = () => {
     if (!authLoading && !isAuthenticated) {
       abortGameLogsRequest();
       setGameLogs([]);
-      setInitialGameLogs([]);
+      clearSeasonGameLogs();
       setAverages([]);
       return undefined;
     }
@@ -287,7 +334,7 @@ const GameLogFilter = () => {
     if (!urlFilters.player_name) {
       abortGameLogsRequest();
       setGameLogs([]);
-      setInitialGameLogs([]);
+      clearSeasonGameLogs();
       setAverages([]);
       setSelectedTeam('');
       return undefined;
@@ -300,11 +347,12 @@ const GameLogFilter = () => {
     // request only to abort it.
     if (hasBrowseSentinel) return undefined;
 
-    requestGameLogs(urlFilters, { includeInitial: true, updateSelectedTeam: true });
+    requestGameLogs(urlFilters, { updateSelectedTeam: true });
     return abortGameLogsRequest;
   }, [
     abortGameLogsRequest,
     authLoading,
+    clearSeasonGameLogs,
     hasBrowseSentinel,
     inWorkspace,
     isAuthenticated,
@@ -501,7 +549,9 @@ const GameLogFilter = () => {
                 playerList={playerList}
                 onApplyFilters={handleApplyFilters}
                 selectedPlayer={selectedPlayer}
-                initialGameLogs={initialGameLogs}
+                seasonGameLogs={playerSeasonGameLogs}
+                seasonGameLogsLoading={seasonGameLogsLoading}
+                onOpenSelfFilters={loadSeasonGameLogs}
                 appliedFilters={appliedFilters}
               />
             </Col>


### PR DESCRIPTION
Closes #39. Final slice of crf04/statsplus#28.

## What
- `initialGameLogs` → `seasonGameLogs` `{ player, gameLogs }`: populated only from an unfiltered `player_name` request and scoped to the on-screen player, so narrowing a stat filter never raises its own slider floor.
- "Self Filters" is now a disclosure; the season is fetched lazily on open, follows a player change while open, and is never requested in a session that doesn't open it.
- Season requests are guarded by AbortController identity; pending requests are cancelled on leaving the Workspace/unmount. Failures show a `role="status"` line and retry on re-open.
- Removed dead `includeInitial` plumbing.

## Tests (request + browser-URL seams only)
New e2e journeys: season bounds after narrowed entry and widening back out; player change moves bounds (distinct per-player fixture); no extra request when never opened; A→B→A re-requests and aborts the superseded fetch; leaving cancels in-flight; fail-then-succeed retry; aria-controls region / applied-filter group structure.

## Review
Cross-vendor review with gpt-5.6-sol (effort high), two passes; all findings fixed.

## Gate
lint, format:check, test:ci (305), build, test:e2e (76 passed, 2 skipped) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)