### PR TITLE
Move the Log Workspace search toggle below the header so pointer clicks reach it

### DIFF
--- a/e2e/specs/core-flows.spec.js
+++ b/e2e/specs/core-flows.spec.js
@@ -1177,9 +1177,8 @@ test('a refused link keeps its explanation when prose names no player', async ({
   await page.goto('/?player_name=LeBron+James&game_filter=0');
   await expect(page.getByRole('alert')).toContainText('game_filter');
 
-  // Reached from the keyboard: the toggle is overlapped by the header in the
-  // workspace, which is a separate pre-existing defect on every link, not this
-  // one's to fix.
+  // Reached from the keyboard, which stays a way in of its own however the
+  // toggle is placed.
   await page.getByRole('button', { name: 'Open search' }).press('Enter');
   await page.getByRole('textbox').fill('last 10 games');
   await page.getByRole('textbox').press('Enter');
@@ -1189,6 +1188,30 @@ test('a refused link keeps its explanation when prose names no player', async ({
   // the user holding neither.
   await expect(page.getByRole('alert')).toContainText('game_filter');
   await expect(page.getByText('Choose a player before applying these filters.')).toBeHidden();
+});
+
+test('@critical the workspace search toggle answers a real pointer click', async ({
+  authenticatedPage: page,
+}) => {
+  for (const viewport of [
+    { width: 1280, height: 800 },
+    { width: 375, height: 667 },
+  ]) {
+    await page.setViewportSize(viewport);
+    await page.goto('/?player_name=LeBron+James');
+    await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
+
+    // A plain click, never `force`. Playwright's own hit test is the assertion:
+    // it fails when the header covers the toggle, which is what a pointer hits
+    // and the keyboard path hides.
+    await page.getByRole('button', { name: 'Open search' }).click();
+    await expect(page.getByPlaceholder('Ask about your favorite player')).toBeVisible();
+    await page.getByRole('button', { name: 'Close search' }).click();
+
+    // Moving the toggle out of the header cannot cost the header its own links.
+    await page.getByRole('link', { name: 'Matchups' }).click();
+    await expect(page).toHaveURL(/\/matchups$/);
+  }
 });
 
 test('a slow request never claims the result was empty', async ({ authenticatedPage: page }) => {

--- a/src/App.css
+++ b/src/App.css
@@ -10,7 +10,9 @@
 :root {
   /* The height of the header band, published so anything floating at the top
      of the viewport can clear it. The header paints above those layers, so a
-     control drawn inside this band takes no pointer clicks. */
+     control drawn inside this band takes no pointer clicks. Keep in step with
+     .app-nav min-height plus the header border; the workspace search-toggle
+     pointer-click e2e test fails if this drifts. */
   --ct-header-height: 69px;
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -7,6 +7,13 @@
     -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Inter', 'SF Pro Display', system-ui, sans-serif;
 }
 
+:root {
+  /* The height of the header band, published so anything floating at the top
+     of the viewport can clear it. The header paints above those layers, so a
+     control drawn inside this band takes no pointer clicks. */
+  --ct-header-height: 69px;
+}
+
 .app-header {
   position: relative;
   z-index: 2001;
@@ -58,6 +65,11 @@
 }
 
 @media (max-width: 620px) {
+  :root {
+    /* The links wrap onto their own row here, so the band grows. */
+    --ct-header-height: 81px;
+  }
+
   .app-nav {
     grid-template-columns: auto 1fr;
     width: min(100% - 20px, 1160px);

--- a/src/ModernSearch.css
+++ b/src/ModernSearch.css
@@ -395,9 +395,8 @@
 
 /* Compact Search Interface Styles (after search) */
 /* Search container wrapper for click-to-expand functionality */
-/* Floats clear of the header band. Inside it the header, which paints above
-   this layer, is what a pointer lands on, so the toggle only ever opened from
-   the keyboard. */
+/* Must float clear of the header band: the header paints above this layer,
+   so anything drawn inside the band takes no pointer clicks. */
 .compact-search-wrapper {
   position: fixed;
   top: calc(var(--ct-header-height) + 12px);

--- a/src/ModernSearch.css
+++ b/src/ModernSearch.css
@@ -395,9 +395,12 @@
 
 /* Compact Search Interface Styles (after search) */
 /* Search container wrapper for click-to-expand functionality */
+/* Floats clear of the header band. Inside it the header, which paints above
+   this layer, is what a pointer lands on, so the toggle only ever opened from
+   the keyboard. */
 .compact-search-wrapper {
   position: fixed;
-  top: 15px;
+  top: calc(var(--ct-header-height) + 12px);
   left: 50%;
   transform: translateX(-50%);
   z-index: 2000;


### PR DESCRIPTION
Closes #55
Part of crf04/statsplus#30

## What

The magnifying-glass button that reopens the prose search in the Log Workspace sat at `top: 15px`, entirely inside the 69px app header, whose `z-index: 2001` stacked above the wrapper's `2000` — so pointer clicks landed on the header's nav-links container and were swallowed. Keyboard activation worked because it bypasses hit-testing.

## Fix

Move the toggle below the header band instead of restacking above it (the button is centred exactly where the header's Search/Matchups links sit, so raising its z-index would have covered them):

- `--ct-header-height` custom property (69px desktop, 81px under the 620px breakpoint where the nav wraps to two rows)
- `.compact-search-wrapper` `top: 15px` → `top: calc(var(--ct-header-height) + 12px)`

The expanded prose panel anchors to the wrapper, so it also drops fully below the header instead of being half-clipped.

## Tests

New `@critical` Playwright test clicks the button with a real pointer click (no `force`, no keyboard) at 1280×800 and 375×667, asserts the search input appears, and clicks the header's Matchups link to prove nav links stay clickable. It failed on the unfixed code with "`.app-links` … intercepts pointer events". The pre-existing keyboard-activation path is untouched and still passes.

## Verification

Full completion gate passed: `npm run lint`, `npm run format:check`, `npm run test:ci` (316 tests), `npm run build`, `npm run test:e2e` (77 passed, 2 pre-existing env-gated skips). Also verified live in a driven browser at desktop and 375px: `elementFromPoint` at the button centre now returns the button's own icon, the click opens the search, and header links navigate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
