### PR TITLE
Describe shared player links in the tab and link previews

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,20 @@
     />
     <meta name="theme-color" content="#0d0b07" />
     <title>CourtAI | NBA Game Log Analytics</title>
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="CourtAI" />
+    <meta property="og:title" content="CourtAI | NBA Game Log Analytics" />
+    <meta
+      property="og:description"
+      content="CourtAI helps explore NBA player game logs with advanced filters, natural language search, and performance analytics."
+    />
+    <meta property="og:image" content="https://courtai.app/logo512.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="CourtAI | NBA Game Log Analytics" />
+    <meta
+      name="twitter:description"
+      content="CourtAI helps explore NBA player game logs with advanced filters, natural language search, and performance analytics."
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/middleware.js
+++ b/middleware.js
@@ -1,0 +1,24 @@
+import { applyLinkPreview, linkPreviewFor } from './src/linkPreview';
+
+// Vercel serves the same static index.html for every route, and link
+// unfurlers (iMessage, Slack, Discord, X) read only that HTML — they never run
+// the app. So a shared Workspace link is described here, at the edge, before
+// the document reaches whoever is previewing it.
+export const config = { matcher: '/' };
+
+export default async function middleware(request) {
+  const url = new URL(request.url);
+  const preview = linkPreviewFor(url.searchParams);
+  if (preview === null) return undefined;
+
+  const response = await fetch(new URL('/index.html', url.origin), {
+    headers: { cookie: request.headers.get('cookie') ?? '' },
+  });
+  if (!response.ok) return undefined;
+
+  const html = applyLinkPreview(await response.text(), preview);
+  const headers = new Headers(response.headers);
+  headers.delete('content-length');
+  headers.set('content-type', 'text/html; charset=utf-8');
+  return new Response(html, { status: 200, headers });
+}

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:debug": "playwright test --debug",
     "lint": "eslint .",
-    "format:check": "prettier --check package.json vercel.json README.md index.html src e2e docs playwright.config.mjs vite.config.mjs babel.config.cjs eslint.config.mjs postcss.config.js tailwind.config.js .github/workflows .prettierrc.json",
-    "format": "prettier --write package.json vercel.json README.md index.html src e2e docs playwright.config.mjs vite.config.mjs babel.config.cjs eslint.config.mjs postcss.config.js tailwind.config.js .github/workflows .prettierrc.json"
+    "format:check": "prettier --check package.json vercel.json README.md index.html middleware.js src e2e docs playwright.config.mjs vite.config.mjs babel.config.cjs eslint.config.mjs postcss.config.js tailwind.config.js .github/workflows .prettierrc.json",
+    "format": "prettier --write package.json vercel.json README.md index.html middleware.js src e2e docs playwright.config.mjs vite.config.mjs babel.config.cjs eslint.config.mjs postcss.config.js tailwind.config.js .github/workflows .prettierrc.json"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/src/GameLogFilter.js
+++ b/src/GameLogFilter.js
@@ -22,6 +22,8 @@ import {
   filterSetToSearchParams,
   mergeFilterSet,
 } from './filterUtils';
+import { linkPreviewFor } from './linkPreview';
+import useDocumentTitle from './useDocumentTitle';
 
 const listNames = (names) =>
   names.length === 1 ? names[0] : `${names.slice(0, -1).join(', ')} and ${names.at(-1)}`;
