### PR TITLE
Save, list, and manage Saved Filter Sets in the Log Workspace

### DIFF
--- a/e2e/fixtures/courtai.js
+++ b/e2e/fixtures/courtai.js
@@ -1047,6 +1047,11 @@ export const installApiContract = async (page, overrides = {}) => {
         );
       const conflict = (message) =>
         route.fulfill({ status: 409, json: { error: { code: 'conflict', message } } });
+      const invalidName = () =>
+        route.fulfill({
+          status: 400,
+          json: { error: { code: 'invalid_request', message: 'Invalid saved filter set.' } },
+        });
       const index = savedFilterSets.findIndex((item) => String(item.id) === savedFilterSetId);
 
       if (method === 'GET') {
@@ -1056,10 +1061,7 @@ export const installApiContract = async (page, overrides = {}) => {
 
       if (method === 'POST') {
         if (!body?.name?.trim() || typeof body.query_string !== 'string') {
-          await route.fulfill({
-            status: 400,
-            json: { error: { code: 'invalid_request', message: 'Invalid saved filter set.' } },
-          });
+          await invalidName();
           return;
         }
         if (duplicateName(body.name)) {
@@ -1075,7 +1077,11 @@ export const installApiContract = async (page, overrides = {}) => {
           created_at: '2026-04-13T00:10:00Z',
           updated_at: '2026-04-13T00:10:00Z',
         });
-        await route.fulfill({ status: 201, json: savedFilterSets[0] });
+        // A single item travels in its own envelope, as the backend sends it.
+        await route.fulfill({
+          status: 201,
+          json: { success: true, saved_filter_set: savedFilterSets[0] },
+        });
         return;
       }
 
@@ -1088,12 +1094,21 @@ export const installApiContract = async (page, overrides = {}) => {
       }
 
       if (method === 'PATCH') {
-        if (duplicateName(body?.name, savedFilterSets[index].id)) {
+        if (!body?.name?.trim()) {
+          await invalidName();
+          return;
+        }
+        if (duplicateName(body.name, savedFilterSets[index].id)) {
           await conflict('You already have a saved Filter Set with that name.');
           return;
         }
-        savedFilterSets[index] = { ...savedFilterSets[index], name: body.name.trim() };
-        await route.fulfill({ json: savedFilterSets[index] });
+        savedFilterSets[index] = {
+          ...savedFilterSets[index],
+          name: body.name.trim(),
+          // The query string is immutable; only the name and its timestamp move.
+          updated_at: '2026-04-13T00:20:00Z',
+        };
+        await route.fulfill({ json: { success: true, saved_filter_set: savedFilterSets[index] } });
         return;
       }
 

--- a/e2e/fixtures/courtai.js
+++ b/e2e/fixtures/courtai.js
@@ -964,6 +964,11 @@ const applySelfFilters = (logs, url) =>
 
 export const installApiContract = async (page, overrides = {}) => {
   const operationsJobs = [...operationsPayload.jobs];
+  // Saved Filter Sets are account state rather than reference data, so the
+  // contract remembers what this page saved: a list that never changes cannot
+  // show that saving, renaming, and deleting reach the same list.
+  const savedFilterSets = [];
+  let nextSavedFilterSetId = 0;
   await page.route('**/api/**', async (route) => {
     const request = route.request();
     const url = new URL(request.url());
@@ -1029,6 +1034,74 @@ export const installApiContract = async (page, overrides = {}) => {
       const response = typeof override === 'function' ? await override(request) : override;
       await route.fulfill({ status: response.status || 200, json: response.body ?? response });
       return;
+    }
+
+    const savedFilterSetPath = url.pathname.match(/^\/api\/user\/saved-filter-sets(?:\/(.+))?$/);
+    if (savedFilterSetPath) {
+      const [, savedFilterSetId] = savedFilterSetPath;
+      const method = request.method();
+      const body = ['POST', 'PATCH'].includes(method) ? request.postDataJSON() : null;
+      const duplicateName = (name, ignoredId) =>
+        savedFilterSets.some(
+          (item) => item.id !== ignoredId && item.name.toLowerCase() === String(name).toLowerCase(),
+        );
+      const conflict = (message) =>
+        route.fulfill({ status: 409, json: { error: { code: 'conflict', message } } });
+      const index = savedFilterSets.findIndex((item) => String(item.id) === savedFilterSetId);
+
+      if (method === 'GET') {
+        await route.fulfill({ json: { success: true, saved_filter_sets: savedFilterSets } });
+        return;
+      }
+
+      if (method === 'POST') {
+        if (!body?.name?.trim() || typeof body.query_string !== 'string') {
+          await route.fulfill({
+            status: 400,
+            json: { error: { code: 'invalid_request', message: 'Invalid saved filter set.' } },
+          });
+          return;
+        }
+        if (duplicateName(body.name)) {
+          await conflict('You already have a saved Filter Set with that name.');
+          return;
+        }
+        nextSavedFilterSetId += 1;
+        // Newest-first is the list's contract, so the store keeps that order.
+        savedFilterSets.unshift({
+          id: nextSavedFilterSetId,
+          name: body.name.trim(),
+          query_string: body.query_string,
+          created_at: '2026-04-13T00:10:00Z',
+          updated_at: '2026-04-13T00:10:00Z',
+        });
+        await route.fulfill({ status: 201, json: savedFilterSets[0] });
+        return;
+      }
+
+      if (index === -1) {
+        await route.fulfill({
+          status: 404,
+          json: { error: { code: 'resource_not_found', message: 'Saved filter set not found.' } },
+        });
+        return;
+      }
+
+      if (method === 'PATCH') {
+        if (duplicateName(body?.name, savedFilterSets[index].id)) {
+          await conflict('You already have a saved Filter Set with that name.');
+          return;
+        }
+        savedFilterSets[index] = { ...savedFilterSets[index], name: body.name.trim() };
+        await route.fulfill({ json: savedFilterSets[index] });
+        return;
+      }
+
+      if (method === 'DELETE') {
+        savedFilterSets.splice(index, 1);
+        await route.fulfill({ json: { success: true } });
+        return;
+      }
     }
 
     if (url.pathname === '/api/players') {

--- a/e2e/specs/core-flows.spec.js
+++ b/e2e/specs/core-flows.spec.js
@@ -1276,11 +1276,14 @@ test('@critical a saved Filter Set is a name that reopens the same Log Workspace
   await expect(page).toHaveURL(/game_filter=10/);
   await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
   await expect(page.getByText('GAMES <= 10').first()).toBeVisible();
+  // Opening an item is done with the list, so the list goes.
+  await expect(page.getByRole('dialog')).toHaveCount(0);
 
   // The account menu opens the same list, so renaming and deleting there is
   // the same list changing.
   await page.getByRole('banner').getByRole('button', { name: 'CourtAI Test User' }).click();
   await page.getByRole('banner').getByRole('button', { name: 'Saved Filter Sets' }).click();
+  await expect(page.getByRole('dialog')).toHaveCount(1);
   await page.getByRole('button', { name: 'Rename LeBron last 10' }).click();
   await page.getByLabel('New name for LeBron last 10').fill('LeBron recent form');
   await page.getByRole('button', { name: 'Save name' }).click();
@@ -1299,4 +1302,58 @@ test('signed-out readers are offered no saved Filter Sets', async ({ page }) => 
   await expect(page.getByText('Sign in to load these game logs')).toBeVisible();
   await expect(page.getByRole('button', { name: 'Save Filter Set' })).toHaveCount(0);
   await expect(page.getByRole('button', { name: 'Saved Filter Sets' })).toHaveCount(0);
+});
+
+test('saved Filter Set fixture answers the documented envelopes and rejections', async ({
+  authenticatedPage: page,
+}) => {
+  await page.goto('/');
+
+  const contract = await page.evaluate(async () => {
+    const base = '/api/user/saved-filter-sets';
+    const send = (path, method, body) =>
+      fetch(path, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: body === undefined ? undefined : JSON.stringify(body),
+      });
+
+    const created = await send(base, 'POST', {
+      name: 'Fixture contract',
+      query_string: 'player_name=LeBron+James',
+    });
+    const createdBody = await created.json();
+    const renamed = await send(`${base}/${createdBody.saved_filter_set.id}`, 'PATCH', {
+      name: 'Fixture contract renamed',
+    });
+    const renamedBody = await renamed.json();
+
+    return {
+      created: { status: created.status, body: createdBody },
+      renamed: { status: renamed.status, body: renamedBody },
+      rejections: await Promise.all(
+        [
+          send(base, 'POST', { name: '   ', query_string: 'player_name=LeBron+James' }),
+          send(`${base}/${createdBody.saved_filter_set.id}`, 'PATCH', { name: '' }),
+          send(`${base}/9999`, 'PATCH', { name: 'No such item' }),
+          send(`${base}/9999`, 'DELETE'),
+        ].map((response) => response.then((settled) => settled.status)),
+      ),
+    };
+  });
+
+  expect(contract.created.status).toBe(201);
+  expect(contract.created.body).toMatchObject({
+    success: true,
+    saved_filter_set: { name: 'Fixture contract', query_string: 'player_name=LeBron+James' },
+  });
+  expect(contract.renamed.status).toBe(200);
+  expect(contract.renamed.body.saved_filter_set).toMatchObject({
+    name: 'Fixture contract renamed',
+    // Renaming moves the name and its timestamp; the query string is immutable.
+    query_string: 'player_name=LeBron+James',
+    created_at: '2026-04-13T00:10:00Z',
+    updated_at: '2026-04-13T00:20:00Z',
+  });
+  expect(contract.rejections).toEqual([400, 400, 404, 404]);
 });

--- a/e2e/specs/core-flows.spec.js
+++ b/e2e/specs/core-flows.spec.js
@@ -1246,3 +1246,57 @@ test('a link carrying filters but no player applies them to the player chosen', 
   expect(requested.searchParams.get('player_name')).toBe('LeBron James');
   expect(requested.searchParams.get('game_filter')).toBe('10');
 });
+
+test('@critical a saved Filter Set is a name that reopens the same Log Workspace', async ({
+  authenticatedPage: page,
+}) => {
+  await page.goto('/?player_name=LeBron+James&game_filter=10');
+  await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Save Filter Set' }).click();
+  await page.getByLabel('Name').fill('LeBron last 10');
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+  await expect(page.getByRole('heading', { name: 'Save this Filter Set' })).toHaveCount(0);
+
+  // The same name twice is the backend's answer, shown rather than swallowed.
+  await page.getByRole('button', { name: 'Save Filter Set' }).click();
+  await page.getByLabel('Name').fill('LeBron last 10');
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+  await expect(page.getByRole('alert')).toContainText('already have a saved Filter Set');
+  await page.getByRole('button', { name: 'Cancel' }).click();
+
+  // Leaving and coming back through the saved list lands on exactly the URL
+  // that was saved.
+  await page.getByRole('button', { name: 'Back to search' }).click();
+  await expect(page).toHaveURL(/\/$/);
+  await page.getByRole('button', { name: 'Saved Filter Sets' }).click();
+  await page.getByRole('button', { name: 'Open saved Filter Set LeBron last 10' }).click();
+
+  await expect(page).toHaveURL(/player_name=LeBron\+James/);
+  await expect(page).toHaveURL(/game_filter=10/);
+  await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
+  await expect(page.getByText('GAMES <= 10').first()).toBeVisible();
+
+  // The account menu opens the same list, so renaming and deleting there is
+  // the same list changing.
+  await page.getByRole('banner').getByRole('button', { name: 'CourtAI Test User' }).click();
+  await page.getByRole('banner').getByRole('button', { name: 'Saved Filter Sets' }).click();
+  await page.getByRole('button', { name: 'Rename LeBron last 10' }).click();
+  await page.getByLabel('New name for LeBron last 10').fill('LeBron recent form');
+  await page.getByRole('button', { name: 'Save name' }).click();
+  await expect(
+    page.getByRole('button', { name: 'Open saved Filter Set LeBron recent form' }),
+  ).toBeVisible();
+
+  await page.getByRole('button', { name: 'Delete LeBron recent form' }).click();
+  await expect(page.getByText('You have not saved any Filter Sets yet')).toBeVisible();
+});
+
+test('signed-out readers are offered no saved Filter Sets', async ({ page }) => {
+  await installApiContract(page);
+  await page.goto('/?player_name=LeBron+James&game_filter=10');
+
+  await expect(page.getByText('Sign in to load these game logs')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Save Filter Set' })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: 'Saved Filter Sets' })).toHaveCount(0);
+});

--- a/src/GameLogFilter.js
+++ b/src/GameLogFilter.js
@@ -12,6 +12,8 @@ import ChartComponent from './ChartComponent';
 import GameLogsTable from './GameLogsTable';
 import NaturalLanguageQuery from './NaturalLanguageQuery';
 import PlayerStatsCards from './PlayerStatsCards';
+import SaveFilterSetModal from './SaveFilterSetModal';
+import SavedFilterSetsModal from './SavedFilterSetsModal';
 import { useAuth } from './contexts/AuthContext';
 import { fetchGameLogsData, getRequestErrorMessage, isRequestCancelled } from './gameLogsApi';
 import {
@@ -62,6 +64,8 @@ const GameLogFilter = () => {
   const [gameLogsError, setGameLogsError] = useState(null);
   const [listsLoading, setListsLoading] = useState(false);
   const [listsError, setListsError] = useState(null);
+  const [showSaveFilterSet, setShowSaveFilterSet] = useState(false);
+  const [showSavedFilterSets, setShowSavedFilterSets] = useState(false);
   const listRequestRef = useRef({ id: 0, controller: null });
   const gameLogsRequestRef = useRef({ id: 0, controller: null });
   const teamsRef = useRef([]);
@@ -452,6 +456,10 @@ const GameLogFilter = () => {
         onQueryUpdate={setCurrentQuery}
         gameLogsLoading={isGameLogsLoading}
         inWorkspace={inWorkspace}
+        // The saved list is reachable from the Query Prompt as well as from the
+        // Workspace, so coming back to a saved Filter Set does not require
+        // building one first.
+        onOpenSavedFilterSets={isAuthenticated ? () => setShowSavedFilterSets(true) : undefined}
       />
 
       {(authLoading || listsLoading) && (
@@ -501,6 +509,29 @@ const GameLogFilter = () => {
               <div className="current-query-display">
                 <span className="query-label">Query:</span>
                 <span className="query-text">"{currentQuery}"</span>
+              </div>
+            )}
+            {isAuthenticated && (
+              <div className="d-flex align-items-center gap-2 ms-auto">
+                {/* There is nothing to save until the URL carries a Filter
+                    Set, and a refused link is one we would not open again —
+                    but the saved list is still the way back out of either. */}
+                {hasUrlFilterSet && !isRefusedLink && (
+                  <button
+                    type="button"
+                    className="btn btn-back-to-search"
+                    onClick={() => setShowSaveFilterSet(true)}
+                  >
+                    Save Filter Set
+                  </button>
+                )}
+                <button
+                  type="button"
+                  className="btn btn-back-to-search"
+                  onClick={() => setShowSavedFilterSets(true)}
+                >
+                  Saved Filter Sets
+                </button>
               </div>
             )}
           </div>
@@ -580,6 +611,24 @@ const GameLogFilter = () => {
             </div>
           </div>
         </Container>
+      )}
+
+      {/* Saving and the saved list belong to an account, so neither exists for
+          a signed-out reader. */}
+      {isAuthenticated && (
+        <>
+          <SaveFilterSetModal
+            show={showSaveFilterSet}
+            onHide={() => setShowSaveFilterSet(false)}
+            // The URL as it stands is what gets saved, so what opens later is
+            // the link the user was looking at.
+            queryString={searchParams.toString()}
+          />
+          <SavedFilterSetsModal
+            show={showSavedFilterSets}
+            onHide={() => setShowSavedFilterSets(false)}
+          />
+        </>
       )}
     </>
   );

--- a/src/GameLogFilter.test.js
+++ b/src/GameLogFilter.test.js
@@ -1,9 +1,10 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, useLocation, useNavigate } from 'react-router-dom';
 import GameLogFilter from './GameLogFilter';
 import { apiClient } from './config';
 import { useAuth } from './contexts/AuthContext';
 import { fetchGameLogsData } from './gameLogsApi';
+import { createSavedFilterSet, fetchSavedFilterSets } from './savedFilterSetsApi';
 
 jest.mock('./config', () => ({
   apiClient: { get: jest.fn() },
@@ -15,14 +16,25 @@ jest.mock('./gameLogsApi', () => ({
   isRequestCancelled: jest.fn(() => false),
 }));
 jest.mock('./contexts/AuthContext', () => ({ useAuth: jest.fn() }));
+jest.mock('./savedFilterSetsApi', () => ({
+  fetchSavedFilterSets: jest.fn(),
+  createSavedFilterSet: jest.fn(),
+  renameSavedFilterSet: jest.fn(),
+  deleteSavedFilterSet: jest.fn(),
+}));
 jest.mock('./NaturalLanguageQuery', () => ({
   __esModule: true,
-  default: ({ inWorkspace, onFiltersApplied }) => (
+  default: ({ inWorkspace, onFiltersApplied, onOpenSavedFilterSets }) => (
     <div data-testid="query-prompt">
       {String(inWorkspace)}
       <button type="button" onClick={() => onFiltersApplied(mockParsedFilters)}>
         Apply parsed query
       </button>
+      {onOpenSavedFilterSets && !inWorkspace && (
+        <button type="button" onClick={onOpenSavedFilterSets}>
+          Saved Filter Sets
+        </button>
+      )}
     </div>
   ),
 }));
@@ -78,6 +90,8 @@ beforeEach(() => {
   useAuth.mockImplementation(() => mockAuthState);
   apiClient.get.mockImplementation(() => new Promise(() => {}));
   fetchGameLogsData.mockImplementation(() => new Promise(() => {}));
+  fetchSavedFilterSets.mockResolvedValue([]);
+  createSavedFilterSet.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -204,4 +218,77 @@ test('keeps a refused link unchanged, refuses a panel apply, and accepts a parse
       '/?player_name=Stephen+Curry&game_filter=10',
     ),
   );
+});
+
+test('saves the Log Workspace URL exactly as it stands', async () => {
+  renderGameLogFilter(['/?player_name=LeBron+James&game_filter=10']);
+
+  await waitFor(() => expect(fetchGameLogsData).toHaveBeenCalled());
+  fireEvent.click(screen.getByRole('button', { name: 'Save Filter Set' }));
+  fireEvent.change(await screen.findByLabelText('Name'), {
+    target: { value: 'LeBron last 10' },
+  });
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+  });
+
+  expect(createSavedFilterSet).toHaveBeenCalledWith({
+    name: 'LeBron last 10',
+    queryString: 'player_name=LeBron+James&game_filter=10',
+  });
+});
+
+test('reaches the saved list from the Query Prompt and from the Log Workspace', async () => {
+  const promptRender = renderGameLogFilter(['/']);
+
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Saved Filter Sets' }));
+  });
+  expect(await screen.findByRole('heading', { name: 'Saved Filter Sets' })).toBeVisible();
+  expect(fetchSavedFilterSets).toHaveBeenCalledTimes(1);
+  promptRender.unmount();
+
+  renderGameLogFilter(['/?player_name=LeBron+James']);
+  await waitFor(() => expect(fetchGameLogsData).toHaveBeenCalled());
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Saved Filter Sets' }));
+  });
+  expect(await screen.findByRole('heading', { name: 'Saved Filter Sets' })).toBeVisible();
+});
+
+test('offers no save affordance and no saved list while signed out', async () => {
+  mockAuthState.isAuthenticated = false;
+  renderGameLogFilter(['/?player_name=LeBron+James&game_filter=10']);
+
+  await waitFor(() => expect(screen.getByText(/Sign in to load these game logs/)).toBeVisible());
+  expect(screen.queryByRole('button', { name: 'Save Filter Set' })).not.toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: 'Saved Filter Sets' })).not.toBeInTheDocument();
+  expect(fetchSavedFilterSets).not.toHaveBeenCalled();
+});
+
+test('a saved link we can no longer honour opens with the existing URL-entry refusal', async () => {
+  fetchSavedFilterSets.mockResolvedValue([
+    { id: 1, name: 'Saved before the rules changed', queryString: 'game_filter=0' },
+  ]);
+  renderGameLogFilter(['/']);
+
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Saved Filter Sets' }));
+  });
+  fireEvent.click(
+    await screen.findByRole('button', {
+      name: 'Open saved Filter Set Saved before the rules changed',
+    }),
+  );
+
+  expect(await screen.findByRole('alert')).toHaveTextContent('game_filter');
+  expect(screen.getByTestId('location')).toHaveTextContent('/?game_filter=0');
+  expect(fetchGameLogsData).not.toHaveBeenCalled();
+});
+
+test('offers nothing to save until the URL carries a Filter Set', async () => {
+  renderGameLogFilter(['/?browse=1']);
+
+  expect(await screen.findByRole('button', { name: 'Saved Filter Sets' })).toBeVisible();
+  expect(screen.queryByRole('button', { name: 'Save Filter Set' })).not.toBeInTheDocument();
 });

