### PR TITLE
Render a badge for every parameter the URL carries

### DIFF
--- a/e2e/specs/core-flows.spec.js
+++ b/e2e/specs/core-flows.spec.js
@@ -409,7 +409,7 @@ test('@critical a link carrying a Filter Set opens the workspace and survives re
     }
   });
 
-  await page.goto('/?player_name=LeBron+James&game_filter=10&location_filter=Home');
+  await page.goto('/?player_name=LeBron+James&game_filter=10&location_filter=Both');
 
   // No prose was typed and no parser was called, yet the workspace is open.
   await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
@@ -417,7 +417,8 @@ test('@critical a link carrying a Filter Set opens the workspace and survives re
   const requested = new URL(gameLogRequests.at(-1));
   expect(requested.searchParams.get('player_name')).toBe('LeBron James');
   expect(requested.searchParams.get('game_filter')).toBe('10');
-  expect(requested.searchParams.get('location_filter')).toBe('Home');
+  expect(requested.searchParams.get('location_filter')).toBe('Both');
+  await expect(page.getByText('Location: Both')).toHaveCount(3);
 
   await page.reload();
   await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();

--- a/src/AppliedFilters.js
+++ b/src/AppliedFilters.js
@@ -75,7 +75,7 @@ const AppliedFilters = ({ filters }) => {
     }
     return (
       typeof value === 'number' ||
-      (typeof value === 'string' && value !== '' && value !== 'null') ||
+      (typeof value === 'string' && value !== '') ||
       (Array.isArray(value) && value.length > 0)
     );
   });

