### PR TITLE
Make the Playtype Matchup Rating slider controlled over the API's 0–200 domain

### DIFF
--- a/e2e/specs/core-flows.spec.js
+++ b/e2e/specs/core-flows.spec.js
@@ -521,6 +521,14 @@ test('a bound the link arrived with survives a later apply', async ({
   await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
   await expect.poll(() => gameLogRequests.length).toBeGreaterThan(0);
 
+  // The label and the thumbs are two separate readings of the same range, and
+  // this journey once passed while they disagreed. The playtype control is the
+  // first of the two range sliders; both name their thumbs the same way.
+  await expect(page.getByText('Playtype Matchup Rating: 0 - 80')).toBeVisible();
+  const playstyleThumbs = page.getByRole('slider');
+  await expect(playstyleThumbs.first()).toHaveAttribute('aria-valuenow', '0');
+  await expect(playstyleThumbs.nth(1)).toHaveAttribute('aria-valuenow', '80');
+
   const arrivedCount = gameLogRequests.length;
   // Touch an unrelated control, so the apply is a real change rather than a
   // rewrite of the Filter Set already in the address bar.

--- a/src/FilterOptions.js
+++ b/src/FilterOptions.js
@@ -40,7 +40,7 @@ const FilterOptions = ({
   const [minutesFilter, setMinutesFilter] = useState([0, 48]);
   const [dateFilter, setDateFilter] = useState('');
   const [gameFilter, setGameFilter] = useState(0);
-  const [playstyleMatchupRating, setPlaystyleMatchupRating] = useState([75, 125]);
+  const [playstyleMatchupRating, setPlaystyleMatchupRating] = useState([0, 200]);
   const [selfFilterColumns, setSelfFilterColumns] = useState([]);
   const [selectedSelfFilter, setSelectedSelfFilter] = useState('');
   const [selfFilterRange, setSelfFilterRange] = useState([0, 0]);
@@ -113,7 +113,7 @@ const FilterOptions = ({
     setMinutesFilter([0, 48]);
     setDateFilter('');
     setGameFilter(0);
-    setPlaystyleMatchupRating([75, 125]);
+    setPlaystyleMatchupRating([0, 200]);
     setSelectedSelfFilter('');
     setSelfFilterRange([0, 0]);
     setActiveSelfFilters([]);
@@ -156,14 +156,16 @@ const FilterOptions = ({
 
       // Pre-populate playstyle rating. Presence, not truthiness: the API's own
       // lower bound is 0, so a link carrying it must reach the slider or a later
-      // apply would silently drop the bound the user arrived with.
+      // apply would silently drop the bound the user arrived with. Either bound
+      // alone is still a range: the side the link left out is the API's own
+      // default, so the slider can show exactly what the request applied.
       if (
-        hasFilterValue(appliedFilters.playstyle_RTG_min) &&
+        hasFilterValue(appliedFilters.playstyle_RTG_min) ||
         hasFilterValue(appliedFilters.playstyle_RTG_max)
       ) {
         setPlaystyleMatchupRating([
-          appliedFilters.playstyle_RTG_min,
-          appliedFilters.playstyle_RTG_max,
+          hasFilterValue(appliedFilters.playstyle_RTG_min) ? appliedFilters.playstyle_RTG_min : 0,
+          hasFilterValue(appliedFilters.playstyle_RTG_max) ? appliedFilters.playstyle_RTG_max : 200,
         ]);
         prepopulatedControls.add('playstyle_RTG');
       }
@@ -614,14 +616,14 @@ const FilterOptions = ({
                 className="horizontal-slider"
                 thumbClassName="thumb"
                 trackClassName="track"
-                defaultValue={[75, 125]}
+                value={playstyleMatchupRating}
                 ariaLabel={['Lower thumb', 'Upper thumb']}
                 ariaValuetext={(state) => `Thumb value ${state.valueNow}`}
                 renderThumb={(props, state) => <div {...props}>{state.valueNow}</div>}
                 pearling
                 minDistance={1}
-                min={75}
-                max={125}
+                min={0}
+                max={200}
                 step={1}
                 onChange={handlePlaystyleMatchupRatingChange}
               />

--- a/src/FilterOptions.test.js
+++ b/src/FilterOptions.test.js
@@ -1,0 +1,97 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import FilterOptions from './FilterOptions';
+
+// jsdom has no ResizeObserver, and the range sliders observe their track on
+// mount. Nothing here asserts on pixel geometry, so an inert observer is enough
+// to let the panel render.
+global.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+const renderPanel = (appliedFilters = {}) => {
+  const onApplyFilters = jest.fn();
+  render(
+    <FilterOptions
+      playerList={['LeBron James']}
+      onApplyFilters={onApplyFilters}
+      selectedPlayer="LeBron James"
+      seasonGameLogs={[]}
+      seasonGameLogsLoading={false}
+      seasonGameLogsFailed={false}
+      onOpenSelfFilters={jest.fn()}
+      appliedFilters={appliedFilters}
+    />,
+  );
+  return onApplyFilters;
+};
+
+// The minutes slider carries the same thumb labels, so the playtype thumbs are
+// reached through their own control's label rather than by role alone.
+const playstyleThumbs = () => {
+  const label = screen.getByText(/^Playtype Matchup Rating:/);
+  return within(label.parentElement)
+    .getAllByRole('slider')
+    .map((thumb) => thumb.getAttribute('aria-valuenow'));
+};
+
+const applyFilters = () => fireEvent.click(screen.getByRole('button', { name: 'Apply Filters' }));
+
+test('the playtype thumbs stand where the link the panel opened under put them', () => {
+  renderPanel({ player_name: 'LeBron James', playstyle_RTG_min: 0, playstyle_RTG_max: 80 });
+
+  expect(playstyleThumbs()).toEqual(['0', '80']);
+});
+
+test('an untouched panel spans the API domain and applies nothing but the player', () => {
+  const onApplyFilters = renderPanel();
+
+  expect(playstyleThumbs()).toEqual(['0', '200']);
+
+  applyFilters();
+
+  expect(onApplyFilters).toHaveBeenCalledWith({ player_name: 'LeBron James' });
+});
+
+test('a range the link arrived with survives a later apply', () => {
+  const onApplyFilters = renderPanel({
+    player_name: 'LeBron James',
+    playstyle_RTG_min: 0,
+    playstyle_RTG_max: 80,
+  });
+
+  applyFilters();
+
+  expect(onApplyFilters).toHaveBeenCalledWith({
+    player_name: 'LeBron James',
+    playstyle_RTG_min: 0,
+    playstyle_RTG_max: 80,
+  });
+});
+
+test('a single-bound link fills the other side with the API default and applies both', () => {
+  const onApplyFilters = renderPanel({ player_name: 'LeBron James', playstyle_RTG_max: 80 });
+
+  expect(playstyleThumbs()).toEqual(['0', '80']);
+
+  applyFilters();
+
+  expect(onApplyFilters).toHaveBeenCalledWith({
+    player_name: 'LeBron James',
+    playstyle_RTG_min: 0,
+    playstyle_RTG_max: 80,
+  });
+});
+
+test('clearing a control applies a blank value instead of leaving the bound behind', () => {
+  const onApplyFilters = renderPanel({ player_name: 'LeBron James', date_filter: '2026-01-09' });
+
+  fireEvent.change(screen.getByLabelText('Date Filter:'), { target: { value: '' } });
+  applyFilters();
+
+  expect(onApplyFilters).toHaveBeenCalledWith({
+    player_name: 'LeBron James',
+    date_filter: null,
+  });
+});

--- a/src/filterUtils.js
+++ b/src/filterUtils.js
@@ -282,8 +282,15 @@ export const filterSetFromSearchParams = (searchParams) => {
     const parsed = wholeNumber(value);
     return parsed !== null && parsed >= 1 ? parsed : null;
   });
-  readDecoded('playstyle_RTG_min', finiteNumber);
-  readDecoded('playstyle_RTG_max', finiteNumber);
+  // 0-200 is the API's own playtype rating domain and the slider now spans
+  // exactly it, so a bound outside it is a value we cannot honour and names
+  // itself rather than arriving as a range no control could show.
+  const playstyleRating = (value) => {
+    const parsed = finiteNumber(value);
+    return parsed !== null && parsed >= 0 && parsed <= 200 ? parsed : null;
+  };
+  readDecoded('playstyle_RTG_min', playstyleRating);
+  readDecoded('playstyle_RTG_max', playstyleRating);
   if (
     hasValue(filters.playstyle_RTG_min) &&
     hasValue(filters.playstyle_RTG_max) &&

--- a/src/filterUtils.test.js
+++ b/src/filterUtils.test.js
@@ -120,6 +120,8 @@ describe('filterSetFromSearchParams', () => {
     ['date_filter=2026-13-45', 'date_filter'],
     ['playstyle_RTG_min=abc', 'playstyle_RTG_min'],
     ['playstyle_RTG_min=120&playstyle_RTG_max=80', 'playstyle_RTG_max'],
+    ['playstyle_RTG_min=-1', 'playstyle_RTG_min'],
+    ['playstyle_RTG_max=201', 'playstyle_RTG_max'],
     ['player_name=+', 'player_name'],
     ['self_filters%5BPTS%5D=20', 'self_filters[PTS]'],
     ['teams_against%5B%5D=Isolation&rank_filter%5B%5D=0', 'rank_filter[]'],


### PR DESCRIPTION
## Summary
- The playtype slider was uncontrolled (`defaultValue`) while its label read state, so a link carrying `playstyle_RTG_min=0&playstyle_RTG_max=80` showed "0 - 80" with thumbs at 75/125. It is now controlled, spanning the API's 0–200 domain with untouched thumbs at the API defaults.
- A link carrying only one bound prepopulates the other side with the API default and Apply emits both.
- A bound outside 0–200 is refused by the decoder and names itself (ADR-0001).
- First rendered Jest tests for `FilterOptions` (thumbs match a URL range, untouched controls absent from the patch, prepopulated range survives Apply, single-bound link, clearing emits blank). The e2e link journey now asserts thumb positions, so it no longer passes for the wrong reason (verified to fail on the old code).

## Verification
`npm run lint && npm run format:check && npm run test:ci && npm run build && npm run test:e2e` — all pass (312 Jest, 76 e2e).

Closes #53
Part of crf04/statsplus#33

🤖 Generated with [Claude Code](https://claude.com/claude-code)