--- a/src/ModernSearch.css
+++ b/src/ModernSearch.css
@@ -1133,6 +1133,7 @@
 .prompt-browse {
   display: flex;
   justify-content: center;
+  gap: 20px;
   margin: -12px 0 24px;
 }
 

--- a/src/NaturalLanguageQuery.js
+++ b/src/NaturalLanguageQuery.js
@@ -23,6 +23,9 @@ const NaturalLanguageQuery = ({
   onQueryUpdate,
   gameLogsLoading,
   inWorkspace = false,
+  // Present only for a signed-in reader, because only an account has saved
+  // Filter Sets to come back to.
+  onOpenSavedFilterSets,
 }) => {
   const { isAuthenticated } = useAuth();
   const [query, setQuery] = useState('');
@@ -240,6 +243,16 @@ const NaturalLanguageQuery = ({
             >
               Browse without a query
             </button>
+            {onOpenSavedFilterSets && (
+              <button
+                type="button"
+                className="prompt-browse-button"
+                disabled={isLoading}
+                onClick={onOpenSavedFilterSets}
+              >
+                Saved Filter Sets
+              </button>
+            )}
           </div>
 
           <QueryLadder

--- a/src/SaveFilterSetModal.js
+++ b/src/SaveFilterSetModal.js
@@ -1,0 +1,84 @@
+import { useEffect, useState } from 'react';
+import { Alert, Button, Form, Modal } from 'react-bootstrap';
+import { getRequestErrorMessage } from './gameLogsApi';
+import { createSavedFilterSet } from './savedFilterSetsApi';
+
+/*
+ * Saving stores the Log Workspace's bare query string under a name and nothing
+ * else, so what comes back later is the link the user was looking at rather
+ * than a snapshot of the results it produced.
+ */
+const SaveFilterSetModal = ({ show, onHide, queryString }) => {
+  const [name, setName] = useState('');
+  const [error, setError] = useState(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    if (!show) return;
+    setName('');
+    setError(null);
+  }, [show]);
+
+  // A duplicate name or a full account is the backend's answer, and it is shown
+  // here rather than swallowed, so the save is retryable under a new name.
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setIsSaving(true);
+    setError(null);
+    try {
+      await createSavedFilterSet({ name: name.trim(), queryString });
+      onHide();
+    } catch (saveError) {
+      setError(
+        getRequestErrorMessage(saveError, 'Unable to save this Filter Set. Please try again.'),
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Modal
+      show={show}
+      onHide={onHide}
+      centered
+      contentClassName="dark-card"
+      aria-labelledby="save-filter-set-title"
+    >
+      <Form onSubmit={handleSubmit}>
+        <Modal.Header closeButton closeVariant="white">
+          <Modal.Title as="h2" className="h5 mb-0" id="save-filter-set-title">
+            Save this Filter Set
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          {error && (
+            <Alert variant="danger" role="alert">
+              {error}
+            </Alert>
+          )}
+          <Form.Group controlId="saved-filter-set-name">
+            <Form.Label>Name</Form.Label>
+            <Form.Control
+              autoFocus
+              value={name}
+              maxLength={100}
+              placeholder="LeBron last 10 at home"
+              onChange={(event) => setName(event.target.value)}
+            />
+          </Form.Group>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={onHide} disabled={isSaving}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={isSaving || !name.trim()}>
+            Save
+          </Button>
+        </Modal.Footer>
+      </Form>
+    </Modal>
+  );
+};
+
+export default SaveFilterSetModal;

--- a/src/SaveFilterSetModal.test.js
+++ b/src/SaveFilterSetModal.test.js
@@ -1,0 +1,54 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import SaveFilterSetModal from './SaveFilterSetModal';
+import { createSavedFilterSet } from './savedFilterSetsApi';
+
+jest.mock('./savedFilterSetsApi', () => ({ createSavedFilterSet: jest.fn() }));
+
+const queryString = 'player_name=LeBron+James&game_filter=10';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('saves the current Filter Set query string under the typed name', async () => {
+  createSavedFilterSet.mockResolvedValue(undefined);
+  const onHide = jest.fn();
+  render(<SaveFilterSetModal show onHide={onHide} queryString={queryString} />);
+
+  fireEvent.change(screen.getByLabelText('Name'), { target: { value: '  LeBron last 10  ' } });
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+  });
+
+  expect(createSavedFilterSet).toHaveBeenCalledWith({
+    name: 'LeBron last 10',
+    queryString,
+  });
+  expect(onHide).toHaveBeenCalled();
+});
+
+test('cannot save without a name', () => {
+  render(<SaveFilterSetModal show onHide={jest.fn()} queryString={queryString} />);
+
+  expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+  expect(createSavedFilterSet).not.toHaveBeenCalled();
+});
+
+test('surfaces the backend conflict message and stays open', async () => {
+  createSavedFilterSet.mockRejectedValue({
+    response: {
+      status: 409,
+      data: { error: { code: 'limit_reached', message: 'You have reached the limit of 100.' } },
+    },
+  });
+  const onHide = jest.fn();
+  render(<SaveFilterSetModal show onHide={onHide} queryString={queryString} />);
+
+  fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'One too many' } });
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+  });
+
+  expect(screen.getByRole('alert')).toHaveTextContent('You have reached the limit of 100.');
+  expect(onHide).not.toHaveBeenCalled();
+});

