### PR TITLE
Tighten the Filter Set apply path

### DIFF
--- a/src/GameLogFilter.js
+++ b/src/GameLogFilter.js
@@ -16,12 +16,9 @@ import { useAuth } from './contexts/AuthContext';
 import { fetchGameLogsData, getRequestErrorMessage, isRequestCancelled } from './gameLogsApi';
 import {
   BROWSE_PARAM,
-  cleanFilterParams,
   filterSetFromSearchParams,
-  isWorkspaceSearch,
   filterSetToSearchParams,
   mergeFilterSet,
-  toGameLogParams,
 } from './filterUtils';
 
 const listNames = (names) =>
@@ -37,8 +34,8 @@ const GameLogFilter = () => {
     [searchParams],
   );
   const hasUrlFilterSet = Object.keys(urlFilters).length > 0 || urlInvalid.length > 0;
-  const inWorkspace = isWorkspaceSearch(searchParams);
   const hasBrowseSentinel = searchParams.has(BROWSE_PARAM);
+  const inWorkspace = hasBrowseSentinel || hasUrlFilterSet;
   // A refused link decoded to nothing, so there is no Filter Set to show, edit,
   // or patch a player into — only the refusal naming what has to be fixed.
   const isRefusedLink = urlInvalid.length > 0;
