### PR TITLE
Fix missing slate team name fallback

### DIFF
--- a/e2e/fixtures/courtai.js
+++ b/e2e/fixtures/courtai.js
@@ -77,6 +77,12 @@ export const slateGame = {
   preseason: false,
 };
 
+export const slateGameWithMissingNameSentinels = {
+  ...slateGame,
+  away_team: { ...slateGame.away_team, name: 'None' },
+  home_team: { ...slateGame.home_team, name: 'None' },
+};
+
 const scheduleOnlySlateGame = {
   ...slateGame,
   away_team: { ...slateGame.away_team, targetable_player_count: 0 },

--- a/e2e/specs/slate.spec.js
+++ b/e2e/specs/slate.spec.js
@@ -1,4 +1,11 @@
-import { expect, installApiContract, slateGame, slatePayload, test } from '../fixtures/courtai';
+import {
+  expect,
+  installApiContract,
+  slateGame,
+  slateGameWithMissingNameSentinels,
+  slatePayload,
+  test,
+} from '../fixtures/courtai';
 
 test('@critical authenticated user opens a slate and navigates dates', async ({
   authenticatedPage: page,
@@ -104,6 +111,19 @@ test('@critical authenticated user opens a slate and navigates dates', async ({
   await expect(page).toHaveURL(/\/matchups$/);
   await expect(page.getByRole('heading', { name: 'Thursday, January 15, 2026' })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Today' })).toBeDisabled();
+});
+
+test('falls back to team tricodes when slate team names are unavailable', async ({
+  authenticatedPage: page,
+}) => {
+  await installApiContract(page, {
+    '/api/games/slate': slatePayload('2025-12-25', [slateGameWithMissingNameSentinels]),
+  });
+
+  await page.goto('/matchups?date=2025-12-25');
+
+  const row = page.getByRole('link', { name: /^LAL @ BOS,/ });
+  await expect(row.getByText('LAL at BOS')).toBeVisible();
 });
 
 test('signed-out matchups keeps the shared shell and does not redirect', async ({

--- a/src/slateApi.js
+++ b/src/slateApi.js
@@ -8,6 +8,7 @@ import {
 } from './slateStatus';
 
 const createInvalidSlateError = () => new Error('The slate endpoint returned an invalid response.');
+const MISSING_TEAM_NAME_SENTINEL = 'None';
 const isRecord = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
 
 const decodeRetrievedAt = (value) => {
@@ -94,7 +95,7 @@ const decodeTeam = (team) => {
   return {
     teamId: team.team_id,
     tricode: team.tricode,
-    name: team.name,
+    name: team.name === MISSING_TEAM_NAME_SENTINEL ? team.tricode : team.name,
     targetablePlayerCount: team.targetable_player_count,
   };
 };


### PR DESCRIPTION
## Summary

- normalize the slate API's `None` team-name sentinel to the team tricode
- add a production-shaped browser fixture for missing team names
- cover the rendered Matchups fallback with a Playwright regression

## Verification

- `npm run lint`
- `npm run format:check`
- `npm run test:ci` — 305 passed
- `npm run build`
- `npm run test:e2e` — 77 passed, 2 production-only checks skipped by design

The regression was independently mutation-tested by restoring the raw sentinel: it failed on `None at None`, then passed again after restoring the decoder normalization.