--- a/src/SavedFilterSetsModal.js
+++ b/src/SavedFilterSetsModal.js
@@ -1,0 +1,188 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Alert, Button, Form, ListGroup, Modal, Spinner } from 'react-bootstrap';
+import { useNavigate } from 'react-router-dom';
+import { getRequestErrorMessage } from './gameLogsApi';
+import {
+  deleteSavedFilterSet,
+  fetchSavedFilterSets,
+  renameSavedFilterSet,
+} from './savedFilterSetsApi';
+
+/*
+ * The saved list is the same list wherever it is opened from: the Query Prompt,
+ * the Log Workspace, or the account menu. Opening an item navigates to its
+ * query string and stops there — the effect watching the URL is what applies
+ * the Filter Set, so a saved link and a pasted link travel the same path, down
+ * to the error a link we can no longer honour produces.
+ */
+const SavedFilterSetsModal = ({ show, onHide }) => {
+  const navigate = useNavigate();
+  const [savedFilterSets, setSavedFilterSets] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [renamingId, setRenamingId] = useState(null);
+  const [draftName, setDraftName] = useState('');
+  const [isMutating, setIsMutating] = useState(false);
+
+  const loadSavedFilterSets = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      setSavedFilterSets(await fetchSavedFilterSets());
+    } catch (loadError) {
+      setError(
+        getRequestErrorMessage(
+          loadError,
+          'Unable to load your saved Filter Sets. Please try again.',
+        ),
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!show) return;
+    setRenamingId(null);
+    loadSavedFilterSets();
+  }, [show, loadSavedFilterSets]);
+
+  // A rejected mutation leaves the list exactly as it was and says why, so a
+  // duplicate name or a full account is a message rather than a lost item.
+  const runMutation = async (mutate, fallbackMessage) => {
+    setIsMutating(true);
+    setError(null);
+    try {
+      await mutate();
+      setRenamingId(null);
+      await loadSavedFilterSets();
+    } catch (mutationError) {
+      setError(getRequestErrorMessage(mutationError, fallbackMessage));
+    } finally {
+      setIsMutating(false);
+    }
+  };
+
+  const handleOpen = (savedFilterSet) => {
+    navigate(`/?${savedFilterSet.queryString}`);
+    onHide();
+  };
+
+  const startRename = (savedFilterSet) => {
+    setRenamingId(savedFilterSet.id);
+    setDraftName(savedFilterSet.name);
+  };
+
+  return (
+    <Modal
+      show={show}
+      onHide={onHide}
+      centered
+      contentClassName="dark-card"
+      aria-labelledby="saved-filter-sets-title"
+    >
+      <Modal.Header closeButton closeVariant="white">
+        <Modal.Title as="h2" className="h5 mb-0" id="saved-filter-sets-title">
+          Saved Filter Sets
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {error && (
+          <Alert variant="danger" role="alert">
+            {error}
+          </Alert>
+        )}
+        {isLoading && (
+          <div className="text-center py-2" role="status" aria-live="polite">
+            <Spinner animation="border" size="sm" className="me-2" />
+            Loading saved Filter Sets…
+          </div>
+        )}
+        {!isLoading && savedFilterSets.length === 0 && !error && (
+          <p className="mb-0">
+            You have not saved any Filter Sets yet. Save one from the Log Workspace to come back to
+            it later.
+          </p>
+        )}
+        {savedFilterSets.length > 0 && (
+          <ListGroup variant="flush">
+            {savedFilterSets.map((savedFilterSet) => (
+              <ListGroup.Item
+                key={savedFilterSet.id}
+                className="bg-transparent text-white px-0 border-secondary"
+              >
+                <div className="d-flex align-items-center justify-content-between gap-2">
+                  <Button
+                    variant="link"
+                    className="p-0 text-start text-decoration-none flex-grow-1"
+                    aria-label={`Open saved Filter Set ${savedFilterSet.name}`}
+                    onClick={() => handleOpen(savedFilterSet)}
+                  >
+                    {savedFilterSet.name}
+                  </Button>
+                  <Button
+                    variant="outline-primary"
+                    size="sm"
+                    aria-label={`Rename ${savedFilterSet.name}`}
+                    disabled={isMutating}
+                    onClick={() => startRename(savedFilterSet)}
+                  >
+                    Rename
+                  </Button>
+                  <Button
+                    variant="outline-danger"
+                    size="sm"
+                    aria-label={`Delete ${savedFilterSet.name}`}
+                    disabled={isMutating}
+                    onClick={() =>
+                      runMutation(
+                        () => deleteSavedFilterSet({ id: savedFilterSet.id }),
+                        'Unable to delete this saved Filter Set. Please try again.',
+                      )
+                    }
+                  >
+                    Delete
+                  </Button>
+                </div>
+                {renamingId === savedFilterSet.id && (
+                  <Form
+                    className="d-flex align-items-center gap-2 mt-2"
+                    onSubmit={(event) => {
+                      event.preventDefault();
+                      runMutation(
+                        () =>
+                          renameSavedFilterSet({ id: savedFilterSet.id, name: draftName.trim() }),
+                        'Unable to rename this saved Filter Set. Please try again.',
+                      );
+                    }}
+                  >
+                    <Form.Control
+                      size="sm"
+                      value={draftName}
+                      maxLength={100}
+                      aria-label={`New name for ${savedFilterSet.name}`}
+                      onChange={(event) => setDraftName(event.target.value)}
+                    />
+                    <Button type="submit" size="sm" disabled={isMutating || !draftName.trim()}>
+                      Save name
+                    </Button>
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      disabled={isMutating}
+                      onClick={() => setRenamingId(null)}
+                    >
+                      Cancel
+                    </Button>
+                  </Form>
+                )}
+              </ListGroup.Item>
+            ))}
+          </ListGroup>
+        )}
+      </Modal.Body>
+    </Modal>
+  );
+};
+
+export default SavedFilterSetsModal;