@@ -385,7 +382,7 @@ const GameLogFilter = () => {
    * the user touched, so a parameter it has no control for — a season that
    * arrived from a Parsed Query — survives an apply instead of being dropped.
    */
-  const handleApplyFilters = (filterParams, isFromNL = false, nlLoadingCallback = null) => {
+  const handleApplyFilters = (filterParams, isFromNL = false) => {
     // A refused link has no Filter Set to patch: the decoder withheld the whole
     // of it, so merging into what it returned would publish a URL missing the
     // very parameter the refusal on screen is naming — a link we declined to
@@ -393,7 +390,7 @@ const GameLogFilter = () => {
     // patch but a whole Filter Set, so it still supersedes the refused link and
     // stays the way out.
     if (!isFromNL && isRefusedLink) {
-      return Promise.resolve({ ok: false, refused: true });
+      return { ok: false, reason: 'refused' };
     }
 
     // A Parsed Query resolves to a whole Filter Set, so it replaces; the panel
@@ -403,14 +400,11 @@ const GameLogFilter = () => {
     // emptied arrives as a blank value, and that blank is the instruction to
     // drop the parameter. Cleaning it away would make clearing a control
     // indistinguishable from never touching it, and the old value would stand.
-    const nextFilters = isFromNL
-      ? cleanFilterParams(filterParams)
-      : mergeFilterSet(urlFilters, filterParams);
+    const nextFilters = isFromNL ? filterParams : mergeFilterSet(urlFilters, filterParams);
 
     if (Object.keys(nextFilters).length === 0) {
-      setGameLogsError('Add at least one filter before loading game logs.');
-      if (isFromNL && nlLoadingCallback) nlLoadingCallback(false);
-      return Promise.resolve({ ok: false, empty: true });
+      if (!isFromNL) setGameLogsError('Add at least one filter before loading game logs.');
+      return { ok: false, reason: 'empty' };
     }
 
     // Arriving on a link that carries filters but no player leaves the panel
@@ -421,15 +415,13 @@ const GameLogFilter = () => {
       // fix, and the player selector this advice points at is not on screen to
       // act on — replacing one with the other loses both.
       if (!isRefusedLink) setGameLogsError('Choose a player before applying these filters.');
-      if (isFromNL && nlLoadingCallback) nlLoadingCallback(false);
-      return Promise.resolve({ ok: false, empty: true });
+      return { ok: false, reason: 'needsPlayer' };
     }
 
     const nextSearch = filterSetToSearchParams(nextFilters);
     // An apply that changes nothing is not a place to come back to.
     if (nextSearch.toString() === searchParams.toString()) {
-      if (nlLoadingCallback) nlLoadingCallback(true);
-      return undefined;
+      return { ok: false, reason: 'unchanged' };
     }
     // Pushed, not replaced, so Back undoes the last filter change.
     setSearchParams(nextSearch, { replace: false });
@@ -437,8 +429,7 @@ const GameLogFilter = () => {
     // The Filter Set is now recorded, which is all a Parsed Query was for. The
     // game-log request that follows reports itself through gameLogsLoading and
     // the error alert.
-    if (nlLoadingCallback) nlLoadingCallback(true);
-    return undefined;
+    return { ok: true };
   };
 
   /*
@@ -451,17 +442,7 @@ const GameLogFilter = () => {
   const handleSelectPlayer = (player) => handleApplyFilters({ player_name: player });
 
   // Handler for natural language query results
-  const handleNLQueryResults = (filters, nlLoadingCallback) => {
-    const convertedFilters = cleanFilterParams(filters);
-    if (Object.keys(convertedFilters).length === 0) {
-      if (nlLoadingCallback) nlLoadingCallback(false);
-      return Promise.resolve({ ok: false, empty: true });
-    }
-
-    const apiFilters = toGameLogParams(convertedFilters);
-
-    return handleApplyFilters(apiFilters, true, nlLoadingCallback);
-  };
+  const handleNLQueryResults = (filters) => handleApplyFilters(filters, true);
 
   return (
     <>

--- a/src/GameLogFilter.test.js
+++ b/src/GameLogFilter.test.js
@@ -1,0 +1,207 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, useLocation, useNavigate } from 'react-router-dom';
+import GameLogFilter from './GameLogFilter';
+import { apiClient } from './config';
+import { useAuth } from './contexts/AuthContext';
+import { fetchGameLogsData } from './gameLogsApi';
+
+jest.mock('./config', () => ({
+  apiClient: { get: jest.fn() },
+  getApiUrl: (name) => `/api/${name.toLowerCase()}`,
+}));
+jest.mock('./gameLogsApi', () => ({
+  fetchGameLogsData: jest.fn(),
+  getRequestErrorMessage: jest.fn(() => 'request failed'),
+  isRequestCancelled: jest.fn(() => false),
+}));
+jest.mock('./contexts/AuthContext', () => ({ useAuth: jest.fn() }));
+jest.mock('./NaturalLanguageQuery', () => ({
+  __esModule: true,
+  default: ({ inWorkspace, onFiltersApplied }) => (
+    <div data-testid="query-prompt">
+      {String(inWorkspace)}
+      <button type="button" onClick={() => onFiltersApplied(mockParsedFilters)}>
+        Apply parsed query
+      </button>
+    </div>
+  ),
+}));
+jest.mock('./FilterOptions', () => ({
+  __esModule: true,
+  default: ({ onApplyFilters }) => (
+    <button type="button" onClick={() => onApplyFilters(mockFilterPatch)}>
+      Apply test filters
+    </button>
+  ),
+}));
+jest.mock('./PlayerSelector', () => ({ __esModule: true, default: () => null }));
+jest.mock('./PlayerProfile', () => ({ __esModule: true, default: () => null }));
+jest.mock('./OpposingTeamProfile', () => ({ __esModule: true, default: () => null }));
+jest.mock('./PerformanceAverages', () => ({ __esModule: true, default: () => null }));
+jest.mock('./ChartComponent', () => ({ __esModule: true, default: () => null }));
+jest.mock('./GameLogsTable', () => ({ __esModule: true, default: () => null }));
+jest.mock('./PlayerStatsCards', () => ({ __esModule: true, default: () => null }));
+
+let mockAuthState;
+let mockFilterPatch;
+let mockParsedFilters;
+
+const LocationProbe = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <output data-testid="location">
+        {location.pathname}
+        {location.search}
+      </output>
+      <button type="button" onClick={() => navigate(-1)}>
+        Browser back
+      </button>
+    </>
+  );
+};
+
+const renderGameLogFilter = (initialEntries, initialIndex) =>
+  render(
+    <MemoryRouter initialEntries={initialEntries} initialIndex={initialIndex}>
+      <GameLogFilter />
+      <LocationProbe />
+    </MemoryRouter>,
+  );
+
+beforeEach(() => {
+  mockAuthState = { isAuthenticated: true, loading: false };
+  mockFilterPatch = { game_filter: 5 };
+  mockParsedFilters = { player_name: 'Stephen Curry', game_filter: 10 };
+  useAuth.mockImplementation(() => mockAuthState);
+  apiClient.get.mockImplementation(() => new Promise(() => {}));
+  fetchGameLogsData.mockImplementation(() => new Promise(() => {}));
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test('pushes an applied filter so browser Back returns to the previous filter URL', async () => {
+  renderGameLogFilter(['/?player_name=LeBron+James']);
+
+  await waitFor(() => expect(fetchGameLogsData).toHaveBeenCalled());
+  fireEvent.click(screen.getByRole('button', { name: 'Apply test filters' }));
+
+  await waitFor(() =>
+    expect(screen.getByTestId('location')).toHaveTextContent(
+      '/?player_name=LeBron+James&game_filter=5',
+    ),
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: 'Browser back' }));
+  await waitFor(() =>
+    expect(screen.getByTestId('location')).toHaveTextContent('/?player_name=LeBron+James'),
+  );
+});
+
+test('replaces the URL with a parsed query Filter Set', async () => {
+  renderGameLogFilter(['/?player_name=LeBron+James&game_filter=5']);
+
+  await waitFor(() => expect(fetchGameLogsData).toHaveBeenCalled());
+  fireEvent.click(screen.getByRole('button', { name: 'Apply parsed query' }));
+
+  await waitFor(() =>
+    expect(screen.getByTestId('location')).toHaveTextContent(
+      '/?player_name=Stephen+Curry&game_filter=10',
+    ),
+  );
+});
+
+test('a missing player reports an error without navigating', async () => {
+  renderGameLogFilter(['/?game_filter=10']);
+
+  fireEvent.click(screen.getByRole('button', { name: 'Apply test filters' }));
+
+  expect(await screen.findByRole('alert')).toHaveTextContent(
+    'Choose a player before applying these filters.',
+  );
+  expect(screen.getByTestId('location')).toHaveTextContent('/?game_filter=10');
+  expect(fetchGameLogsData).not.toHaveBeenCalled();
+});
+
+test('strips only the browse sentinel from a refused raw query', async () => {
+  renderGameLogFilter(['/?browse=1&game_filter=0&utm_source=twitter']);
+
+  await waitFor(() =>
+    expect(screen.getByTestId('location')).toHaveTextContent('/?game_filter=0&utm_source=twitter'),
+  );
+  expect(screen.getByTestId('location')).not.toHaveTextContent('browse');
+  expect(fetchGameLogsData).not.toHaveBeenCalled();
+  expect(screen.getByRole('alert')).toHaveTextContent('game_filter');
+});
+
+test('does not push when applying leaves the raw query string unchanged', async () => {
+  mockFilterPatch = { game_filter: 10 };
+  const rendered = renderGameLogFilter(['/', '/?player_name=LeBron+James&game_filter=10'], 1);
+
+  await waitFor(() => expect(fetchGameLogsData).toHaveBeenCalled());
+  fireEvent.click(screen.getByRole('button', { name: 'Apply test filters' }));
+  fireEvent.click(screen.getByRole('button', { name: 'Browser back' }));
+
+  await waitFor(() => expect(screen.getByTestId('location')).toHaveTextContent('/'));
+  rendered.unmount();
+});
+
+test('uses the raw query string when deciding whether an apply changed anything', async () => {
+  mockFilterPatch = { game_filter: 10 };
+  renderGameLogFilter(['/', '/?game_filter=10&player_name=LeBron+James'], 1);
+
+  await waitFor(() => expect(fetchGameLogsData).toHaveBeenCalled());
+  fireEvent.click(screen.getByRole('button', { name: 'Apply test filters' }));
+
+  await waitFor(() =>
+    expect(screen.getByTestId('location')).toHaveTextContent(
+      '/?player_name=LeBron+James&game_filter=10',
+    ),
+  );
+});
+
+test('keeps a URL-driven request held until authentication settles', async () => {
+  mockAuthState.isAuthenticated = false;
+  const rendered = renderGameLogFilter(['/?player_name=LeBron+James&game_filter=10']);
+
+  await waitFor(() => expect(screen.getByText(/Sign in to load these game logs/)).toBeVisible());
+  expect(screen.getByTestId('location')).toHaveTextContent(
+    '/?player_name=LeBron+James&game_filter=10',
+  );
+  expect(fetchGameLogsData).not.toHaveBeenCalled();
+
+  mockAuthState.isAuthenticated = true;
+  rendered.rerender(
+    <MemoryRouter initialEntries={['/?player_name=LeBron+James&game_filter=10']}>
+      <GameLogFilter />
+      <LocationProbe />
+    </MemoryRouter>,
+  );
+
+  await waitFor(() => expect(fetchGameLogsData).toHaveBeenCalledTimes(1));
+  expect(screen.getByTestId('location')).toHaveTextContent(
+    '/?player_name=LeBron+James&game_filter=10',
+  );
+});
+
+test('keeps a refused link unchanged, refuses a panel apply, and accepts a parsed query', async () => {
+  renderGameLogFilter(['/?player_name=LeBron+James&game_filter=0']);
+
+  expect(await screen.findByRole('alert')).toHaveTextContent('game_filter');
+  expect(screen.getByTestId('location')).toHaveTextContent(
+    '/?player_name=LeBron+James&game_filter=0',
+  );
+  expect(screen.queryByRole('button', { name: 'Apply test filters' })).not.toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', { name: 'Apply parsed query' }));
+
+  await waitFor(() =>
+    expect(screen.getByTestId('location')).toHaveTextContent(
+      '/?player_name=Stephen+Curry&game_filter=10',
+    ),
+  );
+});

--- a/src/NaturalLanguageQuery.js
+++ b/src/NaturalLanguageQuery.js
@@ -133,38 +133,22 @@ const NaturalLanguageQuery = ({
       // Convert NL result to frontend filter format
       const filters = convertNLToFilters(result);
 
-      // A successful parser response can still contain no usable filters.
-      // Finish the request explicitly so the search UI cannot remain locked.
-      if (Object.keys(filters).length === 0) {
+      // Apply filters to the parent component (includes player selection)
+      const application = onFiltersApplied
+        ? onFiltersApplied(filters)
+        : Object.keys(filters).length === 0
+          ? { ok: false, reason: 'empty' }
+          : { ok: true };
+
+      if (application?.reason === 'empty') {
         setError(
           'I could not find usable filters in that query. Please try a player or stat filter.',
         );
-        finishLoading();
-        return;
       }
 
-      // Apply filters to the parent component (includes player selection)
-      if (onFiltersApplied) {
-        // Pass a callback to clear this component's loading state
-        const application = onFiltersApplied(filters, finishLoading);
-        // Parent handlers normally resolve after the game-log request and call
-        // finishLoading themselves. This fallback also supports lightweight
-        // embedders that return a promise but do not use the callback seam.
-        if (application && typeof application.then === 'function') {
-          application
-            .then(() => {
-              if (
-                queryRequestRef.current.id === requestId &&
-                queryRequestRef.current.controller === controller
-              ) {
-                finishLoading();
-              }
-            })
-            .catch(() => finishLoading());
-        }
-      } else {
-        finishLoading();
-      }
+      finishLoading();
+
+      if (application?.reason === 'empty') return;
 
       // Update parent with the successful query
       if (onQueryUpdate) {

--- a/src/NaturalLanguageQuery.test.js
+++ b/src/NaturalLanguageQuery.test.js
@@ -22,7 +22,7 @@ describe('NaturalLanguageQuery', () => {
 
   test('clears loading when the parser returns no usable filters', async () => {
     apiClient.post.mockResolvedValue({ data: { confidence: 0 } });
-    const onFiltersApplied = jest.fn();
+    const onFiltersApplied = jest.fn(() => ({ ok: false, reason: 'empty' }));
 
     render(
       <MemoryRouter>
@@ -36,7 +36,7 @@ describe('NaturalLanguageQuery', () => {
     await waitFor(() =>
       expect(screen.getByText(/could not find usable filters/i)).toBeInTheDocument(),
     );
-    expect(onFiltersApplied).not.toHaveBeenCalled();
+    expect(onFiltersApplied).toHaveBeenCalledWith({});
     expect(screen.getByRole('textbox')).not.toBeDisabled();
   });
 
@@ -60,26 +60,9 @@ describe('NaturalLanguageQuery', () => {
     );
   });
 
-  test('settles a stale game-log application without clearing a newer query', async () => {
-    apiClient.post
-      .mockResolvedValueOnce({ data: { player_name: 'LeBron James' } })
-      .mockResolvedValueOnce({ data: { player_name: 'Stephen Curry' } });
-
-    let firstFinishLoading;
-    let secondFinishLoading;
-    let resolveSecondApplication;
-    const onFiltersApplied = jest
-      .fn()
-      .mockImplementationOnce((_filters, finishLoading) => {
-        firstFinishLoading = finishLoading;
-        return Promise.resolve({ stale: true, cancelled: true });
-      })
-      .mockImplementationOnce((_filters, finishLoading) => {
-        secondFinishLoading = finishLoading;
-        return new Promise((resolve) => {
-          resolveSecondApplication = resolve;
-        });
-      });
+  test('finishes loading for a synchronous unchanged application without showing an error', async () => {
+    apiClient.post.mockResolvedValue({ data: { player_name: 'LeBron James' } });
+    const onFiltersApplied = jest.fn(() => ({ ok: false, reason: 'unchanged' }));
 
     render(
       <MemoryRouter>
@@ -93,22 +76,42 @@ describe('NaturalLanguageQuery', () => {
 
     await waitFor(() => expect(onFiltersApplied).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(input).not.toBeDisabled());
+    expect(screen.queryByText(/could not find usable filters/i)).not.toBeInTheDocument();
+  });
 
+  test('a superseded parser response neither applies nor unlocks the newer query', async () => {
+    let resolveFirst;
+    let resolveSecond;
+    apiClient.post
+      .mockImplementationOnce(() => new Promise((resolve) => (resolveFirst = resolve)))
+      .mockImplementationOnce(() => new Promise((resolve) => (resolveSecond = resolve)));
+    const onFiltersApplied = jest.fn(() => ({ ok: true }));
+
+    render(
+      <MemoryRouter>
+        <NaturalLanguageQuery onFiltersApplied={onFiltersApplied} />
+      </MemoryRouter>,
+    );
+    const input = screen.getByRole('textbox');
+
+    fireEvent.change(input, { target: { value: 'LeBron this year' } });
+    fireEvent.submit(input.closest('form'));
+    await waitFor(() => expect(resolveFirst).toBeDefined());
     fireEvent.change(input, { target: { value: 'Stephen this year' } });
     fireEvent.submit(input.closest('form'));
-    await waitFor(() => expect(onFiltersApplied).toHaveBeenCalledTimes(2));
-    expect(input).toBeDisabled();
-
-    // A late callback from the first request must not finish the second one.
-    await act(async () => {
-      firstFinishLoading(false);
-    });
-    expect(input).toBeDisabled();
+    await waitFor(() => expect(resolveSecond).toBeDefined());
 
     await act(async () => {
-      secondFinishLoading(true);
-      resolveSecondApplication({ ok: true });
+      resolveFirst({ data: { player_name: 'LeBron James' } });
     });
+    expect(onFiltersApplied).not.toHaveBeenCalled();
+    expect(input).toBeDisabled();
+
+    await act(async () => {
+      resolveSecond({ data: { player_name: 'Stephen Curry' } });
+    });
+    expect(onFiltersApplied).toHaveBeenCalledTimes(1);
+    expect(onFiltersApplied).toHaveBeenCalledWith({ player_name: 'Stephen Curry' });
     expect(input).not.toBeDisabled();
   });
 

--- a/src/filterUtils.js
+++ b/src/filterUtils.js
@@ -35,23 +35,6 @@ export const cleanFilterParams = (filters = {}) => {
   }, {});
 };
 
-/**
- * Convert the frontend-only selectedPlayer key to the backend's player_name
- * key.  The natural-language result keeps selectedPlayer until this seam so
- * the UI can still display the resolved player name.
- */
-export const toGameLogParams = (filters = {}) => {
-  const cleaned = cleanFilterParams(filters);
-  const selectedPlayer = cleaned.selectedPlayer;
-
-  delete cleaned.selectedPlayer;
-  if (hasValue(selectedPlayer) && selectedPlayer !== 'None' && !hasValue(cleaned.player_name)) {
-    cleaned.player_name = selectedPlayer;
-  }
-
-  return cleaned;
-};
-
 const toNumericValue = (value) => {
   const numericValue = typeof value === 'number' ? value : Number(value);
   return Number.isFinite(numericValue) ? numericValue : null;
@@ -133,7 +116,7 @@ export const convertNLToFilters = (nlResult = {}) => {
   const filters = {};
 
   if (hasValue(nlResult.player_name)) {
-    filters.selectedPlayer = nlResult.player_name;
+    filters.player_name = nlResult.player_name;
   }
 
   if (hasValue(nlResult.game_count)) {
@@ -356,9 +339,9 @@ const REPEATED_FILTER_NAMES = ['players_on[]', 'players_off[]', 'teams_against[]
  * Encode a Filter Set as game-log query parameters, in a stable order.
  *
  * Only the API's own vocabulary is written. A key outside it — the prose of a
- * query, or the frontend-only `selectedPlayer` — is dropped rather than
- * published, because a parameter nobody re-parses becomes untrue as soon as
- * someone hand-edits the URL.
+ * query or any other unknown key — is dropped rather than published, because
+ * a parameter nobody re-parses becomes untrue as soon as someone hand-edits
+ * the URL.
  */
 export const filterSetToSearchParams = (filters = {}) => {
   const cleaned = cleanFilterParams(filters);
@@ -409,16 +392,3 @@ export const mergeFilterSet = (filters = {}, patch = {}) =>
  * exist — any URL carrying filters stays a pure API query string.
  */
 export const BROWSE_PARAM = 'browse';
-
-/**
- * The one place that decides whether the user is in the Log Workspace.
- *
- * Deriving this from the URL rather than storing it is what keeps a future
- * entry path from being accidentally locked behind the language model, which is
- * exactly what two separate stored flags did to the manual filter panel.
- */
-export const isWorkspaceSearch = (searchParams) => {
-  if (searchParams.has(BROWSE_PARAM)) return true;
-  const { filters, invalid } = filterSetFromSearchParams(searchParams);
-  return Object.keys(filters).length > 0 || invalid.length > 0;
-};

--- a/src/filterUtils.test.js
+++ b/src/filterUtils.test.js
@@ -1,12 +1,9 @@
 import {
-  BROWSE_PARAM,
-  isWorkspaceSearch,
   filterSetFromSearchParams,
   filterSetToSearchParams,
   mergeFilterSet,
   cleanFilterParams,
   convertNLToFilters,
-  toGameLogParams,
 } from './filterUtils';
 
 describe('filterUtils', () => {
@@ -36,17 +33,10 @@ describe('filterUtils', () => {
         players_on: ['Jimmy Butler'],
       }),
     ).toEqual({
-      selectedPlayer: 'Stephen Curry',
+      player_name: 'Stephen Curry',
       minutes_filter: '30,48',
       'self_filters[FGA]': '16,999',
       'players_on[]': ['Jimmy Butler'],
-    });
-  });
-
-  test('moves the frontend player key at the request seam', () => {
-    expect(toGameLogParams({ selectedPlayer: 'A player', game_filter: 0 })).toEqual({
-      player_name: 'A player',
-      game_filter: 0,
     });
   });
 });
@@ -266,11 +256,11 @@ describe('filterSetToSearchParams', () => {
   });
 
   test('writes nothing for a key outside the API vocabulary', () => {
-    // Prose is scaffolding, not part of the Filter Set, and the frontend-only
-    // player key never reaches the wire either.
+    // Prose is scaffolding, not part of the Filter Set, and unknown keys never
+    // reach the wire either.
     const search = filterSetToSearchParams({
       player_name: 'LeBron James',
-      selectedPlayer: 'LeBron James',
+      legacy_player: 'LeBron James',
       query: 'LeBron last 10 games',
     });
 
@@ -304,42 +294,5 @@ describe('mergeFilterSet', () => {
     const current = { player_name: 'LeBron James', minutes_filter: '20,40' };
 
     expect(mergeFilterSet(current, { player_name: 'LeBron James' })).toEqual(current);
-  });
-});
-
-describe('isWorkspaceSearch', () => {
-  const gate = (query) => isWorkspaceSearch(new URLSearchParams(query));
-
-  test('a bare route is the Query Prompt', () => {
-    expect(gate('')).toBe(false);
-  });
-
-  test('the sentinel alone opens an empty Log Workspace', () => {
-    // Manual entry lands with no filters, and an empty Filter Set is otherwise
-    // indistinguishable from a fresh visit.
-    expect(gate(`${BROWSE_PARAM}=1`)).toBe(true);
-  });
-
-  test('any Filter Set opens the Log Workspace', () => {
-    expect(gate('player_name=LeBron+James')).toBe(true);
-    expect(gate('game_filter=10')).toBe(true);
-  });
-
-  test('a link we must refuse still opens the Workspace, to say so', () => {
-    expect(gate('game_filter=0')).toBe(true);
-  });
-
-  test('a stray tracking parameter is not an entry', () => {
-    expect(gate('utm_source=newsletter')).toBe(false);
-  });
-
-  test('the sentinel is not a filter and never reaches a request', () => {
-    const { filters, invalid } = filterSetFromSearchParams(
-      new URLSearchParams(`player_name=LeBron+James&${BROWSE_PARAM}=1`),
-    );
-
-    expect(invalid).toEqual([]);
-    expect(filters).toEqual({ player_name: 'LeBron James' });
-    expect(filterSetToSearchParams(filters).has(BROWSE_PARAM)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
No behaviour change.
- `convertNLToFilters` emits `player_name` directly; the `selectedPlayer` alias and `toGameLogParams` are deleted, and the Filter Set is cleaned once instead of five times.
- `inWorkspace` derives from the already-memoized decode; `isWorkspaceSearch` deleted (URL decoded once per render).
- `onFiltersApplied` returns one synchronous shape `{ ok } | { ok: false, reason }`; the undefined-or-Promise plus ignored-boolean callback protocol is gone. `NaturalLanguageQuery` finishes loading after every outcome.
- First Jest coverage for `GameLogFilter` (parsed replace, panel patch, missing player, unchanged apply, refused link, sentinel strip, auth-gated request) plus a superseded-parser-response test.

## Verification
`npm run lint && npm run format:check && npm run test:ci && npm run build && npm run test:e2e` — all pass (307 Jest, 76 e2e).

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)