@@ -45,6 +47,8 @@ const GameLogFilter = () => {
   // back out of the URL rather than held beside it. One source of truth is what
   // keeps the applied-filter badges describing the data actually on screen.
   const selectedPlayer = urlFilters.player_name || 'None';
+  // The tab and any link preview say the same thing about the same URL.
+  useDocumentTitle(linkPreviewFor(searchParams)?.title);
   const [selectedTeam, setSelectedTeam] = useState('');
   const [lineType, setLineType] = useState('PTS');
   const [lineValue, setLineValue] = useState('');

--- a/src/GameLogFilter.test.js
+++ b/src/GameLogFilter.test.js
@@ -292,3 +292,22 @@ test('offers nothing to save until the URL carries a Filter Set', async () => {
   expect(await screen.findByRole('button', { name: 'Saved Filter Sets' })).toBeVisible();
   expect(screen.queryByRole('button', { name: 'Save Filter Set' })).not.toBeInTheDocument();
 });
+
+test('names the tab after the player the URL shows, and hands the default back', async () => {
+  const { unmount } = renderGameLogFilter(['/?player_name=LeBron+James&game_filter=10']);
+
+  await waitFor(() => expect(document.title).toBe('LeBron James Game Logs | CourtAI'));
+
+  fireEvent.click(screen.getByRole('button', { name: 'Apply parsed query' }));
+  await waitFor(() => expect(document.title).toBe('Stephen Curry Game Logs | CourtAI'));
+
+  unmount();
+  expect(document.title).toBe('CourtAI | NBA Game Log Analytics');
+});
+
+test('does not name a tab after a link it refuses', async () => {
+  renderGameLogFilter(['/?player_name=LeBron+James&game_filter=0']);
+
+  expect(await screen.findByRole('alert')).toHaveTextContent('game_filter');
+  expect(document.title).toBe('CourtAI | NBA Game Log Analytics');
+});

--- a/src/linkPreview.js
+++ b/src/linkPreview.js
@@ -1,0 +1,69 @@
+import { filterSetFromSearchParams } from './filterUtils';
+
+export const SITE_NAME = 'CourtAI';
+export const DEFAULT_TITLE = 'CourtAI | NBA Game Log Analytics';
+export const DEFAULT_DESCRIPTION =
+  'CourtAI helps explore NBA player game logs with advanced filters, natural language search, and performance analytics.';
+
+const listNames = (names) =>
+  names.length === 1 ? names[0] : `${names.slice(0, -1).join(', ')} and ${names.at(-1)}`;
+
+const describeFilters = (filters) => {
+  const parts = [];
+  if (filters.season_filter) parts.push(`${filters.season_filter} season`);
+  if (filters.game_filter) parts.push(`last ${filters.game_filter} games`);
+  if (filters.location_filter && filters.location_filter !== 'Both') {
+    parts.push(`${filters.location_filter.toLowerCase()} games`);
+  }
+  if (filters['teams_against[]']?.length) parts.push(`vs ${listNames(filters['teams_against[]'])}`);
+  if (filters.minutes_filter) {
+    const [low, high] = filters.minutes_filter.split(',');
+    parts.push(`${low}-${high} minutes`);
+  }
+  if (filters.date_filter) parts.push(`since ${filters.date_filter}`);
+  if (filters['players_on[]']?.length) parts.push(`with ${listNames(filters['players_on[]'])}`);
+  if (filters['players_off[]']?.length)
+    parts.push(`without ${listNames(filters['players_off[]'])}`);
+  return parts;
+};
+
+/**
+ * Describe a shared Workspace link for the browser tab and for link unfurlers.
+ *
+ * Returns null when the URL names no player, including when it is a link we
+ * refuse: a refused link shows a refusal, so its preview must not promise the
+ * logs it will not show.
+ */
+export const linkPreviewFor = (searchParams) => {
+  const { filters } = filterSetFromSearchParams(searchParams);
+  if (!filters.player_name) return null;
+  const details = describeFilters(filters);
+  const title = `${filters.player_name} Game Logs | ${SITE_NAME}`;
+  const summary = details.length > 0 ? details.join(', ') : 'every logged game';
+  const description = `${filters.player_name} NBA game logs: ${summary}. Explore on ${SITE_NAME}.`;
+  return { title, description };
+};
+
+const escapeHtml = (value) =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+
+const replaceContent = (html, attribute, name, value) =>
+  html.replace(
+    new RegExp(`(<meta\\s+${attribute}="${name}"\\s+content=")[^"]*(")`),
+    `$1${escapeHtml(value)}$2`,
+  );
+
+/** Rewrite the static document head so a fetch of the link describes its logs. */
+export const applyLinkPreview = (html, preview) => {
+  let next = html.replace(/<title>[^<]*<\/title>/, `<title>${escapeHtml(preview.title)}</title>`);
+  next = replaceContent(next, 'name', 'description', preview.description);
+  next = replaceContent(next, 'property', 'og:title', preview.title);
+  next = replaceContent(next, 'property', 'og:description', preview.description);
+  next = replaceContent(next, 'name', 'twitter:title', preview.title);
+  next = replaceContent(next, 'name', 'twitter:description', preview.description);
+  return next;
+};

--- a/src/linkPreview.js
+++ b/src/linkPreview.js
@@ -40,7 +40,7 @@ export const linkPreviewFor = (searchParams) => {
   const details = describeFilters(filters);
   const title = `${filters.player_name} Game Logs | ${SITE_NAME}`;
   const summary = details.length > 0 ? details.join(', ') : 'every logged game';
-  const description = `${filters.player_name} NBA game logs: ${summary}. Explore on ${SITE_NAME}.`;
+  const description = `${summary[0].toUpperCase()}${summary.slice(1)}. Explore on ${SITE_NAME}.`;
   return { title, description };
 };
 

--- a/src/linkPreview.test.js
+++ b/src/linkPreview.test.js
@@ -14,15 +14,14 @@ describe('linkPreviewFor', () => {
 
     expect(preview).toEqual({
       title: 'LeBron James Game Logs | CourtAI',
-      description:
-        'LeBron James NBA game logs: 2024-25 season, last 10 games, home games, vs BOS. Explore on CourtAI.',
+      description: '2024-25 season, last 10 games, home games, vs BOS. Explore on CourtAI.',
     });
   });
 
   test('describes a bare player link as every logged game', () => {
     expect(linkPreviewFor(new URLSearchParams('player_name=Stephen+Curry'))).toEqual({
       title: 'Stephen Curry Game Logs | CourtAI',
-      description: 'Stephen Curry NBA game logs: every logged game. Explore on CourtAI.',
+      description: 'Every logged game. Explore on CourtAI.',
     });
   });
 

--- a/src/linkPreview.test.js
+++ b/src/linkPreview.test.js
@@ -1,0 +1,77 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { DEFAULT_TITLE, applyLinkPreview, linkPreviewFor } from './linkPreview';
+
+const indexHtml = fs.readFileSync(path.resolve(process.cwd(), 'index.html'), 'utf8');
+
+describe('linkPreviewFor', () => {
+  test('names the player and the filters a link carries', () => {
+    const preview = linkPreviewFor(
+      new URLSearchParams(
+        'player_name=LeBron+James&season_filter=2024-25&game_filter=10&location_filter=Home&teams_against[]=BOS&rank_filter[]=30',
+      ),
+    );
+
+    expect(preview).toEqual({
+      title: 'LeBron James Game Logs | CourtAI',
+      description:
+        'LeBron James NBA game logs: 2024-25 season, last 10 games, home games, vs BOS. Explore on CourtAI.',
+    });
+  });
+
+  test('describes a bare player link as every logged game', () => {
+    expect(linkPreviewFor(new URLSearchParams('player_name=Stephen+Curry'))).toEqual({
+      title: 'Stephen Curry Game Logs | CourtAI',
+      description: 'Stephen Curry NBA game logs: every logged game. Explore on CourtAI.',
+    });
+  });
+
+  test('has nothing to say without a player', () => {
+    expect(linkPreviewFor(new URLSearchParams(''))).toBeNull();
+    expect(linkPreviewFor(new URLSearchParams('browse&season_filter=2024-25'))).toBeNull();
+  });
+
+  test('has nothing to say for a link the Workspace refuses', () => {
+    expect(
+      linkPreviewFor(new URLSearchParams('player_name=LeBron+James&season_filter=2024-26')),
+    ).toBeNull();
+  });
+});
+
+describe('applyLinkPreview', () => {
+  const preview = {
+    title: 'Luka "Magic" Dončić Game Logs | CourtAI',
+    description: 'Luka Dončić NBA game logs: vs BOS & MIA. Explore on CourtAI.',
+  };
+  // Prettier wraps long tags across lines; collapse so assertions read one tag per line.
+  const html = applyLinkPreview(indexHtml, preview).replace(/\s+/g, ' ');
+
+  test('rewrites every title and description the static head declares', () => {
+    expect(indexHtml).toContain(`<title>${DEFAULT_TITLE}</title>`);
+    expect(html).toContain('<title>Luka &quot;Magic&quot; Dončić Game Logs | CourtAI</title>');
+    expect(html).not.toContain(DEFAULT_TITLE);
+    expect(html).toContain(
+      '<meta property="og:title" content="Luka &quot;Magic&quot; Dončić Game Logs | CourtAI" />',
+    );
+    expect(html).toContain(
+      '<meta name="twitter:title" content="Luka &quot;Magic&quot; Dončić Game Logs | CourtAI" />',
+    );
+    for (const attribute of [
+      'name="description"',
+      'property="og:description"',
+      'name="twitter:description"',
+    ]) {
+      expect(html).toContain(
+        `<meta ${attribute} content="Luka Dončić NBA game logs: vs BOS &amp; MIA. Explore on CourtAI." />`,
+      );
+    }
+    expect(html).not.toContain('CourtAI helps explore');
+  });
+
+  test('leaves the rest of the document alone', () => {
+    expect(html).toContain('<script type="module" src="/src/index.js"></script>');
+    expect(html).toContain(
+      '<meta property="og:image" content="https://courtai.app/logo512.png" />',
+    );
+  });
+});

--- a/src/middleware.test.js
+++ b/src/middleware.test.js
@@ -41,7 +41,7 @@ test('describes a player link in the served document head', async () => {
   expect(response.headers.get('content-length')).toBeNull();
   const html = await response.text();
   expect(html).toContain('<title>LeBron James Game Logs | CourtAI</title>');
-  expect(html).toContain('last 10 games');
+  expect(html).toContain('Last 10 games. Explore on CourtAI.');
 });
 
 test('leaves a link without a player, or one the Workspace refuses, to the static document', async () => {

--- a/src/middleware.test.js
+++ b/src/middleware.test.js
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment node
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import middleware, { config } from '../middleware';
+
+const indexHtml = fs.readFileSync(path.resolve(process.cwd(), 'index.html'), 'utf8');
+
+const request = (search, cookie) =>
+  new Request(`https://courtai.app/${search}`, {
+    headers: cookie ? { cookie } : {},
+  });
+
+beforeEach(() => {
+  global.fetch = jest.fn(
+    async () =>
+      new Response(indexHtml, {
+        status: 200,
+        headers: { 'content-type': 'text/html', 'content-length': String(indexHtml.length) },
+      }),
+  );
+});
+
+afterEach(() => {
+  delete global.fetch;
+});
+
+test('runs only for the Workspace route', () => {
+  expect(config).toEqual({ matcher: '/' });
+});
+
+test('describes a player link in the served document head', async () => {
+  const response = await middleware(request('?player_name=LeBron+James&game_filter=10', 'a=b'));
+
+  expect(fetch).toHaveBeenCalledWith(new URL('https://courtai.app/index.html'), {
+    headers: { cookie: 'a=b' },
+  });
+  expect(response.status).toBe(200);
+  expect(response.headers.get('content-type')).toBe('text/html; charset=utf-8');
+  expect(response.headers.get('content-length')).toBeNull();
+  const html = await response.text();
+  expect(html).toContain('<title>LeBron James Game Logs | CourtAI</title>');
+  expect(html).toContain('last 10 games');
+});
+
+test('leaves a link without a player, or one the Workspace refuses, to the static document', async () => {
+  expect(await middleware(request(''))).toBeUndefined();
+  expect(await middleware(request('?browse'))).toBeUndefined();
+  expect(await middleware(request('?player_name=LeBron+James&game_filter=0'))).toBeUndefined();
+  expect(fetch).not.toHaveBeenCalled();
+});
+
+test('falls back to the static document when it cannot be fetched', async () => {
+  fetch.mockResolvedValueOnce(new Response('', { status: 503 }));
+
+  expect(await middleware(request('?player_name=LeBron+James'))).toBeUndefined();
+});

--- a/src/useDocumentTitle.js
+++ b/src/useDocumentTitle.js
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { DEFAULT_TITLE } from './linkPreview';
+
+/** Name the tab after what is on screen, and hand the default back on leaving. */
+const useDocumentTitle = (title) => {
+  useEffect(() => {
+    document.title = title ?? DEFAULT_TITLE;
+    return () => {
+      document.title = DEFAULT_TITLE;
+    };
+  }, [title]);
+};
+
+export default useDocumentTitle;


### PR DESCRIPTION
## Summary
- Vercel serves one static `index.html` for every URL, so a shared Workspace link unfurled as "NBA Game Log Analytics" regardless of whose logs it opened.
- Add a Vercel Edge Middleware (`middleware.js`, matcher `/`) that, for a URL naming a player, rewrites `<title>`, `description`, `og:*` and `twitter:*` in the served document — e.g. **LeBron James Game Logs | CourtAI** / *2024-25 season, last 10 games, vs BOS. Explore on CourtAI.* No-player, refused, or unfetchable cases fall through to the static file.
- The browser tab title follows the same text via `useDocumentTitle`, and resets on leaving the Workspace.
- Add static Open Graph / Twitter tags (including `og:image` → `logo512.png`) as the fallback preview.

## Verification
- `npm run lint`, `npm run format:check`, `npm run test:ci` (349 passed), `npm run build`, `npm run test:e2e` (81 passed, 2 skipped)
- New tests: `linkPreview.test.js`, `middleware.test.js`, two `GameLogFilter` tab-title tests; mutation-checked (removing the hook / bypassing the URL validator fails them).
- Middleware only runs on Vercel; check after deploy with `curl -s 'https://courtai.app/?player_name=LeBron+James' | grep '<title>'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)