--- a/src/SavedFilterSetsModal.test.js
+++ b/src/SavedFilterSetsModal.test.js
@@ -1,0 +1,161 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import SavedFilterSetsModal from './SavedFilterSetsModal';
+import {
+  deleteSavedFilterSet,
+  fetchSavedFilterSets,
+  renameSavedFilterSet,
+} from './savedFilterSetsApi';
+
+jest.mock('./savedFilterSetsApi', () => ({
+  fetchSavedFilterSets: jest.fn(),
+  renameSavedFilterSet: jest.fn(),
+  deleteSavedFilterSet: jest.fn(),
+}));
+
+const savedFilterSets = [
+  { id: 2, name: 'Curry at home', queryString: 'player_name=Stephen+Curry&home_away=home' },
+  { id: 1, name: 'LeBron last 10', queryString: 'player_name=LeBron+James&game_filter=10' },
+];
+
+const LocationProbe = () => {
+  const location = useLocation();
+  return (
+    <output data-testid="location">
+      {location.pathname}
+      {location.search}
+    </output>
+  );
+};
+
+const renderModal = (onHide = jest.fn()) => {
+  render(
+    <MemoryRouter initialEntries={['/matchups']}>
+      <SavedFilterSetsModal show onHide={onHide} />
+      <LocationProbe />
+    </MemoryRouter>,
+  );
+  return onHide;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  fetchSavedFilterSets.mockResolvedValue(savedFilterSets);
+});
+
+test('lists saved Filter Sets in the order the backend returned them', async () => {
+  renderModal();
+
+  const names = await screen.findAllByRole('button', { name: /Open saved Filter Set/ });
+  expect(names.map((button) => button.textContent)).toEqual(['Curry at home', 'LeBron last 10']);
+});
+
+test('opening a saved Filter Set navigates to its query string and closes the list', async () => {
+  const onHide = renderModal();
+
+  fireEvent.click(
+    await screen.findByRole('button', { name: 'Open saved Filter Set Curry at home' }),
+  );
+
+  await waitFor(() =>
+    expect(screen.getByTestId('location')).toHaveTextContent(
+      '/?player_name=Stephen+Curry&home_away=home',
+    ),
+  );
+  expect(onHide).toHaveBeenCalled();
+});
+
+test('renames an item and reloads the list', async () => {
+  renameSavedFilterSet.mockResolvedValue(undefined);
+  // The list is reloaded rather than patched in place, so the order shown is
+  // always the backend's.
+  fetchSavedFilterSets
+    .mockResolvedValueOnce(savedFilterSets)
+    .mockResolvedValueOnce([
+      { ...savedFilterSets[0], name: 'Curry home splits' },
+      savedFilterSets[1],
+    ]);
+  renderModal();
+
+  fireEvent.click(await screen.findByRole('button', { name: 'Rename Curry at home' }));
+  fireEvent.change(screen.getByLabelText('New name for Curry at home'), {
+    target: { value: 'Curry home splits' },
+  });
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Save name' }));
+  });
+
+  expect(renameSavedFilterSet).toHaveBeenCalledWith({ id: 2, name: 'Curry home splits' });
+  expect(fetchSavedFilterSets).toHaveBeenCalledTimes(2);
+  expect(
+    screen.getByRole('button', { name: 'Open saved Filter Set Curry home splits' }),
+  ).toBeVisible();
+});
+
+test('surfaces a duplicate-name conflict and keeps the item in the list', async () => {
+  renameSavedFilterSet.mockRejectedValue({
+    response: {
+      status: 409,
+      data: {
+        error: { code: 'duplicate_name', message: 'You already have a saved set by that name.' },
+      },
+    },
+  });
+  renderModal();
+
+  fireEvent.click(await screen.findByRole('button', { name: 'Rename Curry at home' }));
+  fireEvent.change(screen.getByLabelText('New name for Curry at home'), {
+    target: { value: 'LeBron last 10' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: 'Save name' }));
+
+  expect(await screen.findByRole('alert')).toHaveTextContent(
+    'You already have a saved set by that name.',
+  );
+  expect(screen.getByRole('button', { name: 'Open saved Filter Set Curry at home' })).toBeVisible();
+});
+
+test('deletes an item and reloads the list', async () => {
+  deleteSavedFilterSet.mockResolvedValue(undefined);
+  fetchSavedFilterSets
+    .mockResolvedValueOnce(savedFilterSets)
+    .mockResolvedValueOnce([savedFilterSets[1]]);
+  renderModal();
+
+  const deleteButton = await screen.findByRole('button', { name: 'Delete Curry at home' });
+  await act(async () => {
+    fireEvent.click(deleteButton);
+  });
+
+  expect(deleteSavedFilterSet).toHaveBeenCalledWith({ id: 2 });
+  expect(
+    screen.queryByRole('button', { name: 'Open saved Filter Set Curry at home' }),
+  ).not.toBeInTheDocument();
+});
+
+test('reports a failed load and says when nothing is saved yet', async () => {
+  fetchSavedFilterSets.mockRejectedValueOnce({
+    response: { data: { error: { message: 'Saved filter sets are unavailable.' } } },
+  });
+  const { rerender } = render(
+    <MemoryRouter>
+      <SavedFilterSetsModal show onHide={jest.fn()} />
+    </MemoryRouter>,
+  );
+
+  expect(await screen.findByRole('alert')).toHaveTextContent('Saved filter sets are unavailable.');
+
+  fetchSavedFilterSets.mockResolvedValue([]);
+  rerender(
+    <MemoryRouter>
+      <SavedFilterSetsModal show={false} onHide={jest.fn()} />
+    </MemoryRouter>,
+  );
+  rerender(
+    <MemoryRouter>
+      <SavedFilterSetsModal show onHide={jest.fn()} />
+    </MemoryRouter>,
+  );
+
+  expect(await screen.findByText(/have not saved any Filter Sets yet/i)).toBeVisible();
+});