--- a/src/AppliedFilters.js
+++ b/src/AppliedFilters.js
@@ -1,19 +1,13 @@
 import { Badge } from 'react-bootstrap';
 
 const AppliedFilters = ({ filters }) => {
-  const defaultValues = {
-    minutes_filter: '0,48',
-    location_filter: 'Both',
-    playstyle_RTG_min: 75,
-    playstyle_RTG_max: 125,
-  };
+  const renderBadge = (key, value, bg = 'primary') => (
+    <Badge key={key} bg={bg} className="me-1">
+      {value}
+    </Badge>
+  );
 
   const renderFilterBadge = (key, value) => {
-    // Check if the value is different from the default
-    if (key in defaultValues && value === defaultValues[key]) {
-      return null;
-    }
-
     if (key === 'teams_against[]' && filters['rank_filter[]']) {
       const teamsArray = Array.isArray(value) ? value : [value];
       const ranksArray = Array.isArray(filters['rank_filter[]'])
@@ -21,84 +15,44 @@ const AppliedFilters = ({ filters }) => {
         : [filters['rank_filter[]']];
       return teamsArray.map((team, index) => {
         const rank = ranksArray[index];
-        return (
-          <Badge key={`${key}-${index}`} bg="primary" className="me-1">
-            {`${team} (${rank})`}
-          </Badge>
-        );
+        return renderBadge(`${key}-${index}`, `${team} (${rank})`);
       });
     } else if (key === 'player_name') {
-      return null;
+      return renderBadge(key, `Player: ${value}`);
+    } else if (key === 'season_filter') {
+      return renderBadge(key, `Season: ${value}`);
+    } else if (key === 'playstyle_RTG_min' && filters.playstyle_RTG_max === undefined) {
+      return renderBadge(key, `PLAYTYPE_RTG >= ${value}`);
+    } else if (key === 'playstyle_RTG_max' && filters.playstyle_RTG_min === undefined) {
+      return renderBadge(key, `PLAYTYPE_RTG <= ${value}`);
     } else if (key === 'date_filter') {
-      return (
-        <Badge key={key} bg="primary" className="me-1">
-          {`Date >= ${value}`}
-        </Badge>
-      );
+      return renderBadge(key, `Date >= ${value}`);
     } else if (key === 'game_filter') {
-      return (
-        <Badge key={key} bg="primary" className="me-1">
-          {`GAMES <= ${value}`}
-        </Badge>
-      );
+      return renderBadge(key, `GAMES <= ${value}`);
     } else if (key === 'players_on' || key === 'players_on[]') {
       const playerList = Array.isArray(value) ? value : [value];
-      return (
-        <Badge key={key} bg="success" className="me-1">
-          {`(ON) ${playerList.join(', ')}`}
-        </Badge>
-      );
+      return renderBadge(key, `(ON) ${playerList.join(', ')}`, 'success');
     } else if (key === 'players_off' || key === 'players_off[]') {
       const playerList = Array.isArray(value) ? value : [value];
-      return (
-        <Badge key={key} bg="danger" className="me-1">
-          {`(OFF) ${playerList.join(', ')}`}
-        </Badge>
-      );
+      return renderBadge(key, `(OFF) ${playerList.join(', ')}`, 'danger');
     } else if (key.startsWith('self_filters[')) {
       const stat = key.match(/\[(.*?)\]/)[1];
       if (!value) return null;
       const [min, max] = value.split(',');
 
-      // If max is 999, this is a "greater than or equal" filter
       if (max === '999') {
-        return (
-          <Badge key={key} bg="primary" className="me-1">
-            {`${stat} >= ${min}`}
-          </Badge>
-        );
+        return renderBadge(key, `${stat} >= ${min}`);
+      } else if (min === '0') {
+        return renderBadge(key, `${stat} <= ${max}`);
       }
-      // If min is 0, this is a "less than or equal" filter
-      else if (min === '0') {
-        return (
-          <Badge key={key} bg="primary" className="me-1">
-            {`${stat} <= ${max}`}
-          </Badge>
-        );
-      }
-      // Otherwise show the range
-      else {
-        return (
-          <Badge key={key} bg="primary" className="me-1">
-            {`${min} <= ${stat} <= ${max}`}
-          </Badge>
-        );
-      }
+      return renderBadge(key, `${min} <= ${stat} <= ${max}`);
     } else if (key === 'location_filter') {
-      return (
-        <Badge key={key} bg="primary" className="me-1">
-          {`Location: ${value}`}
-        </Badge>
-      );
+      return renderBadge(key, `Location: ${value}`);
     } else if (key === 'minutes_filter') {
       if (!value) return null;
       const parts = value.split(',');
       if (parts.length !== 2) return null;
-      return (
-        <Badge key={key} bg="primary" className="me-1">
-          {`${parts[0]} <= MIN <= ${parts[1]}`}
-        </Badge>
-      );
+      return renderBadge(key, `${parts[0]} <= MIN <= ${parts[1]}`);
     }
     return null;
   };
@@ -106,31 +60,33 @@ const AppliedFilters = ({ filters }) => {
   const playstyleMin = filters.playstyle_RTG_min;
   const playstyleMax = filters.playstyle_RTG_max;
   const playstyleBadge =
-    // Only show if values are defined and different from defaults
     playstyleMin !== undefined &&
-      playstyleMax !== undefined &&
-      (playstyleMin !== defaultValues.playstyle_RTG_min ||
-        playstyleMax !== defaultValues.playstyle_RTG_max) && (
-        <Badge key="playstyle_RTG" bg="primary" className="me-1">
-          {`${playstyleMin} <= PLAYTYPE_RTG <= ${playstyleMax}`}
-        </Badge>
-      );
+    playstyleMax !== undefined &&
+    renderBadge('playstyle_RTG', `${playstyleMin} <= PLAYTYPE_RTG <= ${playstyleMax}`);
 
-  const nonDefaultFilters = Object.entries(filters).filter(([key, value]) => {
-    if (key === 'rank_filter[]') return false; // Skip rank_filter[] as it's handled with teams_against[]
-    if (key in defaultValues) {
-      return value !== defaultValues[key];
+  const appliedFilters = Object.entries(filters).filter(([key, value]) => {
+    if (key === 'rank_filter[]') return false;
+    if (
+      (key === 'playstyle_RTG_min' || key === 'playstyle_RTG_max') &&
+      playstyleMin !== undefined &&
+      playstyleMax !== undefined
+    ) {
+      return false;
     }
-    return value && value !== 'null' && (typeof value === 'number' || value.length > 0);
+    return (
+      typeof value === 'number' ||
+      (typeof value === 'string' && value !== '' && value !== 'null') ||
+      (Array.isArray(value) && value.length > 0)
+    );
   });
 
-  if (nonDefaultFilters.length === 0) {
+  if (appliedFilters.length === 0 && !playstyleBadge) {
     return null;
   }
 
   return (
     <>
-      {nonDefaultFilters.map(([key, value]) => renderFilterBadge(key, value))}
+      {appliedFilters.map(([key, value]) => renderFilterBadge(key, value))}
       {playstyleBadge}
     </>
   );

--- a/src/AppliedFilters.test.js
+++ b/src/AppliedFilters.test.js
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import AppliedFilters from './AppliedFilters';
+
+test('renders an explicit default-valued parameter as a badge', () => {
+  render(<AppliedFilters filters={{ location_filter: 'Both', minutes_filter: '0,48' }} />);
+
+  expect(screen.getByText('Location: Both')).toBeVisible();
+  expect(screen.getByText('0 <= MIN <= 48')).toBeVisible();
+});
+
+test('renders one badge per recognised parameter', () => {
+  render(
+    <AppliedFilters
+      filters={{ player_name: 'LeBron James', playstyle_RTG_min: 75, playstyle_RTG_max: 125 }}
+    />,
+  );
+
+  expect(screen.getByText('Player: LeBron James')).toBeVisible();
+  expect(screen.getByText('75 <= PLAYTYPE_RTG <= 125')).toBeVisible();
+  expect(screen.getAllByText(/PLAYTYPE_RTG/)).toHaveLength(1);
+});


### PR DESCRIPTION
## Summary
- Delete the frontend copy of API default values in `AppliedFilters.js`; ADR-0001 rejects it and it hid badges for parameters a shared link explicitly carried (e.g. `location_filter=Both`).
- Render exactly one badge per recognised parameter, now including `player_name` and `season_filter`. Badges stay display-only.
- First Jest tests for `AppliedFilters`; e2e link test now asserts the explicit-default badge.

## Verification
`npm run lint && npm run format:check && npm run test:ci && npm run build && npm run test:e2e` — all pass (307 Jest, 76 e2e).

Closes #49
Part of crf04/statsplus#32

🤖 Generated with [Claude Code](https://claude.com/claude-code)