--- a/src/components/Auth/UserProfile.js
+++ b/src/components/Auth/UserProfile.js
@@ -1,11 +1,13 @@
 import { useState } from 'react';
 import { Dropdown } from 'react-bootstrap';
-import { ChevronDown, LogOut } from 'lucide-react';
+import { Bookmark, ChevronDown, LogOut } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
+import SavedFilterSetsModal from '../../SavedFilterSetsModal';
 
 const UserProfile = () => {
   const { currentUser, logout } = useAuth();
   const [isLoggingOut, setIsLoggingOut] = useState(false);
+  const [showSavedFilterSets, setShowSavedFilterSets] = useState(false);
 
   if (!currentUser) {
     return null;
@@ -48,56 +50,70 @@ const UserProfile = () => {
   const displayName = currentUser.displayName || currentUser.email?.split('@')[0] || 'User';
 
   return (
-    <Dropdown align="end">
-      <Dropdown.Toggle
-        variant="outline-light"
-        id="user-dropdown"
-        className="d-flex align-items-center gap-2 border-0 bg-transparent p-0"
-        style={{ boxShadow: 'none' }}
-        bsPrefix="custom-dropdown-toggle"
-      >
-        <div
-          className="d-flex align-items-center justify-content-center rounded-circle"
-          style={{
-            width: 36,
-            height: 36,
-            background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-            color: 'white',
-            fontSize: '14px',
-            fontWeight: '600',
-            border: '2px solid rgba(255, 255, 255, 0.4)',
-            flexShrink: 0,
-            boxShadow: '0 2px 8px rgba(102, 126, 234, 0.3)',
-          }}
+    <>
+      <Dropdown align="end">
+        <Dropdown.Toggle
+          variant="outline-light"
+          id="user-dropdown"
+          className="d-flex align-items-center gap-2 border-0 bg-transparent p-0"
+          style={{ boxShadow: 'none' }}
+          bsPrefix="custom-dropdown-toggle"
         >
-          {initials}
-        </div>
+          <div
+            className="d-flex align-items-center justify-content-center rounded-circle"
+            style={{
+              width: 36,
+              height: 36,
+              background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+              color: 'white',
+              fontSize: '14px',
+              fontWeight: '600',
+              border: '2px solid rgba(255, 255, 255, 0.4)',
+              flexShrink: 0,
+              boxShadow: '0 2px 8px rgba(102, 126, 234, 0.3)',
+            }}
+          >
+            {initials}
+          </div>
 
-        <span
-          style={{
-            color: 'white',
-            fontSize: '14px',
-            fontWeight: '500',
-            whiteSpace: 'nowrap',
-          }}
-        >
-          {displayName}
-        </span>
+          <span
+            style={{
+              color: 'white',
+              fontSize: '14px',
+              fontWeight: '500',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {displayName}
+          </span>
 
-        <ChevronDown size={12} color="white" style={{ opacity: 0.7 }} />
-      </Dropdown.Toggle>
+          <ChevronDown size={12} color="white" style={{ opacity: 0.7 }} />
+        </Dropdown.Toggle>
 
-      <Dropdown.Menu className="mt-2">
-        <Dropdown.Item
-          onClick={handleLogout}
-          disabled={isLoggingOut}
-          className="d-flex align-items-center gap-2"
-        >
-          <LogOut size={16} />
-          {isLoggingOut ? 'Signing out...' : 'Sign out'}
-        </Dropdown.Item>
-      </Dropdown.Menu>
-    </Dropdown>
+        <Dropdown.Menu className="mt-2">
+          <Dropdown.Item
+            onClick={() => setShowSavedFilterSets(true)}
+            className="d-flex align-items-center gap-2"
+          >
+            <Bookmark size={16} />
+            Saved Filter Sets
+          </Dropdown.Item>
+          <Dropdown.Item
+            onClick={handleLogout}
+            disabled={isLoggingOut}
+            className="d-flex align-items-center gap-2"
+          >
+            <LogOut size={16} />
+            {isLoggingOut ? 'Signing out...' : 'Sign out'}
+          </Dropdown.Item>
+        </Dropdown.Menu>
+      </Dropdown>
+
+      <SavedFilterSetsModal
+        show={showSavedFilterSets}
+        onHide={() => setShowSavedFilterSets(false)}
+      />
+    </>
   );
 };
 

--- a/src/components/Auth/UserProfile.test.js
+++ b/src/components/Auth/UserProfile.test.js
@@ -1,0 +1,49 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import UserProfile from './UserProfile';
+import { useAuth } from '../../contexts/AuthContext';
+import { fetchSavedFilterSets } from '../../savedFilterSetsApi';
+
+jest.mock('../../contexts/AuthContext', () => ({ useAuth: jest.fn() }));
+jest.mock('../../savedFilterSetsApi', () => ({
+  fetchSavedFilterSets: jest.fn(),
+  renameSavedFilterSet: jest.fn(),
+  deleteSavedFilterSet: jest.fn(),
+}));
+
+const renderUserProfile = () =>
+  render(
+    <MemoryRouter>
+      <UserProfile />
+    </MemoryRouter>,
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  fetchSavedFilterSets.mockResolvedValue([]);
+  useAuth.mockReturnValue({
+    currentUser: { displayName: 'Chris Fu', email: 'chris@example.com' },
+    logout: jest.fn(),
+  });
+});
+
+test('opens the saved list from the account menu', async () => {
+  renderUserProfile();
+
+  fireEvent.click(screen.getByRole('button', { name: /Chris Fu/ }));
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Saved Filter Sets' }));
+  });
+
+  expect(await screen.findByRole('heading', { name: 'Saved Filter Sets' })).toBeVisible();
+  expect(fetchSavedFilterSets).toHaveBeenCalledTimes(1);
+});
+
+test('shows nothing at all while signed out', () => {
+  useAuth.mockReturnValue({ currentUser: null, logout: jest.fn() });
+
+  const { container } = renderUserProfile();
+
+  expect(container).toBeEmptyDOMElement();
+  expect(fetchSavedFilterSets).not.toHaveBeenCalled();
+});

--- a/src/config.js
+++ b/src/config.js
@@ -20,6 +20,7 @@ const config = {
     PLAYER_PROFILE: '/api/players/profile',
     TEAM_STATS: '/api/teams/stats',
     NL_QUERY: '/api/nl-query',
+    SAVED_FILTER_SETS: '/api/user/saved-filter-sets',
   },
 
   // Application settings

--- a/src/savedFilterSetsApi.js
+++ b/src/savedFilterSetsApi.js
@@ -1,0 +1,47 @@
+import { apiClient, getApiUrl } from './config';
+
+const createInvalidResponseError = () =>
+  new Error('The saved filter sets API returned an invalid response.');
+
+/*
+ * A Saved Filter Set is a name and the bare query string of a Log Workspace
+ * URL. Timestamps order the list on the backend, which is why nothing here
+ * carries them: the list arrives newest-first and is shown in that order.
+ */
+const decodeSavedFilterSet = (item) => {
+  if (!item || typeof item !== 'object') throw createInvalidResponseError();
+  const { id, name, query_string: queryString } = item;
+  const hasId = typeof id === 'string' || typeof id === 'number';
+  if (!hasId || typeof name !== 'string' || typeof queryString !== 'string') {
+    throw createInvalidResponseError();
+  }
+  return { id, name, queryString };
+};
+
+export const decodeSavedFilterSets = (payload = {}) => {
+  if (!payload || !Array.isArray(payload.saved_filter_sets)) throw createInvalidResponseError();
+  return payload.saved_filter_sets.map(decodeSavedFilterSet);
+};
+
+const savedFilterSetsUrl = (path = '') => `${getApiUrl('SAVED_FILTER_SETS')}${path}`;
+
+export const fetchSavedFilterSets = async ({ signal } = {}) => {
+  const response = await apiClient.get(savedFilterSetsUrl(), { signal });
+  return decodeSavedFilterSets(response.data);
+};
+
+/*
+ * The mutations report success or throw; the caller reloads the list rather
+ * than patching one in place, so the order shown is always the backend's.
+ */
+export const createSavedFilterSet = async ({ name, queryString }) => {
+  await apiClient.post(savedFilterSetsUrl(), { name, query_string: queryString });
+};
+
+export const renameSavedFilterSet = async ({ id, name }) => {
+  await apiClient.patch(savedFilterSetsUrl(`/${encodeURIComponent(id)}`), { name });
+};
+
+export const deleteSavedFilterSet = async ({ id }) => {
+  await apiClient.delete(savedFilterSetsUrl(`/${encodeURIComponent(id)}`));
+};

--- a/src/savedFilterSetsApi.test.js
+++ b/src/savedFilterSetsApi.test.js
@@ -1,0 +1,85 @@
+import { apiClient } from './config';
+import {
+  createSavedFilterSet,
+  decodeSavedFilterSets,
+  deleteSavedFilterSet,
+  fetchSavedFilterSets,
+  renameSavedFilterSet,
+} from './savedFilterSetsApi';
+
+jest.mock('./config', () => ({
+  apiClient: { get: jest.fn(), post: jest.fn(), patch: jest.fn(), delete: jest.fn() },
+  getApiUrl: (name) => `/api/${name.toLowerCase()}`,
+}));
+
+describe('savedFilterSetsApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('decodes the list to what the UI needs, keeping the backend order', () => {
+    expect(
+      decodeSavedFilterSets({
+        success: true,
+        saved_filter_sets: [
+          {
+            id: 2,
+            name: 'Newest',
+            query_string: 'player_name=LeBron+James',
+            created_at: '2026-01-02T00:00:00Z',
+            updated_at: '2026-01-02T00:00:00Z',
+          },
+          {
+            id: 1,
+            name: 'Oldest',
+            query_string: 'player_name=Stephen+Curry',
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+          },
+        ],
+      }),
+    ).toEqual([
+      { id: 2, name: 'Newest', queryString: 'player_name=LeBron+James' },
+      { id: 1, name: 'Oldest', queryString: 'player_name=Stephen+Curry' },
+    ]);
+  });
+
+  test('refuses a response that is not the documented list', () => {
+    expect(() => decodeSavedFilterSets({ success: true })).toThrow(/invalid response/i);
+    expect(() =>
+      decodeSavedFilterSets({ saved_filter_sets: [{ id: 1, name: 'No query' }] }),
+    ).toThrow(/invalid response/i);
+  });
+
+  test('fetches the list from the documented path', async () => {
+    apiClient.get.mockResolvedValue({ data: { success: true, saved_filter_sets: [] } });
+    const controller = new AbortController();
+
+    await expect(fetchSavedFilterSets({ signal: controller.signal })).resolves.toEqual([]);
+    expect(apiClient.get).toHaveBeenCalledWith('/api/saved_filter_sets', {
+      signal: controller.signal,
+    });
+  });
+
+  test('creates with the bare query string under the documented field names', async () => {
+    apiClient.post.mockResolvedValue({ data: {} });
+
+    await createSavedFilterSet({ name: 'Curry threes', queryString: 'player_name=Stephen+Curry' });
+
+    expect(apiClient.post).toHaveBeenCalledWith('/api/saved_filter_sets', {
+      name: 'Curry threes',
+      query_string: 'player_name=Stephen+Curry',
+    });
+  });
+
+  test('renames and deletes by id', async () => {
+    apiClient.patch.mockResolvedValue({ data: {} });
+    apiClient.delete.mockResolvedValue({ data: {} });
+
+    await renameSavedFilterSet({ id: 7, name: 'Renamed' });
+    await deleteSavedFilterSet({ id: 7 });
+
+    expect(apiClient.patch).toHaveBeenCalledWith('/api/saved_filter_sets/7', { name: 'Renamed' });
+    expect(apiClient.delete).toHaveBeenCalledWith('/api/saved_filter_sets/7');
+  });
+});


### PR DESCRIPTION
Closes #56
Part of crf04/statsplus#34
Merge after: crf04/statsplus-backend#194

## What

- New `savedFilterSetsApi` module (gameLogsApi pattern) for `/api/user/saved-filter-sets`.
- "Save Filter Set" button in the Log Workspace (signed-in only, hidden when the URL carries no Filter Set) storing `searchParams.toString()` under a name.
- Saved Filter Sets list modal reachable from the Query Prompt, the Workspace, and a new account-dropdown entry; items open via `/?<query_string>` so the existing URL effect applies them (ADR 0001 intact — stale links ride the existing URL-entry error), with rename and delete in place.
- 409 messages (duplicate name, 100-item cap) surfaced in place; signed-out users see none of it.
- E2E fixture models the real contract (enveloped 201/200 mutation responses, validated PATCH, `updated_at` bump) with the error branches exercised.

## Verification

- Full gate green: `npm run lint`, `npm run format:check`, `npm run test:ci` (337 tests), `npm run build`, `npm run test:e2e` (79 passed, 2 deployment-only skips).
- Reviewed on two axes (standards + spec) with all findings fixed or explicitly accepted.
- Integrated browser verification against the real backend branch running locally: save, list, rename (case-insensitive duplicate → 409 shown in modal), open (exact URL round-trip), delete, all three entry points, and signed-out invisibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)