### PR TITLE
Render the Historical Matchup experience from section-owned evidence

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -89,6 +89,12 @@ accidentally set.
 but small. A test can override one route to cover failures without relying on Firebase, the private
 backend, or live NBA data.
 
+The Matchup contract serves two games. `0022500584` is the current/live slate matchup. `0022501082`
+is the completed-season LAC @ MIL Historical Matchup: every Season defense Surface published, Last 15
+unavailable for want of a point-in-time snapshot, no archived DFS markets, and canonical game-log
+participants for both teams. One authenticated journey covers each; keep the historical outcome in a
+single integrated journey rather than splitting it across implementation-shaped tests.
+
 ## CI and failure evidence
 
 The `CI` workflow runs Jest/build validation first and then the hermetic Chromium suite. Critical

--- a/e2e/fixtures/courtai.js
+++ b/e2e/fixtures/courtai.js
@@ -645,13 +645,19 @@ const historicalScoreWindow = (value, category, available, missingInputs) => {
       ? { components: { traditional: { value, thin: false } }, missing_inputs: [] }
       : { components: { traditional: { value: 0.91, thin: true } }, missing_inputs: missingInputs };
   }
+  // A withheld offensive Blend still ships the components that were computable
+  // and names the inputs the score contract did not get.
   return available
     ? {
         components: { shot_zones: { value, thin: false } },
         blend: { value, thin: false },
         missing_inputs: [],
       }
-    : { components: {}, blend: null, missing_inputs: missingInputs };
+    : {
+        components: { shot_zones: { value: 0.88, thin: true } },
+        blend: null,
+        missing_inputs: missingInputs,
+      };
 };
 
 const historicalScores = (base, unavailable = []) =>

--- a/e2e/fixtures/courtai.js
+++ b/e2e/fixtures/courtai.js
@@ -714,6 +714,8 @@ export const historicalMatchupPayload = {
         source: 'event_catalog',
         context: 'completed_season_catalog',
         unavailable_reason: null,
+        // Immutable completed-season provenance, never a staleness signal.
+        collected_at: '2026-03-30T04:10:00Z',
       },
       participants: {
         status: 'available',

--- a/e2e/fixtures/courtai.js
+++ b/e2e/fixtures/courtai.js
@@ -1384,7 +1384,10 @@ export const installApiContract = async (page, overrides = {}) => {
       return;
     }
 
-    const savedFilterSetPath = url.pathname.match(/^\/api\/user\/saved-filter-sets(?:\/(.+))?$/);
+    const savedFilterSetPath =
+      url.pathname === '/api/user/saved-filter-sets'
+        ? [url.pathname, undefined]
+        : url.pathname.match(/^\/api\/user\/saved-filter-sets\/(.+)$/);
     if (savedFilterSetPath) {
       const [, savedFilterSetId] = savedFilterSetPath;
       const method = request.method();

--- a/e2e/fixtures/courtai.js
+++ b/e2e/fixtures/courtai.js
@@ -639,9 +639,11 @@ const historicalLeague = () => {
 
 const historicalScoreWindow = (value, category, available, missingInputs) => {
   if (DEFENSIVE_MARKETS.includes(category)) {
+    // A withheld defensive score can still ship its component evidence, so the
+    // component must not stand in for the score the contract did not complete.
     return available
       ? { components: { traditional: { value, thin: false } }, missing_inputs: [] }
-      : { components: {}, missing_inputs: missingInputs };
+      : { components: { traditional: { value: 0.91, thin: true } }, missing_inputs: missingInputs };
   }
   return available
     ? {
@@ -661,7 +663,10 @@ const historicalScores = (base, unavailable = []) =>
           base + index / 100,
           category,
           !unavailable.includes(category),
-          ['team_defense:play_types', 'player_diet:shot_zones'],
+          // A category can only be missing inputs its own score contract needs.
+          DEFENSIVE_MARKETS.includes(category)
+            ? ['team_defense:traditional']
+            : ['team_defense:play_types', 'player_diet:shot_zones'],
         ),
         last_15: historicalScoreWindow(0, category, false, HISTORICAL_LAST_15_MISSING),
       },
@@ -787,7 +792,7 @@ export const historicalMatchupPayload = {
       minutes: 27.8,
       focalStats: { PTS: 10, REB: 12, AST: 1, FGA: 8, FG3A: 0, TOV: 1 },
       scoreBase: 0.05,
-      unavailable: ['PTS'],
+      unavailable: ['PTS', 'TOV'],
     }),
     historicalParticipant({
       id: 203507,

--- a/e2e/fixtures/courtai.js
+++ b/e2e/fixtures/courtai.js
@@ -555,6 +555,280 @@ export const matchupPayload = {
   },
 };
 
+// Production LAC @ MIL 0022501082: every Season defense Surface published, no
+// point-in-time Last 15, no archived DFS markets, canonical game-log players.
+export const HISTORICAL_GAME_ID = '0022501082';
+const HISTORICAL_CATEGORIES = ['PTS', 'REB', 'AST', 'FGA', 'FG3A', 'TOV'];
+const HISTORICAL_LAST_15_MISSING = [
+  'team_defense:play_types',
+  'team_defense:shot_zones',
+  'team_defense:shot_types',
+  'team_defense:assist_locations',
+  'team_defense:traditional',
+];
+
+const historicalGame = {
+  game_id: HISTORICAL_GAME_ID,
+  away_team: {
+    team_id: 1610612746,
+    tricode: 'LAC',
+    name: 'LA Clippers',
+    targetable_player_count: 0,
+  },
+  home_team: {
+    team_id: 1610612749,
+    tricode: 'MIL',
+    name: 'Milwaukee Bucks',
+    targetable_player_count: 0,
+  },
+  scheduled_at: '2026-03-29T23:00:00Z',
+  status: { state: 'final', label: 'Final' },
+  classification: null,
+  preseason: false,
+};
+
+const withoutPointInTimeWindow = (sheet) => {
+  Object.values(sheet.defense_sheet).forEach((rows) =>
+    rows.forEach((row) => {
+      row.last_15 = null;
+    }),
+  );
+  Object.values(sheet.defensive_columns).forEach((column) => {
+    column.last_15 = null;
+  });
+  return sheet;
+};
+
+const historicalPlayTypes = (offset) => [
+  defenseRow(
+    'Transition:PTS',
+    'Transition PTS',
+    ['PTS', 'PA', 'PR', 'PRA'],
+    defenseValue(17.9 + offset, 9, 1.2, 24),
+    null,
+  ),
+  defenseRow(
+    'Isolation:PTS',
+    'Isolation PTS',
+    ['PTS', 'PA', 'PR', 'PRA'],
+    defenseValue(8.3 + offset, 3, 0.4, 17),
+    null,
+  ),
+  defenseRow(
+    'Postup:PTS',
+    'Postup PTS',
+    ['PTS', 'PA', 'PR', 'PRA'],
+    defenseValue(12.4 + offset, 11, 1.3, 26),
+    null,
+  ),
+];
+
+const historicalLeague = () => {
+  const scoped = JSON.parse(JSON.stringify(league));
+  scoped.surface_availability = Object.fromEntries(
+    Object.keys(scoped.surface_availability).map((base) => [
+      base,
+      {
+        season: { status: 'available', unavailable_reason: null },
+        last_15: { status: 'unavailable', unavailable_reason: 'no_point_in_time_snapshot' },
+      },
+    ]),
+  );
+  return withoutPointInTimeWindow(scoped);
+};
+
+const historicalScoreWindow = (value, category, available, missingInputs) => {
+  if (DEFENSIVE_MARKETS.includes(category)) {
+    return available
+      ? { components: { traditional: { value, thin: false } }, missing_inputs: [] }
+      : { components: {}, missing_inputs: missingInputs };
+  }
+  return available
+    ? {
+        components: { shot_zones: { value, thin: false } },
+        blend: { value, thin: false },
+        missing_inputs: [],
+      }
+    : { components: {}, blend: null, missing_inputs: missingInputs };
+};
+
+const historicalScores = (base, unavailable = []) =>
+  Object.fromEntries(
+    HISTORICAL_CATEGORIES.map((category, index) => [
+      category,
+      {
+        season: historicalScoreWindow(
+          base + index / 100,
+          category,
+          !unavailable.includes(category),
+          ['team_defense:play_types', 'player_diet:shot_zones'],
+        ),
+        last_15: historicalScoreWindow(0, category, false, HISTORICAL_LAST_15_MISSING),
+      },
+    ]),
+  );
+
+const historicalFocalLine = (minutes, stats) => ({
+  game_id: HISTORICAL_GAME_ID,
+  game_date: '2026-03-29',
+  matchup: 'LAC @ MIL',
+  minutes,
+  stats: Object.fromEntries(HISTORICAL_CATEGORIES.map((category) => [category, stats[category]])),
+});
+
+const historicalParticipant = ({
+  id,
+  name,
+  team,
+  seasonScoring,
+  minutes,
+  focalStats,
+  scoreBase,
+  unavailable = [],
+  dietShares = { play_types: [], shot_zones: [], shot_types: [], assist_locations: [] },
+}) => ({
+  canonical_id: id,
+  name,
+  team_id: team.team_id,
+  tricode: team.tricode,
+  player_source: 'game_logs',
+  posted_markets: [],
+  provenance: {},
+  stat_categories: HISTORICAL_CATEGORIES,
+  focal_game_line: historicalFocalLine(minutes, focalStats),
+  season_scoring: seasonScoring,
+  last_10_minutes: [34, 33, 36, 32, 35, 34, 33, 36, 35, 34],
+  diet_shares: dietShares,
+  injury_badge_ref: null,
+  scores: historicalScores(scoreBase, unavailable),
+});
+
+export const historicalMatchupPayload = {
+  game: historicalGame,
+  experience: {
+    mode: 'historical',
+    player_source: 'game_logs',
+    sections: {
+      schedule: {
+        status: 'available',
+        source: 'event_catalog',
+        context: 'completed_season_catalog',
+        unavailable_reason: null,
+      },
+      participants: {
+        status: 'available',
+        source: 'player_game_logs',
+        context: 'completed_season',
+        unavailable_reason: null,
+      },
+      season_defense: {
+        status: 'available',
+        source: 'team_matchup_publication',
+        context: 'completed_season',
+        unavailable_reason: null,
+      },
+      last_15_defense: {
+        status: 'unavailable',
+        source: null,
+        context: null,
+        unavailable_reason: 'no_point_in_time_snapshot',
+      },
+      injuries: {
+        status: 'unavailable',
+        source: null,
+        context: null,
+        unavailable_reason: 'no_pregame_snapshot',
+      },
+    },
+  },
+  league: historicalLeague(),
+  teams: [
+    withoutPointInTimeWindow(teamSheet(historicalGame.away_team, historicalPlayTypes(0))),
+    withoutPointInTimeWindow(teamSheet(historicalGame.home_team, historicalPlayTypes(0.4), 1)),
+  ],
+  players: [
+    historicalParticipant({
+      id: 202695,
+      name: 'Kawhi Leonard',
+      team: historicalGame.away_team,
+      seasonScoring: 21.4,
+      minutes: 34.5,
+      focalStats: { PTS: 24, REB: 5, AST: 7, FGA: 18, FG3A: 6, TOV: 2 },
+      scoreBase: 0.18,
+      dietShares: {
+        play_types: [dietShare('Transition', 0.22), dietShare('Postup', 0.14)],
+        shot_zones: [dietShare('Restricted Area', 0.28, 5.4, 'field_goal_attempts')],
+        shot_types: [dietShare('Catch and Shoot', 0.34, 4.4, 'field_goal_attempts')],
+        assist_locations: [dietShare('AtRimAssists', 0.3, 1.2, 'assists')],
+      },
+    }),
+    historicalParticipant({
+      id: 201935,
+      name: 'James Harden',
+      team: historicalGame.away_team,
+      seasonScoring: 19.8,
+      minutes: 36.2,
+      focalStats: { PTS: 19, REB: 4, AST: 11, FGA: 15, FG3A: 9, TOV: 4 },
+      scoreBase: 0.26,
+      dietShares: {
+        play_types: [dietShare('Isolation', 0.24)],
+        shot_zones: [dietShare('Above the Break 3', 0.31, 6.2, 'field_goal_attempts')],
+        shot_types: [],
+        assist_locations: [dietShare('AtRimAssists', 0.38, 1.9, 'assists')],
+      },
+    }),
+    historicalParticipant({
+      id: 1627826,
+      name: 'Ivica Zubac',
+      team: historicalGame.away_team,
+      seasonScoring: 12.1,
+      minutes: 27.8,
+      focalStats: { PTS: 10, REB: 12, AST: 1, FGA: 8, FG3A: 0, TOV: 1 },
+      scoreBase: 0.05,
+      unavailable: ['PTS'],
+    }),
+    historicalParticipant({
+      id: 203507,
+      name: 'Giannis Antetokounmpo',
+      team: historicalGame.home_team,
+      seasonScoring: 30.2,
+      minutes: 35.1,
+      focalStats: { PTS: 33, REB: 14, AST: 6, FGA: 22, FG3A: 2, TOV: 3 },
+      scoreBase: 0.21,
+      dietShares: {
+        play_types: [dietShare('Transition', 0.26)],
+        shot_zones: [dietShare('Restricted Area', 0.41, 8.1, 'field_goal_attempts')],
+        shot_types: [],
+        assist_locations: [dietShare('AtRimAssists', 0.29, 1.4, 'assists')],
+      },
+    }),
+    historicalParticipant({
+      id: 203081,
+      name: 'Damian Lillard',
+      team: historicalGame.home_team,
+      seasonScoring: 24.6,
+      minutes: 33.4,
+      focalStats: { PTS: 22, REB: 3, AST: 8, FGA: 17, FG3A: 11, TOV: 2 },
+      scoreBase: 0.13,
+    }),
+  ],
+  injuries: {
+    status: 'unavailable',
+    unavailable_reason: 'fetch_failed',
+    retrieved_at: null,
+    source: 'rotowire',
+    source_url: 'https://www.rotowire.com/basketball/injury-report.php',
+    teams: [],
+  },
+  freshness: {
+    schedule: { status: 'fresh', retrieved_at: '2026-03-29T10:00:00Z' },
+    pool: { status: 'unavailable', retrieved_at: null, providers: {} },
+    // The reported production failure: no stats_tables publication marker.
+    stats: { status: 'missing', retrieved_at: null },
+    injuries: { status: 'unavailable', retrieved_at: null },
+  },
+};
+
 const selectionLine = (date, matchup, minutes, values, deltas) => ({
   row_type: date === null ? 'average' : 'game',
   game_date: date,
@@ -655,6 +929,61 @@ export const austinSelectionPayload = {
         { PTS: 22, FG3A: 7, STL: 1 },
         { PTS: 0.022, FG3A: 0.013, STL: -0.004 },
       ),
+    ],
+  },
+};
+
+const historicalSelectionStats = { PTS: 21, REB: 6, AST: 5, FGA: 17, FG3A: 5, TOV: 2 };
+const historicalSelectionDeltas = {
+  PTS: 0.061,
+  REB: 0.014,
+  AST: -0.008,
+  FGA: 0.012,
+  FG3A: 0.009,
+  TOV: -0.003,
+};
+
+// Pregame samples use games strictly before 2026-03-29; the focal game never
+// appears in either table.
+export const historicalSelectionPayload = {
+  player_id: 202695,
+  experience: {
+    mode: 'historical',
+    player_source: 'game_logs',
+    focal_game: {
+      game_id: HISTORICAL_GAME_ID,
+      game_date: '2026-03-29',
+      matchup: 'LAC @ MIL',
+      minutes: 34.5,
+      stats: { PTS: 24, REB: 5, AST: 7, FGA: 18, FG3A: 6, TOV: 2 },
+    },
+    samples: { context: 'pregame', excludes_focal_game: true },
+    baseline: { context: 'completed_season', hindsight: true },
+  },
+  h2h: {
+    thin: true,
+    rows: [
+      selectionLine(
+        '2026-01-12',
+        'LAC vs. MIL',
+        33,
+        historicalSelectionStats,
+        historicalSelectionDeltas,
+      ),
+      selectionLine(null, 'AVG', 33, historicalSelectionStats, historicalSelectionDeltas),
+    ],
+  },
+  archetype: {
+    thin: false,
+    rows: [
+      selectionLine(
+        '2026-02-08',
+        'LAC @ BOS',
+        35,
+        historicalSelectionStats,
+        historicalSelectionDeltas,
+      ),
+      selectionLine(null, 'AVG', 35, historicalSelectionStats, historicalSelectionDeltas),
     ],
   },
 };
@@ -1168,18 +1497,26 @@ export const installApiContract = async (page, overrides = {}) => {
     }
 
     if (url.pathname === '/api/games/matchup') {
-      await route.fulfill({ json: matchupPayload });
+      const gameId = url.searchParams.get('game_id');
+      await route.fulfill({
+        json: gameId === HISTORICAL_GAME_ID ? historicalMatchupPayload : matchupPayload,
+      });
       return;
     }
 
     if (url.pathname === '/api/games/matchup/selection') {
       const gameId = url.searchParams.get('game_id');
       const playerId = url.searchParams.get('player_id');
-      const payloads = {
-        2544: selectionPayload,
-        1630559: austinSelectionPayload,
+      const payloadsByGame = {
+        [matchupPayload.game.game_id]: {
+          2544: selectionPayload,
+          1630559: austinSelectionPayload,
+        },
+        // A canonical game-log participant is selectable with no Player Pool.
+        [HISTORICAL_GAME_ID]: { 202695: historicalSelectionPayload },
       };
-      if (gameId !== matchupPayload.game.game_id || !payloads[playerId]) {
+      const payloads = payloadsByGame[gameId];
+      if (!payloads || !payloads[playerId]) {
         await route.fulfill({ status: 404, json: { error: { code: 'resource_not_found' } } });
         return;
       }

--- a/e2e/specs/core-flows.spec.js
+++ b/e2e/specs/core-flows.spec.js
@@ -1279,7 +1279,7 @@ test('@critical a saved Filter Set is a name that reopens the same Log Workspace
   await page.getByRole('button', { name: 'Save Filter Set' }).click();
   await page.getByLabel('Name').fill('LeBron last 10');
   await page.getByRole('button', { name: 'Save', exact: true }).click();
-  await expect(page.getByRole('heading', { name: 'Save this Filter Set' })).toHaveCount(0);
+  await expect(page.getByRole('heading', { name: 'Save this Filter Set' })).toBeHidden();
 
   // The same name twice is the backend's answer, shown rather than swallowed.
   await page.getByRole('button', { name: 'Save Filter Set' }).click();

--- a/e2e/specs/matchup-detail.spec.js
+++ b/e2e/specs/matchup-detail.spec.js
@@ -152,6 +152,9 @@ test('@critical a completed-season matchup renders section-owned evidence and ga
   await expect(
     page.getByText('Completed-season baseline — hindsight, not pregame evidence.'),
   ).toBeVisible();
+  const matrix = page.getByRole('table', { name: 'Kawhi Leonard Score Matrix' });
+  await expect(matrix.getByRole('columnheader', { name: 'Category' })).toBeVisible();
+  await expect(matrix.getByRole('columnheader', { name: 'Market' })).toHaveCount(0);
   await expect(page.getByRole('rowheader', { name: '2026-01-12 · LAC vs. MIL' })).toBeVisible();
   await expect(page.getByRole('rowheader', { name: /2026-03-29/ })).toHaveCount(0);
   await page.screenshot({

--- a/e2e/specs/matchup-detail.spec.js
+++ b/e2e/specs/matchup-detail.spec.js
@@ -1,4 +1,201 @@
-import { expect, installApiContract, matchupPayload, test } from '../fixtures/courtai';
+import {
+  expect,
+  HISTORICAL_GAME_ID,
+  historicalMatchupPayload,
+  installApiContract,
+  matchupPayload,
+  test,
+} from '../fixtures/courtai';
+
+test('@critical a completed-season matchup renders section-owned evidence and game-log players', async ({
+  authenticatedPage: page,
+}, testInfo) => {
+  await page.clock.setFixedTime(new Date('2026-04-02T12:00:00Z'));
+  const matchupRequests = [];
+  const consoleErrors = [];
+  const failedResponses = [];
+  page.on('console', (message) => {
+    if (message.type() === 'error') consoleErrors.push(message.text());
+  });
+  page.on('response', (response) => {
+    if (response.status() >= 400) failedResponses.push(`${response.status()} ${response.url()}`);
+  });
+  page.on('request', (request) => {
+    if (new URL(request.url()).pathname === '/api/games/matchup')
+      matchupRequests.push(request.url());
+  });
+
+  await page.goto(`/matchups/${HISTORICAL_GAME_ID}`);
+
+  // Season defense renders even though the legacy stats marker is missing.
+  await expect(page.getByRole('heading', { name: 'MIL Defense Sheet' })).toBeVisible();
+  await expect(page.getByText('Transition PTS')).toBeVisible();
+  await expect(page.getByText('Restricted Area FGA')).toBeVisible();
+  await expect(page.getByText('Above the Break 3 FGA')).toBeVisible();
+  await expect(page.getByText('Defense Sheet unavailable because stats are missing.')).toHaveCount(
+    0,
+  );
+
+  // Section-owned statuses replace the generic Pool/Stats freshness warnings.
+  const evidence = page.getByRole('region', { name: 'Historical matchup evidence' });
+  await expect(evidence).toBeVisible();
+  await expect(page.getByRole('region', { name: 'Matchup data freshness' })).toHaveCount(0);
+  await expect(evidence).toContainText('Schedule: Completed-season catalog · from Event Catalog');
+  await expect(evidence).toContainText('Participants: Completed-season context · from game logs');
+  await expect(evidence).toContainText(
+    'Season defense: Completed-season context · from Defense Sheet publication',
+  );
+  await expect(evidence).toContainText(
+    'Last 15 defense: unavailable — No point-in-time snapshot was captured for this game.',
+  );
+  await expect(page.getByText(/pool data warning/i)).toHaveCount(0);
+  await expect(page.getByText(/stats data warning/i)).toHaveCount(0);
+
+  await expect(
+    page.getByText(
+      'Season defense provenance: Completed-season context · Defense Sheet publication',
+    ),
+  ).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Last 15', exact: true })).toBeDisabled();
+  await expect(
+    page.getByText('No point-in-time snapshot was captured for this game.').last(),
+  ).toBeVisible();
+  await expect(
+    page
+      .getByRole('region', { name: 'Injuries' })
+      .getByText('No pregame injury snapshot was archived for this game.'),
+  ).toBeVisible();
+
+  // The rail is Players in game, drawn from the opposing side's game logs.
+  const rail = page.getByRole('complementary', { name: 'Players in game' });
+  await expect(rail.getByRole('article', { name: 'Kawhi Leonard player' })).toBeVisible();
+  await expect(rail.getByRole('article', { name: 'James Harden player' })).toBeVisible();
+  await expect(rail.getByRole('article', { name: 'Ivica Zubac player' })).toBeVisible();
+  await expect(rail.getByRole('article', { name: 'Giannis Antetokounmpo player' })).toHaveCount(0);
+  await expect(page.getByText('Targetable players')).toHaveCount(0);
+  await expect(page.getByText(/targetable returned/)).toHaveCount(0);
+  await expect(page.getByRole('group', { name: 'Kawhi Leonard posted markets' })).toHaveCount(0);
+  await expect(page.getByRole('group', { name: 'Market' })).toHaveCount(0);
+
+  // The focal outcome and the completed-season baseline stay distinguishable.
+  await expect(
+    rail
+      .getByRole('article', { name: 'Kawhi Leonard player' })
+      .getByText('Focal game LAC @ MIL · 34.5 MIN · 24.0 PTS · 5.0 REB · 7.0 AST'),
+  ).toBeVisible();
+  await expect(page.getByText('21.4 PPG · completed-season context')).toBeVisible();
+  await expect(page.getByText(/Kawhi Leonard · 22% poss/)).toBeVisible();
+  await expect(page.getByText(/Kawhi Leonard · 28% FGA/)).toBeVisible();
+  await expect(page.getByText(/James Harden · 31% FGA/)).toBeVisible();
+  await page.screenshot({
+    path: testInfo.outputPath('historical-matchup-desktop.png'),
+    fullPage: true,
+  });
+
+  // Governed Stat Categories, not posted DFS markets, drive the control.
+  const categories = page.getByRole('group', { name: 'Stat category' });
+  await expect(categories).toBeVisible();
+  await expect(categories.getByRole('button', { name: 'FG3A', exact: true })).toBeVisible();
+  await categories.getByRole('button', { name: 'PTS', exact: true }).click();
+  await expect(page.getByText('Transition PTS')).toBeVisible();
+  await expect(page.getByText('Above the Break 3 FGA')).toHaveCount(0);
+
+  // Season scoring order, then Matchup Score order, with unavailable last.
+  let players = page.getByRole('article', { name: /player$/ });
+  await expect(players.first()).toHaveAccessibleName('Kawhi Leonard player');
+  await page.getByRole('button', { name: 'Matchup Score' }).click();
+  players = page.getByRole('article', { name: /player$/ });
+  await expect(players.first()).toHaveAccessibleName('James Harden player');
+  await expect(players.last()).toHaveAccessibleName('Ivica Zubac player');
+  await expect(
+    page.getByText(
+      'PTS Matchup Score unavailable: missing team_defense:play_types, player_diet:shot_zones.',
+    ),
+  ).toBeVisible();
+  await page.screenshot({
+    path: testInfo.outputPath('historical-matchup-score-sort.png'),
+    fullPage: true,
+  });
+
+  // Switching the defense team switches the opposing participant rail.
+  await page.getByRole('button', { name: 'LAC defense' }).click();
+  await expect(page.getByRole('heading', { name: 'LAC Defense Sheet' })).toBeVisible();
+  await expect(page.getByRole('article', { name: 'Giannis Antetokounmpo player' })).toBeVisible();
+  await expect(page.getByRole('article', { name: 'Damian Lillard player' })).toBeVisible();
+  await expect(page.getByRole('article', { name: 'Kawhi Leonard player' })).toHaveCount(0);
+  await page.getByRole('button', { name: 'MIL defense' }).click();
+
+  // Selecting a game-log participant opens the stored-data dossier.
+  await page
+    .getByRole('article', { name: 'Kawhi Leonard player' })
+    .getByRole('button', { name: 'Open selection card' })
+    .click();
+  await expect(page).toHaveURL(new RegExp(`player=202695`));
+  await expect(page.getByRole('heading', { name: 'Kawhi Leonard', level: 2 })).toBeVisible();
+  await expect(
+    page.getByText('Focal game LAC @ MIL · 2026-03-29 · 34.5 MIN · 24.0 PTS · 5.0 REB · 7.0 AST'),
+  ).toBeVisible();
+  await expect(
+    page.getByText('Pregame samples use games strictly before the focal game.'),
+  ).toBeVisible();
+  await expect(
+    page.getByText('Completed-season baseline — hindsight, not pregame evidence.'),
+  ).toBeVisible();
+  await expect(page.getByRole('rowheader', { name: '2026-01-12 · LAC vs. MIL' })).toBeVisible();
+  await expect(page.getByRole('rowheader', { name: /2026-03-29/ })).toHaveCount(0);
+  await page.screenshot({
+    path: testInfo.outputPath('historical-selection-card.png'),
+    fullPage: true,
+  });
+
+  await page.setViewportSize({ width: 393, height: 852 });
+  await expect(page.getByRole('heading', { name: 'MIL Defense Sheet' })).toBeVisible();
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(
+    true,
+  );
+  await page.screenshot({
+    path: testInfo.outputPath('historical-matchup-narrow.png'),
+    fullPage: true,
+  });
+
+  expect(matchupRequests).toHaveLength(1);
+  expect(consoleErrors).toEqual([]);
+  expect(failedResponses).toEqual([]);
+});
+
+test('historical participants stay unavailable with a precise reason without hiding defense evidence', async ({
+  page,
+}, testInfo) => {
+  await page.clock.setFixedTime(new Date('2026-04-02T12:00:00Z'));
+  await page.addInitScript(() => localStorage.setItem('courtai:e2e-authenticated', 'true'));
+  const candidate = JSON.parse(JSON.stringify(historicalMatchupPayload));
+  candidate.experience.sections.participants = {
+    status: 'unavailable',
+    source: null,
+    context: null,
+    unavailable_reason: 'game_logs_incomplete',
+  };
+  const consoleErrors = [];
+  page.on('console', (message) => {
+    if (message.type() === 'error') consoleErrors.push(message.text());
+  });
+  await installApiContract(page, { '/api/games/matchup': candidate });
+
+  await page.goto(`/matchups/${HISTORICAL_GAME_ID}`);
+  await expect(page.getByRole('heading', { name: 'MIL Defense Sheet' })).toBeVisible();
+  await expect(page.getByText('Transition PTS')).toBeVisible();
+  await expect(
+    page
+      .getByRole('complementary', { name: 'Players in game' })
+      .getByText('Canonical game logs are incomplete for this game.'),
+  ).toBeVisible();
+  await expect(page.getByRole('article', { name: 'Kawhi Leonard player' })).toHaveCount(0);
+  expect(consoleErrors).toEqual([]);
+  await page.screenshot({
+    path: testInfo.outputPath('historical-participants-unavailable.png'),
+    fullPage: true,
+  });
+});
 
 test('matchup detail preserves the approved Open Team Sheets hierarchy', async ({
   authenticatedPage: page,

--- a/e2e/specs/matchup-detail.spec.js
+++ b/e2e/specs/matchup-detail.spec.js
@@ -1,7 +1,6 @@
 import {
   expect,
   HISTORICAL_GAME_ID,
-  historicalMatchupPayload,
   installApiContract,
   matchupPayload,
   test,
@@ -40,7 +39,9 @@ test('@critical a completed-season matchup renders section-owned evidence and ga
   const evidence = page.getByRole('region', { name: 'Historical matchup evidence' });
   await expect(evidence).toBeVisible();
   await expect(page.getByRole('region', { name: 'Matchup data freshness' })).toHaveCount(0);
-  await expect(evidence).toContainText('Schedule: Completed-season catalog · from Event Catalog');
+  await expect(evidence).toContainText(
+    'Schedule: Completed-season catalog · from Event Catalog · collected 2026-03-30',
+  );
   await expect(evidence).toContainText('Participants: Completed-season context · from game logs');
   await expect(evidence).toContainText(
     'Season defense: Completed-season context · from Defense Sheet publication',
@@ -161,40 +162,6 @@ test('@critical a completed-season matchup renders section-owned evidence and ga
   expect(matchupRequests).toHaveLength(1);
   expect(consoleErrors).toEqual([]);
   expect(failedResponses).toEqual([]);
-});
-
-test('historical participants stay unavailable with a precise reason without hiding defense evidence', async ({
-  page,
-}, testInfo) => {
-  await page.clock.setFixedTime(new Date('2026-04-02T12:00:00Z'));
-  await page.addInitScript(() => localStorage.setItem('courtai:e2e-authenticated', 'true'));
-  const candidate = JSON.parse(JSON.stringify(historicalMatchupPayload));
-  candidate.experience.sections.participants = {
-    status: 'unavailable',
-    source: null,
-    context: null,
-    unavailable_reason: 'game_logs_incomplete',
-  };
-  const consoleErrors = [];
-  page.on('console', (message) => {
-    if (message.type() === 'error') consoleErrors.push(message.text());
-  });
-  await installApiContract(page, { '/api/games/matchup': candidate });
-
-  await page.goto(`/matchups/${HISTORICAL_GAME_ID}`);
-  await expect(page.getByRole('heading', { name: 'MIL Defense Sheet' })).toBeVisible();
-  await expect(page.getByText('Transition PTS')).toBeVisible();
-  await expect(
-    page
-      .getByRole('complementary', { name: 'Players in game' })
-      .getByText('Canonical game logs are incomplete for this game.'),
-  ).toBeVisible();
-  await expect(page.getByRole('article', { name: 'Kawhi Leonard player' })).toHaveCount(0);
-  expect(consoleErrors).toEqual([]);
-  await page.screenshot({
-    path: testInfo.outputPath('historical-participants-unavailable.png'),
-    fullPage: true,
-  });
 });
 
 test('matchup detail preserves the approved Open Team Sheets hierarchy', async ({

--- a/e2e/specs/matchup-detail.spec.js
+++ b/e2e/specs/matchup-detail.spec.js
@@ -118,6 +118,16 @@ test('@critical a completed-season matchup renders section-owned evidence and ga
     fullPage: true,
   });
 
+  // A withheld defensive score still ships component evidence. That component
+  // must not be promoted into an available score or an ordering position.
+  await categories.getByRole('button', { name: 'TOV', exact: true }).click();
+  await expect(
+    page.getByText('TOV Matchup Score unavailable: missing team_defense:traditional.'),
+  ).toBeVisible();
+  players = page.getByRole('article', { name: /player$/ });
+  await expect(players.last()).toHaveAccessibleName('Ivica Zubac player');
+  await categories.getByRole('button', { name: 'PTS', exact: true }).click();
+
   // Switching the defense team switches the opposing participant rail.
   await page.getByRole('button', { name: 'LAC defense' }).click();
   await expect(page.getByRole('heading', { name: 'LAC Defense Sheet' })).toBeVisible();

--- a/src/matchups/MatchupDetailPage.css
+++ b/src/matchups/MatchupDetailPage.css
@@ -182,10 +182,19 @@
 .hidden-count,
 .honest-empty,
 .no-lean,
-.rail-count {
+.rail-count,
+.sheet-provenance,
+.window-context,
+.focal-line,
+.selection-provenance {
   margin: 0;
   color: var(--ct-dim);
   font-size: 0.68rem;
+}
+
+.focal-line,
+.window-context {
+  overflow-wrap: anywhere;
 }
 
 .sheet-base,

--- a/src/matchups/MatchupDetailPage.js
+++ b/src/matchups/MatchupDetailPage.js
@@ -613,7 +613,6 @@ function Detail({ matchup, gameId }) {
   const [windowKey, setWindowKey] = useState('season');
   const [deviation, setDeviation] = useState(1);
   const selectedId = searchParams.get('player');
-  const selectedPlayer = matchup.players.find((player) => String(player.id) === selectedId) || null;
   const selectionTriggers = useRef(new Map());
   const previousSelectedId = useRef(null);
   const [selectionState, setSelectionState] = useState({
@@ -632,6 +631,11 @@ function Detail({ matchup, gameId }) {
   const participantsAvailable = historical
     ? sections.participants.status === 'available'
     : poolAvailable;
+  // Nobody is selectable when Participants are unavailable, so a deep link
+  // cannot open a dossier the rail says this matchup does not have.
+  const selectedPlayer =
+    (participantsAvailable && matchup.players.find((player) => String(player.id) === selectedId)) ||
+    null;
   const opposingPlayers = useMemo(
     () =>
       participantsAvailable
@@ -843,6 +847,7 @@ function Detail({ matchup, gameId }) {
               windowKey={windowKey}
               sheetMarket={market}
               whyRelevant={selectedPlayer.teamId !== defenseTeam.teamId}
+              historical={historical}
               onClose={() => updateSelectedPlayer(null)}
             />
           )}

--- a/src/matchups/MatchupDetailPage.js
+++ b/src/matchups/MatchupDetailPage.js
@@ -851,22 +851,30 @@ function Detail({ matchup, gameId }) {
               onClose={() => updateSelectedPlayer(null)}
             />
           )}
-          {/* The Defense Sheet is governed by its own Surface availability. The
-              generic legacy stats freshness marker never suppresses it. */}
-          <DefenseSheet
-            team={defenseTeam}
-            players={opposingPlayers}
-            market={market}
-            windowKey={windowKey}
-            deviation={deviation}
-            selectedPlayer={selectedPlayer?.teamId !== defenseTeam.teamId ? selectedPlayer : null}
-            surfaceAvailability={matchup.league.surfaceAvailability}
-            provenance={
-              windowSection
-                ? `${WINDOWS.find((item) => item.key === windowKey).label} defense provenance: ${contextLabel(windowSection)} · ${sourceLabel(windowSection)}`
-                : null
-            }
-          />
+          {/* A historical Defense Sheet is governed by its own Surface
+              availability, so the generic legacy stats marker never suppresses
+              it. The live journey keeps the gate it has always had. */}
+          {!historical && matchup.freshness.stats.status === 'missing' ? (
+            <section className="defense-sheet" aria-labelledby="defense-sheet-heading">
+              <h2 id="defense-sheet-heading">{defenseTeam.tricode} Defense Sheet</h2>
+              <p className="honest-empty">Defense Sheet unavailable because stats are missing.</p>
+            </section>
+          ) : (
+            <DefenseSheet
+              team={defenseTeam}
+              players={opposingPlayers}
+              market={market}
+              windowKey={windowKey}
+              deviation={deviation}
+              selectedPlayer={selectedPlayer?.teamId !== defenseTeam.teamId ? selectedPlayer : null}
+              surfaceAvailability={matchup.league.surfaceAvailability}
+              provenance={
+                windowSection
+                  ? `${WINDOWS.find((item) => item.key === windowKey).label} defense provenance: ${contextLabel(windowSection)} · ${sourceLabel(windowSection)}`
+                  : null
+              }
+            />
+          )}
         </div>
       </div>
     </>

--- a/src/matchups/MatchupDetailPage.js
+++ b/src/matchups/MatchupDetailPage.js
@@ -32,6 +32,59 @@ const SHARE_LABELS = {
   assistLocations: 'ast',
 };
 const UNAVAILABLE_RELATIVE_LABEL = 'vs league: unavailable (not comparable)';
+const SECTION_ORDER = [
+  ['schedule', 'Schedule'],
+  ['participants', 'Participants'],
+  ['seasonDefense', 'Season defense'],
+  ['last15Defense', 'Last 15 defense'],
+  ['injuries', 'Injuries'],
+];
+const CONTEXT_LABELS = {
+  completed_season_catalog: 'Completed-season catalog',
+  current_season_catalog: 'Current-season catalog',
+  completed_season: 'Completed-season context',
+  pregame: 'Pregame',
+  posted_markets: 'Posted markets',
+  current: 'Current',
+};
+const SOURCE_LABELS = {
+  event_catalog: 'Event Catalog',
+  player_game_logs: 'game logs',
+  player_pool: 'Player Pool',
+  team_matchup_publication: 'Defense Sheet publication',
+  rotowire: 'rotowire',
+};
+const SECTION_REASONS = {
+  no_point_in_time_snapshot: 'No point-in-time snapshot was captured for this game.',
+  no_pregame_snapshot: 'No pregame injury snapshot was archived for this game.',
+  game_logs_incomplete: 'Canonical game logs are incomplete for this game.',
+  no_game_log_rows: 'No canonical game-log rows exist for this game.',
+  player_pool_unavailable: 'No Player Pool snapshot is available for this game.',
+};
+const sectionReason = (section) =>
+  SECTION_REASONS[section.unavailableReason] || `${section.unavailableReason}.`;
+const contextLabel = (section) => CONTEXT_LABELS[section.context] || section.context;
+const sourceLabel = (section) => SOURCE_LABELS[section.source] || section.source;
+
+// Historical sections replace the live freshness bars: each one governs only its
+// own evidence, so a missing pool or stats marker cannot speak for the others.
+function HistoricalEvidence({ sections }) {
+  return (
+    <section className="matchup-freshness" aria-label="Historical matchup evidence">
+      {SECTION_ORDER.map(([key, label]) => {
+        const section = sections[key];
+        return (
+          <span key={key}>
+            <strong>{label}</strong>:{' '}
+            {section.status === 'available'
+              ? `${contextLabel(section)} · from ${sourceLabel(section)}`
+              : `${section.status} — ${sectionReason(section)}`}
+          </span>
+        );
+      })}
+    </section>
+  );
+}
 
 function Freshness({ freshness, now }) {
   const surfaces = [
@@ -95,6 +148,8 @@ function Sparkline({ values, playerName }) {
 function PlayerRail({
   players,
   injuries,
+  historical,
+  unavailableMessage,
   market,
   windowKey,
   targetableCount,
@@ -109,24 +164,38 @@ function PlayerRail({
   const injuryById = new Map(
     injuries.teams.flatMap((team) => team.entries).map((entry) => [entry.id, entry]),
   );
+  const windowScoreFor = (player) => player.scores[market]?.[windowKey] ?? null;
+  // A score is unavailable, not zero, when the contract could not compute it.
   const scoreFor = (player) => {
-    const score = player.scores[market]?.[windowKey];
-    if (!score) return -Infinity;
-    return score.blend?.value ?? Object.values(score.components)[0]?.value ?? -Infinity;
+    const score = windowScoreFor(player);
+    if (!score) return null;
+    return score.blend?.value ?? Object.values(score.components)[0]?.value ?? null;
   };
-  const seasonScoreFor = (player) => player.seasonScoring ?? -Infinity;
+  const byScore = sortMode === 'score' && market !== 'All';
+  const rank = (a, b, valueOf) => {
+    const first = valueOf(a);
+    const second = valueOf(b);
+    if ((first === null) !== (second === null)) return first === null ? 1 : -1;
+    if (first === null || first === second) return 0;
+    return second - first;
+  };
   const scoped = players.filter(
-    (player) => market === 'All' || player.postedMarkets.includes(market),
+    (player) => market === 'All' || player.statCategories.includes(market),
   );
-  scoped.sort((a, b) =>
-    sortMode === 'score' && market !== 'All'
-      ? scoreFor(b) - scoreFor(a) || seasonScoreFor(b) - seasonScoreFor(a)
-      : seasonScoreFor(b) - seasonScoreFor(a) || a.name.localeCompare(b.name),
+  scoped.sort(
+    (a, b) =>
+      (byScore ? rank(a, b, scoreFor) : 0) ||
+      rank(a, b, (player) => player.seasonScoring) ||
+      a.name.localeCompare(b.name),
   );
   return (
-    <aside className="player-rail" aria-labelledby="player-rail-heading">
+    <aside
+      className="player-rail"
+      aria-label={historical ? 'Players in game' : undefined}
+      aria-labelledby={historical ? undefined : 'player-rail-heading'}
+    >
       <div className="section-heading">
-        <p className="matchup-eyebrow">Targetable players</p>
+        <p className="matchup-eyebrow">{historical ? 'Players in game' : 'Targetable players'}</p>
         <h2 id="player-rail-heading">
           {sortMode === 'score' && market !== 'All'
             ? `${market} Matchup Score order`
@@ -153,13 +222,22 @@ function PlayerRail({
           </button>
         </div>
       </div>
-      {scoped.length === 0 ? (
-        <p className="honest-empty">No posted players are available for this market.</p>
+      {unavailableMessage ? (
+        <p className="honest-empty">{unavailableMessage}</p>
+      ) : scoped.length === 0 ? (
+        <p className="honest-empty">
+          {historical
+            ? 'No participants are available for this Stat Category.'
+            : 'No posted players are available for this market.'}
+        </p>
       ) : (
         <div className="player-list">
           {scoped.map((player) => {
-            const injury = injuryById.get(player.injuryBadgeRef);
+            const injury = historical ? undefined : injuryById.get(player.injuryBadgeRef);
             const serializedPlayerId = String(player.id);
+            const focalLine = player.focalGameLine;
+            const unscored = market !== 'All' && scoreFor(player) === null;
+            const missingInputs = unscored ? (windowScoreFor(player)?.missingInputs ?? []) : [];
             return (
               <article
                 key={player.id}
@@ -172,28 +250,51 @@ function PlayerRail({
                     {player.seasonScoring === null
                       ? 'Season scoring unavailable'
                       : `${player.seasonScoring.toFixed(1)} PPG`}
+                    {historical && player.seasonScoring !== null
+                      ? ' · completed-season context'
+                      : ''}
                   </p>
                 </div>
                 {injury && (
                   <span className="injury-badge">{injury.status || injury.rawStatus}</span>
                 )}
-                <div
-                  className="market-chips"
-                  role="group"
-                  aria-label={`${player.name} posted markets`}
-                >
-                  {player.postedMarkets.map((postedMarket) => {
-                    const providers = Object.entries(player.provenance)
-                      .filter(([, markets]) => markets.includes(postedMarket))
-                      .map(([provider]) => provider);
-                    const provenanceLabel = `${postedMarket} from ${providers.join(', ')}`;
-                    return (
-                      <span key={postedMarket} aria-label={provenanceLabel} title={provenanceLabel}>
-                        {postedMarket}
-                      </span>
-                    );
-                  })}
-                </div>
+                {historical && focalLine && (
+                  <p className="focal-line">
+                    Focal game {focalLine.matchup} · {focalLine.minutes.toFixed(1)} MIN ·{' '}
+                    {(market === 'All' ? player.statCategories : [market])
+                      .map((category) => `${focalLine.stats[category].toFixed(1)} ${category}`)
+                      .join(' · ')}
+                  </p>
+                )}
+                {historical && unscored && (
+                  <p className="honest-empty">
+                    {market} Matchup Score unavailable
+                    {missingInputs.length ? `: missing ${missingInputs.join(', ')}` : ''}.
+                  </p>
+                )}
+                {!historical && (
+                  <div
+                    className="market-chips"
+                    role="group"
+                    aria-label={`${player.name} posted markets`}
+                  >
+                    {player.postedMarkets.map((postedMarket) => {
+                      const providers = Object.entries(player.provenance)
+                        .filter(([, markets]) => markets.includes(postedMarket))
+                        .map(([provider]) => provider);
+                      const provenanceLabel = `${postedMarket} from ${providers.join(', ')}`;
+                      return (
+                        <span
+                          key={postedMarket}
+                          aria-label={provenanceLabel}
+                          title={provenanceLabel}
+                        >
+                          {postedMarket}
+                        </span>
+                      );
+                    })}
+                  </div>
+                )}
                 <Sparkline values={player.last10Minutes} playerName={player.name} />
                 <button
                   ref={(node) => registerTrigger(serializedPlayerId, node)}
@@ -217,7 +318,7 @@ function PlayerRail({
 function DietShareChips({ players, base, sliceKey, market }) {
   if (!SHARE_LABELS[base]) return null;
   const chips = players
-    .filter((player) => market === 'All' || player.postedMarkets.includes(market))
+    .filter((player) => market === 'All' || player.statCategories.includes(market))
     .flatMap((player) => {
       const share = getDisplayableDietShare(player, base, sliceKey);
       if (!share) return [];
@@ -244,6 +345,7 @@ function DefenseSheet({
   deviation,
   selectedPlayer,
   surfaceAvailability,
+  provenance,
 }) {
   let hidden = 0;
   const sections = Object.entries(team.defenseSheet).map(([base, rows]) => {
@@ -290,6 +392,7 @@ function DefenseSheet({
       <div className="section-heading">
         <p className="matchup-eyebrow">Relative concessions · per 48</p>
         <h2 id="defense-sheet-heading">{team.tricode} Defense Sheet</h2>
+        {provenance && <p className="sheet-provenance">{provenance}</p>}
       </div>
       <p className="hidden-count">
         {hidden} {hidden === 1 ? 'row' : 'rows'} hidden near league average.
@@ -514,19 +617,31 @@ function Detail({ matchup, gameId }) {
   const defenseTeam = matchup.teams.find((team) => team.teamId === teamId) || initialTeam;
   const opposingTeam = matchup.teams.find((team) => team.teamId !== defenseTeam.teamId);
   const opposingTeamId = opposingTeam?.teamId;
+  const historical = matchup.experience.mode === 'historical';
+  const sections = matchup.experience.sections;
   const poolAvailable = !['missing', 'unavailable'].includes(matchup.freshness.pool.status);
+  const participantsAvailable = historical
+    ? sections.participants.status === 'available'
+    : poolAvailable;
   const opposingPlayers = useMemo(
     () =>
-      poolAvailable ? matchup.players.filter((player) => player.teamId === opposingTeamId) : [],
-    [matchup.players, opposingTeamId, poolAvailable],
+      participantsAvailable
+        ? matchup.players.filter((player) => player.teamId === opposingTeamId)
+        : [],
+    [matchup.players, opposingTeamId, participantsAvailable],
   );
   const opposingGameTeam = [matchup.game.away, matchup.game.home].find(
     (team) => team.teamId === opposingTeamId,
   );
   const markets = useMemo(
-    () => ['All', ...new Set(opposingPlayers.flatMap((player) => player.postedMarkets))],
+    () => ['All', ...new Set(opposingPlayers.flatMap((player) => player.statCategories))],
     [opposingPlayers],
   );
+  const windowSection = historical
+    ? sections[windowKey === 'season' ? 'seasonDefense' : 'last15Defense']
+    : null;
+  const last15Section = historical ? sections.last15Defense : null;
+  const last15Blocked = Boolean(last15Section) && last15Section.status !== 'available';
   useEffect(() => {
     if (!markets.includes(market)) setMarket('All');
   }, [market, markets]);
@@ -538,7 +653,7 @@ function Detail({ matchup, gameId }) {
     const controller = new AbortController();
     let current = true;
     setSelectionState({ status: 'loading', playerId: selectedPlayer.id, data: null, error: null });
-    fetchMatchupSelection(gameId, selectedPlayer.id, selectedPlayer.postedMarkets, {
+    fetchMatchupSelection(gameId, selectedPlayer.id, selectedPlayer.statCategories, {
       signal: controller.signal,
     })
       .then((data) => {
@@ -582,12 +697,20 @@ function Detail({ matchup, gameId }) {
       <header className="matchup-heading">
         <div>
           <Link to="/matchups">← Back to slate</Link>
-          <p className="matchup-eyebrow">Open Team Sheets · live contract</p>
+          <p className="matchup-eyebrow">
+            {historical
+              ? 'Historical Matchup · stored evidence'
+              : 'Open Team Sheets · live contract'}
+          </p>
           <h1>
             {matchup.game.away.tricode} @ {matchup.game.home.tricode}
           </h1>
         </div>
-        <Freshness freshness={matchup.freshness} now={now} />
+        {historical ? (
+          <HistoricalEvidence sections={sections} />
+        ) : (
+          <Freshness freshness={matchup.freshness} now={now} />
+        )}
       </header>
       {matchup.game.preseason && (
         <p
@@ -604,14 +727,27 @@ function Detail({ matchup, gameId }) {
             Tap a player to trace their rows across the sheet; use the score card for the full
             dossier.
           </p>
-          <InjuryReport injuries={matchup.injuries} now={now} />
+          {historical && sections.injuries.status !== 'available' ? (
+            <section className="injury-report" aria-labelledby="injury-heading">
+              <h2 id="injury-heading">Injuries</h2>
+              <p className="honest-empty">{sectionReason(sections.injuries)}</p>
+            </section>
+          ) : (
+            <InjuryReport injuries={matchup.injuries} now={now} />
+          )}
           <PlayerRail
             players={opposingPlayers}
             injuries={matchup.injuries}
+            historical={historical}
+            unavailableMessage={
+              historical && !participantsAvailable ? sectionReason(sections.participants) : null
+            }
             market={market}
             windowKey={windowKey}
             targetableCount={
-              poolAvailable ? (opposingGameTeam?.targetablePlayerCount ?? null) : null
+              !historical && poolAvailable
+                ? (opposingGameTeam?.targetablePlayerCount ?? null)
+                : null
             }
             selectedId={selectedId}
             onSelect={(player) => updateSelectedPlayer(player.id)}
@@ -620,7 +756,11 @@ function Detail({ matchup, gameId }) {
         </div>
         <div className="matchup-workspace">
           <section className="detail-controls" aria-label="Defense Sheet controls">
-            <div className="segmented market-tabs" role="group" aria-label="Market">
+            <div
+              className="segmented market-tabs"
+              role="group"
+              aria-label={historical ? 'Stat category' : 'Market'}
+            >
               {markets.map((item) => (
                 <button
                   type="button"
@@ -638,6 +778,7 @@ function Detail({ matchup, gameId }) {
                   <button
                     type="button"
                     aria-pressed={windowKey === item.key}
+                    disabled={item.key === 'last15' && last15Blocked}
                     key={item.key}
                     onClick={() => setWindowKey(item.key)}
                   >
@@ -670,6 +811,10 @@ function Detail({ matchup, gameId }) {
                 ))}
               </div>
             </div>
+            {windowSection?.context && (
+              <p className="window-context">{contextLabel(windowSection)}</p>
+            )}
+            {last15Blocked && <p className="honest-empty">{sectionReason(last15Section)}</p>}
           </section>
           {selectedId && !selectedPlayer && (
             <p role="alert" className="selection-card">
@@ -690,22 +835,22 @@ function Detail({ matchup, gameId }) {
               onClose={() => updateSelectedPlayer(null)}
             />
           )}
-          {matchup.freshness.stats.status === 'missing' ? (
-            <section className="defense-sheet" aria-labelledby="defense-sheet-heading">
-              <h2 id="defense-sheet-heading">{defenseTeam.tricode} Defense Sheet</h2>
-              <p className="honest-empty">Defense Sheet unavailable because stats are missing.</p>
-            </section>
-          ) : (
-            <DefenseSheet
-              team={defenseTeam}
-              players={opposingPlayers}
-              market={market}
-              windowKey={windowKey}
-              deviation={deviation}
-              selectedPlayer={selectedPlayer?.teamId !== defenseTeam.teamId ? selectedPlayer : null}
-              surfaceAvailability={matchup.league.surfaceAvailability}
-            />
-          )}
+          {/* The Defense Sheet is governed by its own Surface availability. The
+              generic legacy stats freshness marker never suppresses it. */}
+          <DefenseSheet
+            team={defenseTeam}
+            players={opposingPlayers}
+            market={market}
+            windowKey={windowKey}
+            deviation={deviation}
+            selectedPlayer={selectedPlayer?.teamId !== defenseTeam.teamId ? selectedPlayer : null}
+            surfaceAvailability={matchup.league.surfaceAvailability}
+            provenance={
+              windowSection
+                ? `${WINDOWS.find((item) => item.key === windowKey).label} defense provenance: ${contextLabel(windowSection)} · ${sourceLabel(windowSection)}`
+                : null
+            }
+          />
         </div>
       </div>
     </>

--- a/src/matchups/MatchupDetailPage.js
+++ b/src/matchups/MatchupDetailPage.js
@@ -5,7 +5,7 @@ import { getRequestErrorMessage, isRequestCancelled } from '../gameLogsApi';
 import { formatAge, useMinuteNow } from '../freshness';
 import { getSurfaceFreshnessPresentation } from '../slateStatus';
 import { fetchMatchup, fetchMatchupSelection } from './matchupApi';
-import { getDisplayableDietShare } from './displayConfig';
+import { formatFocalGameLine, getDisplayableDietShare } from './displayConfig';
 import SelectionCard from './SelectionCard';
 import './MatchupDetailPage.css';
 
@@ -268,10 +268,10 @@ function PlayerRail({
                 )}
                 {historical && focalLine && (
                   <p className="focal-line">
-                    Focal game {focalLine.matchup} · {focalLine.minutes.toFixed(1)} MIN ·{' '}
-                    {(market === 'All' ? player.statCategories : [market])
-                      .map((category) => `${focalLine.stats[category].toFixed(1)} ${category}`)
-                      .join(' · ')}
+                    {formatFocalGameLine(
+                      focalLine,
+                      market === 'All' ? player.statCategories : [market],
+                    )}
                   </p>
                 )}
                 {historical && unscored && (

--- a/src/matchups/MatchupDetailPage.js
+++ b/src/matchups/MatchupDetailPage.js
@@ -170,9 +170,13 @@ function PlayerRail({
   );
   const windowScoreFor = (player) => player.scores[market]?.[windowKey] ?? null;
   // A score is unavailable, not zero, when the contract could not compute it.
+  // A Blend withheld alongside named missing inputs is an incomplete score, so
+  // no single component may stand in for it. A defensive category has no Blend
+  // by contract and names nothing missing, so its component is the whole score.
   const scoreFor = (player) => {
     const score = windowScoreFor(player);
     if (!score) return null;
+    if (score.blend === null && score.missingInputs.length > 0) return null;
     return score.blend?.value ?? Object.values(score.components)[0]?.value ?? null;
   };
   const byScore = sortMode === 'score' && market !== 'All';
@@ -621,7 +625,8 @@ function Detail({ matchup, gameId }) {
   const defenseTeam = matchup.teams.find((team) => team.teamId === teamId) || initialTeam;
   const opposingTeam = matchup.teams.find((team) => team.teamId !== defenseTeam.teamId);
   const opposingTeamId = opposingTeam?.teamId;
-  const historical = matchup.experience.mode === 'historical';
+  const experienceMode = matchup.experience.mode;
+  const historical = experienceMode === 'historical';
   const sections = matchup.experience.sections;
   const poolAvailable = !['missing', 'unavailable'].includes(matchup.freshness.pool.status);
   const participantsAvailable = historical
@@ -659,6 +664,7 @@ function Detail({ matchup, gameId }) {
     setSelectionState({ status: 'loading', playerId: selectedPlayer.id, data: null, error: null });
     fetchMatchupSelection(gameId, selectedPlayer.id, selectedPlayer.statCategories, {
       signal: controller.signal,
+      mode: experienceMode,
     })
       .then((data) => {
         if (current)
@@ -677,7 +683,7 @@ function Detail({ matchup, gameId }) {
       current = false;
       controller.abort();
     };
-  }, [gameId, selectedPlayer]);
+  }, [experienceMode, gameId, selectedPlayer]);
   useEffect(() => {
     if (previousSelectedId.current && !selectedId) {
       selectionTriggers.current.get(previousSelectedId.current)?.focus();

--- a/src/matchups/MatchupDetailPage.js
+++ b/src/matchups/MatchupDetailPage.js
@@ -65,6 +65,10 @@ const sectionReason = (section) =>
   SECTION_REASONS[section.unavailableReason] || `${section.unavailableReason}.`;
 const contextLabel = (section) => CONTEXT_LABELS[section.context] || section.context;
 const sourceLabel = (section) => SOURCE_LABELS[section.source] || section.source;
+// Collection time is provenance for immutable evidence, so it is stated as a
+// date rather than an age that would read as an operational staleness warning.
+const collectedLabel = (section) =>
+  section.collectedAt ? ` · collected ${section.collectedAt.slice(0, 10)}` : '';
 
 // Historical sections replace the live freshness bars: each one governs only its
 // own evidence, so a missing pool or stats marker cannot speak for the others.
@@ -77,7 +81,7 @@ function HistoricalEvidence({ sections }) {
           <span key={key}>
             <strong>{label}</strong>:{' '}
             {section.status === 'available'
-              ? `${contextLabel(section)} · from ${sourceLabel(section)}`
+              ? `${contextLabel(section)} · from ${sourceLabel(section)}${collectedLabel(section)}`
               : `${section.status} — ${sectionReason(section)}`}
           </span>
         );
@@ -172,7 +176,7 @@ function PlayerRail({
     return score.blend?.value ?? Object.values(score.components)[0]?.value ?? null;
   };
   const byScore = sortMode === 'score' && market !== 'All';
-  const rank = (a, b, valueOf) => {
+  const compareDescendingUnavailableLast = (a, b, valueOf) => {
     const first = valueOf(a);
     const second = valueOf(b);
     if ((first === null) !== (second === null)) return first === null ? 1 : -1;
@@ -184,8 +188,8 @@ function PlayerRail({
   );
   scoped.sort(
     (a, b) =>
-      (byScore ? rank(a, b, scoreFor) : 0) ||
-      rank(a, b, (player) => player.seasonScoring) ||
+      (byScore ? compareDescendingUnavailableLast(a, b, scoreFor) : 0) ||
+      compareDescendingUnavailableLast(a, b, (player) => player.seasonScoring) ||
       a.name.localeCompare(b.name),
   );
   return (

--- a/src/matchups/MatchupDetailPage.js
+++ b/src/matchups/MatchupDetailPage.js
@@ -665,6 +665,7 @@ function Detail({ matchup, gameId }) {
     fetchMatchupSelection(gameId, selectedPlayer.id, selectedPlayer.statCategories, {
       signal: controller.signal,
       mode: experienceMode,
+      focalGameLine: selectedPlayer.focalGameLine,
     })
       .then((data) => {
         if (current)

--- a/src/matchups/MatchupDetailPage.test.js
+++ b/src/matchups/MatchupDetailPage.test.js
@@ -32,11 +32,17 @@ const score = (season, last15 = season) => ({
   season: {
     components: { playTypes: { value: season, thin: false } },
     blend: { value: season, thin: false },
+    missingInputs: [],
   },
   last15: {
     components: { playTypes: { value: last15, thin: false } },
     blend: { value: last15, thin: false },
+    missingInputs: [],
   },
+});
+const unavailableScore = (missingInputs) => ({
+  season: { components: {}, blend: null, missingInputs },
+  last15: { components: {}, blend: null, missingInputs },
 });
 
 const matchup = {
@@ -46,6 +52,7 @@ const matchup = {
     home: { tricode: 'BOS' },
     preseason: false,
   },
+  experience: { mode: 'current', playerSource: 'player_pool', sections: null },
   league: {
     surfaceAvailability: Object.fromEntries(
       ['playTypes', 'shotZones', 'shotTypes', 'assistLocations', 'traditional'].map((base) => [
@@ -107,6 +114,9 @@ const matchup = {
       teamId: 1,
       tricode: 'LAL',
       postedMarkets: ['PTS', 'FG3A'],
+      statCategories: ['PTS', 'FG3A'],
+      playerSource: 'player_pool',
+      focalGameLine: null,
       provenance: { prizepicks: ['PTS', 'FG3A'], underdog: ['PTS'] },
       seasonScoring: 20.1,
       last10Minutes: [32, 35, 34],
@@ -127,6 +137,9 @@ const matchup = {
       teamId: 1,
       tricode: 'LAL',
       postedMarkets: ['PTS', 'FGA'],
+      statCategories: ['PTS', 'FGA'],
+      playerSource: 'player_pool',
+      focalGameLine: null,
       provenance: { prizepicks: ['PTS', 'FGA'], underdog: ['PTS'] },
       seasonScoring: 25.4,
       last10Minutes: [35, 36, 38],
@@ -147,6 +160,9 @@ const matchup = {
       teamId: 2,
       tricode: 'BOS',
       postedMarkets: ['REB'],
+      statCategories: ['REB'],
+      playerSource: 'player_pool',
+      focalGameLine: null,
       provenance: { prizepicks: ['REB'] },
       seasonScoring: 27.2,
       last10Minutes: [36, 37, 38],
@@ -328,6 +344,7 @@ test('names an unavailable surface window while leaving available surfaces usabl
   });
   const lebron = candidate.players.find((player) => player.id === 2544);
   lebron.postedMarkets.push('AST');
+  lebron.statCategories.push('AST');
   lebron.provenance.prizepicks.push('AST');
   lebron.scores.AST = score(0.05);
   candidate.teams.find((team) => team.tricode === 'BOS').defenseSheet.assistLocations = [
@@ -384,10 +401,19 @@ test('renders one relevant traditional unavailability notice for All and specifi
   });
   const lebron = candidate.players.find((player) => player.id === 2544);
   lebron.postedMarkets.push('TOV', 'AST');
+  lebron.statCategories.push('TOV', 'AST');
   lebron.provenance.prizepicks.push('TOV', 'AST');
   lebron.scores.TOV = {
-    season: { components: { traditional: { value: 0.03, thin: false } }, blend: null },
-    last15: { components: { traditional: { value: 0.02, thin: false } }, blend: null },
+    season: {
+      components: { traditional: { value: 0.03, thin: false } },
+      blend: null,
+      missingInputs: [],
+    },
+    last15: {
+      components: { traditional: { value: 0.02, thin: false } },
+      blend: null,
+      missingInputs: [],
+    },
   };
   lebron.scores.AST = score(0.05);
   fetchMatchup.mockResolvedValueOnce(candidate);
@@ -437,6 +463,7 @@ test('names an unavailable OPP_REB window without hiding other traditional marke
   ];
   const lebron = candidate.players.find((player) => player.id === 2544);
   lebron.postedMarkets.push('REB', 'TOV');
+  lebron.statCategories.push('REB', 'TOV');
   lebron.provenance.prizepicks.push('REB', 'TOV');
   fetchMatchup.mockResolvedValueOnce(candidate);
   render(
@@ -546,7 +573,7 @@ test('renders nullable season scoring and explains zero-component offensive scor
   const candidate = JSON.parse(JSON.stringify(matchup));
   const lebron = candidate.players.find((player) => player.id === 2544);
   lebron.seasonScoring = null;
-  lebron.scores.FGA.last15 = { components: {}, blend: null };
+  lebron.scores.FGA.last15 = { components: {}, blend: null, missingInputs: [] };
   fetchMatchup.mockResolvedValueOnce(candidate);
   render(
     <MemoryRouter initialEntries={['/matchups/game-1?player=2544']}>
@@ -785,6 +812,197 @@ test('card stat choices persist while a different global sheet market remains ac
   expect(cardStats.getByRole('button', { name: 'FGA' })).toHaveAttribute('aria-pressed', 'true');
   expect(sheetMarkets.getByRole('button', { name: 'PTS' })).toHaveAttribute('aria-pressed', 'true');
   expect(fetchMatchupSelection).toHaveBeenCalledTimes(1);
+});
+
+const historicalSection = (status, source, context, unavailableReason = null) => ({
+  status,
+  source,
+  context,
+  unavailableReason,
+});
+
+const historicalMatchup = () => {
+  const candidate = JSON.parse(JSON.stringify(matchup));
+  candidate.experience = {
+    mode: 'historical',
+    playerSource: 'game_logs',
+    sections: {
+      schedule: historicalSection('available', 'event_catalog', 'completed_season_catalog'),
+      participants: historicalSection('available', 'player_game_logs', 'completed_season'),
+      seasonDefense: historicalSection('available', 'team_matchup_publication', 'completed_season'),
+      last15Defense: historicalSection('unavailable', null, null, 'no_point_in_time_snapshot'),
+      injuries: historicalSection('unavailable', null, null, 'no_pregame_snapshot'),
+    },
+  };
+  // The production red signal: no stats_tables marker and no archived pool.
+  candidate.freshness.stats = { status: 'missing', retrievedAt: null };
+  candidate.freshness.pool = { status: 'unavailable', retrievedAt: null, providers: [] };
+  candidate.players.forEach((player, index) => {
+    player.playerSource = 'game_logs';
+    player.postedMarkets = [];
+    player.provenance = {};
+    player.injuryBadgeRef = null;
+    player.focalGameLine = {
+      gameId: 'game-1',
+      gameDate: '2026-03-29',
+      matchup: 'LAL @ BOS',
+      minutes: 30 + index,
+      stats: Object.fromEntries(
+        player.statCategories.map((category, offset) => [category, 10 + offset]),
+      ),
+    };
+  });
+  return candidate;
+};
+
+const renderMatchup = (path = '/matchups/game-1') =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/matchups/:gameId" element={<MatchupDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+test('renders Season defense from its own Surface while legacy stats freshness is missing', async () => {
+  fetchMatchup.mockResolvedValueOnce(historicalMatchup());
+  renderMatchup();
+
+  expect(await screen.findByRole('heading', { name: 'BOS Defense Sheet' })).toBeVisible();
+  expect(screen.getByText('Transition')).toBeVisible();
+  expect(
+    screen.queryByText('Defense Sheet unavailable because stats are missing.'),
+  ).not.toBeInTheDocument();
+
+  const evidence = screen.getByRole('region', { name: 'Historical matchup evidence' });
+  expect(screen.queryByRole('region', { name: 'Matchup data freshness' })).not.toBeInTheDocument();
+  expect(evidence).toHaveTextContent('Schedule: Completed-season catalog · from Event Catalog');
+  expect(evidence).toHaveTextContent('Participants: Completed-season context · from game logs');
+  expect(evidence).toHaveTextContent(
+    'Season defense: Completed-season context · from Defense Sheet publication',
+  );
+  expect(evidence).toHaveTextContent(
+    'Last 15 defense: unavailable — No point-in-time snapshot was captured for this game.',
+  );
+
+  expect(screen.getByText('Completed-season context')).toBeVisible();
+  expect(
+    screen.getByText(
+      'Season defense provenance: Completed-season context · Defense Sheet publication',
+    ),
+  ).toBeVisible();
+  expect(screen.getByRole('button', { name: 'Last 15' })).toBeDisabled();
+  expect(
+    screen.getAllByText('No point-in-time snapshot was captured for this game.').length,
+  ).toBeGreaterThan(0);
+  expect(screen.getByText('No pregame injury snapshot was archived for this game.')).toBeVisible();
+  expect(screen.queryByText('Left calf soreness')).not.toBeInTheDocument();
+});
+
+test('labels the historical rail Players in game and switches it with the defense team', async () => {
+  fetchMatchup.mockResolvedValueOnce(historicalMatchup());
+  renderMatchup();
+
+  const rail = await screen.findByRole('complementary', { name: 'Players in game' });
+  expect(within(rail).getByRole('article', { name: 'LeBron James player' })).toBeVisible();
+  expect(within(rail).getByRole('article', { name: 'Austin Reaves player' })).toBeVisible();
+  expect(
+    within(rail).queryByRole('article', { name: 'Jayson Tatum player' }),
+  ).not.toBeInTheDocument();
+  expect(screen.queryByText('Targetable players')).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole('group', { name: 'LeBron James posted markets' }),
+  ).not.toBeInTheDocument();
+  expect(screen.queryByRole('group', { name: 'Market' })).not.toBeInTheDocument();
+  expect(screen.getByRole('group', { name: 'Stat category' })).toBeVisible();
+
+  const lebron = within(rail).getByRole('article', { name: 'LeBron James player' });
+  expect(lebron).toHaveTextContent('25.4 PPG · completed-season context');
+  expect(lebron).toHaveTextContent('Focal game LAL @ BOS · 31.0 MIN · 10.0 PTS · 11.0 FGA');
+
+  await userEvent.click(screen.getByRole('button', { name: 'LAL defense' }));
+  expect(await screen.findByRole('article', { name: 'Jayson Tatum player' })).toBeVisible();
+  expect(screen.queryByRole('article', { name: 'LeBron James player' })).not.toBeInTheDocument();
+});
+
+test('keeps a participant with an unavailable score visible, named, and sorted last', async () => {
+  const candidate = historicalMatchup();
+  candidate.players.find((player) => player.id === 1630559).scores.PTS = unavailableScore([
+    'team_defense:play_types',
+    'player_diet:shot_zones',
+  ]);
+  fetchMatchup.mockResolvedValueOnce(candidate);
+  renderMatchup();
+
+  await screen.findByRole('heading', { name: 'BOS Defense Sheet' });
+  await userEvent.click(screen.getByRole('button', { name: 'PTS' }));
+  expect(
+    screen.getByText(
+      'PTS Matchup Score unavailable: missing team_defense:play_types, player_diet:shot_zones.',
+    ),
+  ).toBeVisible();
+
+  await userEvent.click(screen.getByRole('button', { name: 'Matchup Score' }));
+  const cards = screen.getAllByRole('article', { name: /player$/ });
+  expect(cards[0]).toHaveTextContent('LeBron James');
+  expect(cards.at(-1)).toHaveTextContent('Austin Reaves');
+});
+
+test('names an unavailable participant source while the Defense Sheet stays usable', async () => {
+  const candidate = historicalMatchup();
+  candidate.experience.sections.participants = historicalSection(
+    'unavailable',
+    null,
+    null,
+    'game_logs_incomplete',
+  );
+  fetchMatchup.mockResolvedValueOnce(candidate);
+  renderMatchup();
+
+  expect(await screen.findByRole('heading', { name: 'BOS Defense Sheet' })).toBeVisible();
+  expect(screen.getByText('Transition')).toBeVisible();
+  expect(screen.getByText('Canonical game logs are incomplete for this game.')).toBeVisible();
+  expect(screen.queryByRole('article', { name: 'LeBron James player' })).not.toBeInTheDocument();
+});
+
+test('separates the focal outcome from hindsight context in the historical dossier', async () => {
+  fetchMatchup.mockResolvedValueOnce(historicalMatchup());
+  fetchMatchupSelection.mockResolvedValueOnce({
+    playerId: 2544,
+    experience: {
+      mode: 'historical',
+      playerSource: 'game_logs',
+      focalGame: {
+        gameId: 'game-1',
+        gameDate: '2026-03-29',
+        matchup: 'LAL @ BOS',
+        minutes: 31,
+        stats: { PTS: 10, FGA: 11 },
+      },
+      samples: { context: 'pregame', excludesFocalGame: true },
+      baseline: { context: 'completed_season', hindsight: true },
+    },
+    h2h: { thin: false, rows: [] },
+    archetype: { thin: false, rows: [] },
+  });
+  renderMatchup('/matchups/game-1?player=2544');
+
+  expect(await screen.findByRole('heading', { name: 'LeBron James', level: 2 })).toBeVisible();
+  expect(
+    await screen.findByText('Pregame samples use games strictly before the focal game.'),
+  ).toBeVisible();
+  expect(
+    screen.getByText('Completed-season baseline — hindsight, not pregame evidence.'),
+  ).toBeVisible();
+  expect(
+    screen.getByText('Focal game LAL @ BOS · 2026-03-29 · 31.0 MIN · 10.0 PTS · 11.0 FGA'),
+  ).toBeVisible();
+  // The dossier is requested for governed Stat Categories, not posted markets.
+  expect(fetchMatchupSelection.mock.calls.at(-1).slice(0, 3)).toEqual([
+    'game-1',
+    2544,
+    ['PTS', 'FGA'],
+  ]);
 });
 
 test('selection request errors replace loading with an honest alert', async () => {

--- a/src/matchups/MatchupDetailPage.test.js
+++ b/src/matchups/MatchupDetailPage.test.js
@@ -1017,6 +1017,57 @@ test('keeps a participant with an unavailable score visible, named, and sorted l
   expect(cards.at(-1)).toHaveTextContent('Austin Reaves');
 });
 
+test('refuses to open a dossier for an unavailable participant', async () => {
+  const candidate = historicalMatchup();
+  candidate.experience.sections.participants = historicalSection(
+    'unavailable',
+    null,
+    null,
+    'game_logs_incomplete',
+  );
+  fetchMatchup.mockResolvedValueOnce(candidate);
+  renderMatchup('/matchups/game-1?player=2544');
+
+  await screen.findByRole('heading', { name: 'BOS Defense Sheet' });
+  expect(screen.getByText('That player is not available in this matchup.')).toBeVisible();
+  expect(screen.queryByRole('heading', { name: 'LeBron James', level: 2 })).not.toBeInTheDocument();
+  expect(fetchMatchupSelection).not.toHaveBeenCalled();
+});
+
+test('names the missing inputs of a withheld score in the dossier', async () => {
+  fetchMatchup.mockResolvedValueOnce(
+    withDefensiveScores(historicalMatchup(), ['team_defense:traditional']),
+  );
+  renderMatchup('/matchups/game-1?player=1630559');
+
+  await screen.findByRole('heading', { name: 'Austin Reaves', level: 2 });
+  // The component evidence survives, so the card must say why the score did not.
+  expect(screen.getByRole('table', { name: 'Austin Reaves Score Matrix' })).toHaveTextContent(
+    '+44%',
+  );
+  expect(
+    screen.getByText('TOV Matchup Score unavailable in Season: missing team_defense:traditional.'),
+  ).toBeVisible();
+});
+
+test('drops posted-market vocabulary from the historical dossier', async () => {
+  fetchMatchup.mockResolvedValueOnce(historicalMatchup());
+  renderMatchup('/matchups/game-1?player=2544');
+
+  await screen.findByRole('heading', { name: 'LeBron James', level: 2 });
+  const matrix = screen.getByRole('table', { name: 'LeBron James Score Matrix' });
+  expect(within(matrix).getByRole('columnheader', { name: 'Category' })).toBeVisible();
+  expect(within(matrix).queryByRole('columnheader', { name: 'Market' })).not.toBeInTheDocument();
+});
+
+test('keeps posted-market vocabulary in the live dossier', async () => {
+  renderMatchup('/matchups/game-1?player=2544');
+
+  await screen.findByRole('heading', { name: 'LeBron James', level: 2 });
+  const matrix = screen.getByRole('table', { name: 'LeBron James Score Matrix' });
+  expect(within(matrix).getByRole('columnheader', { name: 'Market' })).toBeVisible();
+});
+
 test('names an unavailable participant source while the Defense Sheet stays usable', async () => {
   const candidate = historicalMatchup();
   candidate.experience.sections.participants = historicalSection(

--- a/src/matchups/MatchupDetailPage.test.js
+++ b/src/matchups/MatchupDetailPage.test.js
@@ -865,6 +865,17 @@ const renderMatchup = (path = '/matchups/game-1') =>
     </MemoryRouter>,
   );
 
+test('keeps the live Defense Sheet gated on missing legacy stats freshness', async () => {
+  const candidate = JSON.parse(JSON.stringify(matchup));
+  candidate.freshness.stats = { status: 'missing', retrievedAt: null };
+  fetchMatchup.mockResolvedValueOnce(candidate);
+  renderMatchup();
+
+  expect(await screen.findByRole('heading', { name: 'BOS Defense Sheet' })).toBeVisible();
+  expect(screen.getByText('Defense Sheet unavailable because stats are missing.')).toBeVisible();
+  expect(screen.queryByText('Transition')).not.toBeInTheDocument();
+});
+
 test('renders Season defense from its own Surface while legacy stats freshness is missing', async () => {
   fetchMatchup.mockResolvedValueOnce(historicalMatchup());
   renderMatchup();

--- a/src/matchups/MatchupDetailPage.test.js
+++ b/src/matchups/MatchupDetailPage.test.js
@@ -819,6 +819,7 @@ const historicalSection = (status, source, context, unavailableReason = null) =>
   source,
   context,
   unavailableReason,
+  collectedAt: null,
 });
 
 const historicalMatchup = () => {
@@ -897,6 +898,22 @@ test('renders Season defense from its own Surface while legacy stats freshness i
   ).toBeGreaterThan(0);
   expect(screen.getByText('No pregame injury snapshot was archived for this game.')).toBeVisible();
   expect(screen.queryByText('Left calf soreness')).not.toBeInTheDocument();
+});
+
+test('states schedule collection time as provenance rather than a staleness warning', async () => {
+  const candidate = historicalMatchup();
+  candidate.experience.sections.schedule.collectedAt = '2026-03-30T04:10:00.000Z';
+  fetchMatchup.mockResolvedValueOnce(candidate);
+  renderMatchup();
+
+  await screen.findByRole('heading', { name: 'BOS Defense Sheet' });
+  const evidence = screen.getByRole('region', { name: 'Historical matchup evidence' });
+  expect(evidence).toHaveTextContent(
+    'Schedule: Completed-season catalog · from Event Catalog · collected 2026-03-30',
+  );
+  expect(evidence).not.toHaveTextContent('warning');
+  expect(evidence).not.toHaveTextContent('ago');
+  expect(evidence.querySelector('.matchup-warning')).not.toBeInTheDocument();
 });
 
 test('labels the historical rail Players in game and switches it with the defense team', async () => {

--- a/src/matchups/MatchupDetailPage.test.js
+++ b/src/matchups/MatchupDetailPage.test.js
@@ -911,9 +911,12 @@ test('states schedule collection time as provenance rather than a staleness warn
   expect(evidence).toHaveTextContent(
     'Schedule: Completed-season catalog · from Event Catalog · collected 2026-03-30',
   );
-  expect(evidence).not.toHaveTextContent('warning');
+  // The live bars say "<surface> data warning" and age their timestamps. An
+  // immutable completed season states neither.
+  expect(evidence).not.toHaveTextContent('data warning');
   expect(evidence).not.toHaveTextContent('ago');
-  expect(evidence.querySelector('.matchup-warning')).not.toBeInTheDocument();
+  expect(evidence).not.toHaveTextContent('stale');
+  expect(screen.queryByText(/schedule: .*, as of/i)).not.toBeInTheDocument();
 });
 
 test('labels the historical rail Players in game and switches it with the defense team', async () => {

--- a/src/matchups/MatchupDetailPage.test.js
+++ b/src/matchups/MatchupDetailPage.test.js
@@ -942,6 +942,55 @@ test('labels the historical rail Players in game and switches it with the defens
   expect(screen.queryByRole('article', { name: 'LeBron James player' })).not.toBeInTheDocument();
 });
 
+// A defensive category has no Blend by contract, so its component carries the
+// score. That is the reachable shape in which a withheld score can still ship
+// component evidence: the offensive case is already rejected by the decoder.
+const withDefensiveScores = (candidate, missingInputs) => {
+  candidate.players.forEach((player) => {
+    player.statCategories = [...player.statCategories, 'TOV'];
+    player.scores.TOV = {
+      season: {
+        components: { traditional: { value: player.id === 1630559 ? 0.44 : 0.12, thin: false } },
+        blend: null,
+        missingInputs: player.id === 1630559 ? missingInputs : [],
+      },
+      last15: { components: {}, blend: null, missingInputs: [] },
+    };
+    player.focalGameLine.stats.TOV = 2;
+  });
+  return candidate;
+};
+
+test('treats a withheld score with named missing inputs as unavailable', async () => {
+  fetchMatchup.mockResolvedValueOnce(
+    withDefensiveScores(historicalMatchup(), ['team_defense:traditional']),
+  );
+  renderMatchup();
+
+  await screen.findByRole('heading', { name: 'BOS Defense Sheet' });
+  await userEvent.click(screen.getByRole('button', { name: 'TOV' }));
+  expect(
+    screen.getByText('TOV Matchup Score unavailable: missing team_defense:traditional.'),
+  ).toBeVisible();
+
+  // 0.44 would outrank every complete score if the component were promoted.
+  await userEvent.click(screen.getByRole('button', { name: 'Matchup Score' }));
+  const cards = screen.getAllByRole('article', { name: /player$/ });
+  expect(cards[0]).toHaveTextContent('LeBron James');
+  expect(cards.at(-1)).toHaveTextContent('Austin Reaves');
+});
+
+test('keeps a complete defensive score available from its only component', async () => {
+  fetchMatchup.mockResolvedValueOnce(withDefensiveScores(historicalMatchup(), []));
+  renderMatchup();
+
+  await screen.findByRole('heading', { name: 'BOS Defense Sheet' });
+  await userEvent.click(screen.getByRole('button', { name: 'TOV' }));
+  expect(screen.queryByText(/TOV Matchup Score unavailable/)).not.toBeInTheDocument();
+  await userEvent.click(screen.getByRole('button', { name: 'Matchup Score' }));
+  expect(screen.getAllByRole('article', { name: /player$/ })[0]).toHaveTextContent('Austin Reaves');
+});
+
 test('keeps a participant with an unavailable score visible, named, and sorted last', async () => {
   const candidate = historicalMatchup();
   candidate.players.find((player) => player.id === 1630559).scores.PTS = unavailableScore([

--- a/src/matchups/SelectionCard.js
+++ b/src/matchups/SelectionCard.js
@@ -60,6 +60,7 @@ export default function SelectionCard({
   windowKey,
   sheetMarket,
   whyRelevant,
+  historical,
   onClose,
 }) {
   const panelRef = useRef(null);
@@ -143,7 +144,7 @@ export default function SelectionCard({
         <table aria-label={`${player.name} Score Matrix`}>
           <thead>
             <tr>
-              <th scope="col">Market</th>
+              <th scope="col">{historical ? 'Category' : 'Market'}</th>
               {bases.map((base) => (
                 <th scope="col" key={base}>
                   {BASE_LABELS[base] || base}
@@ -190,6 +191,16 @@ export default function SelectionCard({
         .map(({ market }) => (
           <p className="honest-empty" key={`degraded-${market}`}>
             No score components were computable for {market} in {WINDOW_LABELS[windowKey]}.
+          </p>
+        ))}
+      {/* Component evidence can survive a score the contract could not
+          complete, so the card names what that score was missing. */}
+      {rows
+        .filter(({ score }) => score.blend === null && score.missingInputs.length > 0)
+        .map(({ market, score }) => (
+          <p className="honest-empty" key={`withheld-${market}`}>
+            {market} Matchup Score unavailable in {WINDOW_LABELS[windowKey]}: missing{' '}
+            {score.missingInputs.join(', ')}.
           </p>
         ))}
       {status === 'loading' && <p role="status">Loading selection logs…</p>}

--- a/src/matchups/SelectionCard.js
+++ b/src/matchups/SelectionCard.js
@@ -65,7 +65,7 @@ export default function SelectionCard({
   const previousPlayerId = useRef(player.id);
   const previousSheetMarket = useRef(sheetMarket);
   const [activeStat, setActiveStat] = useState(
-    player.postedMarkets.includes(sheetMarket) ? sheetMarket : player.postedMarkets[0],
+    player.statCategories.includes(sheetMarket) ? sheetMarket : player.statCategories[0],
   );
   useEffect(() => panelRef.current?.focus(), [player.id]);
   useEffect(() => {
@@ -73,21 +73,21 @@ export default function SelectionCard({
     const sheetMarketChanged = previousSheetMarket.current !== sheetMarket;
     setActiveStat((current) => {
       if (playerChanged) {
-        return player.postedMarkets.includes(sheetMarket) ? sheetMarket : player.postedMarkets[0];
+        return player.statCategories.includes(sheetMarket) ? sheetMarket : player.statCategories[0];
       }
       if (
         sheetMarketChanged &&
         sheetMarket !== 'All' &&
-        player.postedMarkets.includes(sheetMarket)
+        player.statCategories.includes(sheetMarket)
       ) {
         return sheetMarket;
       }
-      return player.postedMarkets.includes(current) ? current : player.postedMarkets[0];
+      return player.statCategories.includes(current) ? current : player.statCategories[0];
     });
     previousPlayerId.current = player.id;
     previousSheetMarket.current = sheetMarket;
-  }, [player.id, player.postedMarkets, sheetMarket]);
-  const rows = player.postedMarkets.map((market) => ({
+  }, [player.id, player.statCategories, sheetMarket]);
+  const rows = player.statCategories.map((market) => ({
     market,
     score: player.scores[market][windowKey],
   }));
@@ -119,8 +119,17 @@ export default function SelectionCard({
           : 'This player is not opposing the viewed Defense Sheet, so no why rows are highlighted.'}{' '}
         Scores and deltas are delivered by the API.
       </p>
+      {player.focalGameLine && (
+        <p className="focal-line">
+          Focal game {player.focalGameLine.matchup} · {player.focalGameLine.gameDate} ·{' '}
+          {player.focalGameLine.minutes.toFixed(1)} MIN ·{' '}
+          {player.statCategories
+            .map((category) => `${player.focalGameLine.stats[category].toFixed(1)} ${category}`)
+            .join(' · ')}
+        </p>
+      )}
       <div className="selection-stat-control" role="group" aria-label="Selection log stat">
-        {player.postedMarkets.map((market) => (
+        {player.statCategories.map((market) => (
           <button
             type="button"
             key={market}
@@ -188,6 +197,16 @@ export default function SelectionCard({
       {status === 'error' && <p role="alert">{error}</p>}
       {status === 'ready' && (
         <div className="selection-logs">
+          {selection.experience?.samples.excludesFocalGame && (
+            <p className="selection-provenance">
+              Pregame samples use games strictly before the focal game.
+            </p>
+          )}
+          {selection.experience?.baseline.hindsight && (
+            <p className="selection-provenance">
+              Completed-season baseline — hindsight, not pregame evidence.
+            </p>
+          )}
           <LogTable title="Games vs this opponent" table={selection.h2h} market={activeStat} />
           <LogTable title="Archetype sample" table={selection.archetype} market={activeStat} />
         </div>

--- a/src/matchups/SelectionCard.js
+++ b/src/matchups/SelectionCard.js
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { formatFocalGameLine } from './displayConfig';
 
 const BASE_LABELS = {
   playTypes: 'Play types',
@@ -121,11 +122,9 @@ export default function SelectionCard({
       </p>
       {player.focalGameLine && (
         <p className="focal-line">
-          Focal game {player.focalGameLine.matchup} · {player.focalGameLine.gameDate} ·{' '}
-          {player.focalGameLine.minutes.toFixed(1)} MIN ·{' '}
-          {player.statCategories
-            .map((category) => `${player.focalGameLine.stats[category].toFixed(1)} ${category}`)
-            .join(' · ')}
+          {formatFocalGameLine(player.focalGameLine, player.statCategories, {
+            includeDate: true,
+          })}
         </p>
       )}
       <div className="selection-stat-control" role="group" aria-label="Selection log stat">

--- a/src/matchups/displayConfig.js
+++ b/src/matchups/displayConfig.js
@@ -14,6 +14,16 @@ export const shouldDisplayDietShare = (base, value) => {
   );
 };
 
+// The focal outcome reads the same in the rail and the dossier. The rail scopes
+// to the selected category; the dossier dates the game it is contextualizing.
+export const formatFocalGameLine = (focalGameLine, categories, { includeDate = false } = {}) =>
+  [
+    `Focal game ${focalGameLine.matchup}`,
+    ...(includeDate ? [focalGameLine.gameDate] : []),
+    `${focalGameLine.minutes.toFixed(1)} MIN`,
+    ...categories.map((category) => `${focalGameLine.stats[category].toFixed(1)} ${category}`),
+  ].join(' · ');
+
 export const getDisplayableDietShare = (player, base, sliceKey) => {
   const value = player.dietShares[base]?.find((entry) => entry.key === sliceKey)?.season;
   return value && shouldDisplayDietShare(base, value) ? value : null;

--- a/src/matchups/displayConfig.test.js
+++ b/src/matchups/displayConfig.test.js
@@ -1,4 +1,4 @@
-import { shouldDisplayDietShare } from './displayConfig';
+import { formatFocalGameLine, shouldDisplayDietShare } from './displayConfig';
 
 test.each([
   ['playTypes', { share: 0.15, volumePerGame: 0 }, true],
@@ -11,4 +11,25 @@ test.each([
   ['assistLocations', { share: 0.35, volumePerGame: 0.99 }, false],
 ])('%s gating returns %s for the named share and volume floors', (base, value, expected) => {
   expect(shouldDisplayDietShare(base, value)).toBe(expected);
+});
+
+const focalGameLine = {
+  gameId: '0022501082',
+  gameDate: '2026-03-29',
+  matchup: 'LAC @ MIL',
+  minutes: 34.5,
+  stats: { PTS: 24, REB: 5, AST: 7 },
+};
+
+test('states the focal game line the same way wherever it is shown', () => {
+  expect(formatFocalGameLine(focalGameLine, ['PTS', 'REB', 'AST'])).toBe(
+    'Focal game LAC @ MIL · 34.5 MIN · 24.0 PTS · 5.0 REB · 7.0 AST',
+  );
+  // The rail scopes to the selected category; the dossier dates the outcome.
+  expect(formatFocalGameLine(focalGameLine, ['REB'])).toBe(
+    'Focal game LAC @ MIL · 34.5 MIN · 5.0 REB',
+  );
+  expect(formatFocalGameLine(focalGameLine, ['PTS'], { includeDate: true })).toBe(
+    'Focal game LAC @ MIL · 2026-03-29 · 34.5 MIN · 24.0 PTS',
+  );
 });

--- a/src/matchups/matchupApi.js
+++ b/src/matchups/matchupApi.js
@@ -468,9 +468,18 @@ const decodeFocalGameLine = (line, statCategories) =>
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
+// A date fence is only meaningful over real calendar dates, so a string that
+// merely looks sortable is not one.
+const isCalendarDate = (value) => {
+  if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const parsed = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
+};
+
 // A game's local calendar date is either the UTC date of its tip or the day
 // before it, for every North American time zone the league plays in.
 const focalDateFits = (gameDate, scheduledAt) => {
+  if (!isCalendarDate(gameDate)) return false;
   const utcDate = scheduledAt.slice(0, 10);
   const dayBefore = new Date(new Date(`${utcDate}T00:00:00Z`).getTime() - DAY_MS)
     .toISOString()
@@ -532,7 +541,7 @@ const decodePlayer = (player, experience, game) => {
     dietShares: decodeDietShares(player.diet_shares),
     injuryBadgeRef:
       player.injury_badge_ref === null ? null : requireString(player.injury_badge_ref),
-    scores: decodeScores(player.scores, statCategories),
+    scores: decodeScores(player.scores, statCategories, gameLogSourced),
   };
 };
 
@@ -694,7 +703,7 @@ const decodeScoreCell = (cell) => {
 
 const DEFENSIVE_SCORE_MARKETS = new Set(['TOV', 'STL', 'BLK', 'STKS']);
 
-const decodeScoreWindow = (window, market) => {
+const decodeScoreWindow = (window, market, historical) => {
   if (!isRecord(window) || !isRecord(window.components)) throw invalid();
   const defensive = DEFENSIVE_SCORE_MARKETS.has(market);
   const componentBases = Object.keys(window.components);
@@ -703,11 +712,6 @@ const decodeScoreWindow = (window, market) => {
     (defensive && componentBases.some((base) => base !== 'traditional'))
   )
     throw invalid();
-  const componentCount = Object.keys(window.components).length;
-  const validOffensiveBlend = componentCount === 0 ? window.blend === null : isRecord(window.blend);
-  if ((!defensive && !validOffensiveBlend) || (defensive && window.blend != null)) {
-    throw invalid();
-  }
   const missingInputs =
     window.missing_inputs === undefined ? [] : requireStringList(window.missing_inputs);
   if (
@@ -716,6 +720,17 @@ const decodeScoreWindow = (window, market) => {
   ) {
     throw invalid();
   }
+  const componentCount = componentBases.length;
+  // A historical window may show its components while withholding a Blend the
+  // score contract could not complete, and names what was missing. It may never
+  // present a Blend as complete while naming a missing input.
+  const withheldBlend = historical && window.blend === null && missingInputs.length > 0;
+  const validOffensiveBlend =
+    componentCount === 0 ? window.blend === null : isRecord(window.blend) || withheldBlend;
+  if ((!defensive && !validOffensiveBlend) || (defensive && window.blend != null)) {
+    throw invalid();
+  }
+  if (historical && isRecord(window.blend) && missingInputs.length > 0) throw invalid();
   return {
     components: Object.fromEntries(
       Object.entries(window.components).map(([base, cell]) => [
@@ -728,7 +743,7 @@ const decodeScoreWindow = (window, market) => {
   };
 };
 
-function decodeScores(scores, statCategories) {
+function decodeScores(scores, statCategories, historical) {
   if (
     !isRecord(scores) ||
     Object.keys(scores).sort().join() !== [...statCategories].sort().join() ||
@@ -744,8 +759,8 @@ function decodeScores(scores, statCategories) {
     statCategories.map((category) => [
       category,
       {
-        season: decodeScoreWindow(scores[category].season, category),
-        last15: decodeScoreWindow(scores[category].last_15, category),
+        season: decodeScoreWindow(scores[category].season, category, historical),
+        last15: decodeScoreWindow(scores[category].last_15, category, historical),
       },
     ]),
   );
@@ -920,6 +935,20 @@ const decodeInjuries = (injuries, matchupTeams) => {
   };
 };
 
+// A defense section speaks for one window's Surfaces and for nothing else, so
+// each window's section status must agree with what that window delivered.
+const validateSectionSurfaces = (sections, surfaceAvailability) => {
+  [
+    ['season', sections.seasonDefense],
+    ['last15', sections.last15Defense],
+  ].forEach(([windowKey, section]) => {
+    const delivered = Object.values(surfaceAvailability).some(
+      (windows) => windows[windowKey].status === 'available',
+    );
+    if (delivered !== (section.status === 'available')) throw invalid();
+  });
+};
+
 export const decodeMatchup = (data) => {
   if (
     !isRecord(data) ||
@@ -943,6 +972,23 @@ export const decodeMatchup = (data) => {
     throw invalid();
   const experience = decodeExperience(data.experience);
   const game = decodeGame(data.game);
+  // The sheets the toggle switches between are this game's two teams, away
+  // then home, under the identities the game header records.
+  if (
+    teams.some(
+      (team, index) =>
+        team.teamId !== [game.away, game.home][index].teamId ||
+        team.tricode !== [game.away, game.home][index].tricode,
+    )
+  ) {
+    throw invalid();
+  }
+  // Historical mode describes a completed, non-postponed Regular Season game.
+  // The mode itself stays backend-declared; only its coherence is checked.
+  if (experience.mode === 'historical' && (game.status !== 'final' || game.preseason)) {
+    throw invalid();
+  }
+  if (experience.sections) validateSectionSurfaces(experience.sections, league.surfaceAvailability);
   const players = data.players.map((player) => decodePlayer(player, experience, game));
   // One game is focal, so every participant's line has to date it the same way.
   const focalDates = new Set(
@@ -982,7 +1028,13 @@ const decodeLogLine = (line, markets, focalGame) => {
   }
   // A pregame sample is strictly earlier than the game it contextualizes, which
   // is what excludes the focal game itself rather than a flag claiming so.
-  if (!average && focalGame && line.game_date >= focalGame.gameDate) throw selectionInvalid();
+  if (
+    !average &&
+    focalGame &&
+    (!isCalendarDate(line.game_date) || line.game_date >= focalGame.gameDate)
+  ) {
+    throw selectionInvalid();
+  }
   return {
     date: line.game_date,
     matchup: average ? null : requireSelectionString(line.matchup),
@@ -1065,6 +1117,7 @@ const decodeSelectionExperience = (experience, statCategories, expected) => {
     throw selectionInvalid();
   }
   const focalGame = decodeFocalGame(experience.focal_game, statCategories);
+  if (focalGame !== null && !isCalendarDate(focalGame.gameDate)) throw selectionInvalid();
   // The dossier contextualizes the focal game the client asked about, and it
   // cannot contradict the participant's own line for that game.
   if (focalGame !== null && expected.gameId !== undefined && focalGame.gameId !== expected.gameId) {

--- a/src/matchups/matchupApi.js
+++ b/src/matchups/matchupApi.js
@@ -64,21 +64,6 @@ const EXPERIENCE_SECTIONS = [
   'last_15_defense',
   'injuries',
 ];
-const SECTION_SOURCES = [
-  'event_catalog',
-  'player_game_logs',
-  'player_pool',
-  'team_matchup_publication',
-  'rotowire',
-];
-const SECTION_CONTEXTS = [
-  'completed_season_catalog',
-  'current_season_catalog',
-  'completed_season',
-  'pregame',
-  'posted_markets',
-  'current',
-];
 const MISSING_INPUT_PATTERN = new RegExp(
   `^(?:player_season_rate|(?:team_defense|player_diet):(?:${DEFENSE_BASES.join('|')}))$`,
 );
@@ -184,12 +169,25 @@ const SECTION_STATE_KEYS = ['status', 'source', 'context', 'unavailable_reason']
 // as pregame, and a live slate cannot be described as hindsight, so a response
 // that mixes them is incoherent rather than merely unusual.
 const MODE_PLAYER_SOURCES = { historical: 'game_logs', current: 'player_pool' };
-const MODE_ONLY_CONTEXTS = {
-  historical: ['completed_season_catalog', 'completed_season'],
-  current: ['current_season_catalog', 'pregame', 'posted_markets', 'current'],
+// Provenance is owned by the section, not the mode. Each section names the one
+// source and context its own evidence can truthfully have. Historical Last-15
+// and injuries describe archived pregame snapshots when any were captured.
+const SECTION_PROVENANCE = {
+  historical: {
+    schedule: { source: 'event_catalog', context: 'completed_season_catalog' },
+    participants: { source: 'player_game_logs', context: 'completed_season' },
+    season_defense: { source: 'team_matchup_publication', context: 'completed_season' },
+    last_15_defense: { source: 'team_matchup_publication', context: 'pregame' },
+    injuries: { source: 'rotowire', context: 'pregame' },
+  },
+  current: {
+    schedule: { source: 'event_catalog', context: 'current_season_catalog' },
+    participants: { source: 'player_pool', context: 'posted_markets' },
+    season_defense: { source: 'team_matchup_publication', context: 'pregame' },
+    last_15_defense: { source: 'team_matchup_publication', context: 'pregame' },
+    injuries: { source: 'rotowire', context: 'current' },
+  },
 };
-const MODE_ONLY_SOURCES = { historical: ['player_game_logs'], current: ['player_pool'] };
-const otherMode = (mode) => (mode === 'historical' ? 'current' : 'historical');
 
 // Only the schedule section carries collection provenance. It is immutable
 // evidence of a completed season, never an age-based staleness signal.
@@ -201,10 +199,8 @@ const decodeExperienceSection = (section, name, mode) => {
     SECTION_STATE_KEYS.some((key) => !Object.hasOwn(section, key)) ||
     Object.keys(section).some((key) => !allowedKeys.includes(key)) ||
     !['available', 'unavailable', 'missing'].includes(section.status) ||
-    (section.source !== null && !SECTION_SOURCES.includes(section.source)) ||
-    (section.context !== null && !SECTION_CONTEXTS.includes(section.context)) ||
-    MODE_ONLY_CONTEXTS[otherMode(mode)].includes(section.context) ||
-    MODE_ONLY_SOURCES[otherMode(mode)].includes(section.source) ||
+    (section.source !== null && section.source !== SECTION_PROVENANCE[mode][name].source) ||
+    (section.context !== null && section.context !== SECTION_PROVENANCE[mode][name].context) ||
     // An available section owns its evidence, so it must name where that
     // evidence came from and what it describes.
     (section.status === 'available'
@@ -470,9 +466,26 @@ const decodeFocalGameLine = (line, statCategories) =>
     requireValue: requireNumber,
   });
 
-const decodePlayer = (player, experience, gameId) => {
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// A game's local calendar date is either the UTC date of its tip or the day
+// before it, for every North American time zone the league plays in.
+const focalDateFits = (gameDate, scheduledAt) => {
+  const utcDate = scheduledAt.slice(0, 10);
+  const dayBefore = new Date(new Date(`${utcDate}T00:00:00Z`).getTime() - DAY_MS)
+    .toISOString()
+    .slice(0, 10);
+  return gameDate === utcDate || gameDate === dayBefore;
+};
+
+const decodePlayer = (player, experience, game) => {
   if (!isRecord(player) || !Number.isInteger(player.team_id)) throw invalid();
   if (!Array.isArray(player.last_10_minutes)) throw invalid();
+  // A participant played for one of this game's two teams, under the identity
+  // the game header records for it.
+  const tricode = requireString(player.tricode);
+  const focalTeam = [game.away, game.home].find((team) => team.teamId === player.team_id);
+  if (!focalTeam || focalTeam.tricode !== tricode) throw invalid();
   // A participant cannot claim a different source than its own experience.
   const playerSource = player.player_source ?? experience.playerSource;
   if (!PLAYER_SOURCES.includes(playerSource) || playerSource !== experience.playerSource)
@@ -493,14 +506,22 @@ const decodePlayer = (player, experience, gameId) => {
     throw invalid();
   const focalGameLine = decodeFocalGameLine(player.focal_game_line, statCategories);
   // A historical participant always has a focal line; a pool player never does.
-  // The line is evidence about this game, so it cannot describe another one.
+  // The line is evidence about this game, so its game, matchup identity, and
+  // date must all be this game's.
   if (gameLogSourced ? focalGameLine === null : focalGameLine !== null) throw invalid();
-  if (focalGameLine !== null && focalGameLine.gameId !== gameId) throw invalid();
+  if (
+    focalGameLine !== null &&
+    (focalGameLine.gameId !== game.gameId ||
+      focalGameLine.matchup !== `${game.away.tricode} @ ${game.home.tricode}` ||
+      !focalDateFits(focalGameLine.gameDate, game.scheduledAt))
+  ) {
+    throw invalid();
+  }
   return {
     id: requireInteger(player.canonical_id),
     name: requireString(player.name),
     teamId: player.team_id,
-    tricode: requireString(player.tricode),
+    tricode,
     playerSource,
     postedMarkets,
     statCategories,
@@ -922,15 +943,13 @@ export const decodeMatchup = (data) => {
     throw invalid();
   const experience = decodeExperience(data.experience);
   const game = decodeGame(data.game);
-  return {
-    game,
-    experience,
-    league,
-    teams,
-    players: data.players.map((player) => decodePlayer(player, experience, game.gameId)),
-    injuries,
-    freshness,
-  };
+  const players = data.players.map((player) => decodePlayer(player, experience, game));
+  // One game is focal, so every participant's line has to date it the same way.
+  const focalDates = new Set(
+    players.map((player) => player.focalGameLine?.gameDate).filter(Boolean),
+  );
+  if (focalDates.size > 1) throw invalid();
+  return { game, experience, league, teams, players, injuries, freshness };
 };
 
 export const fetchMatchup = async (gameId, { signal } = {}) => {
@@ -951,7 +970,7 @@ const decodeSelectionStatMap = (value, markets) => {
   );
 };
 
-const decodeLogLine = (line, markets) => {
+const decodeLogLine = (line, markets, focalGame) => {
   if (!isRecord(line)) throw selectionInvalid();
   if (!['game', 'average'].includes(line.row_type)) throw selectionInvalid();
   const average = line.row_type === 'average';
@@ -961,6 +980,9 @@ const decodeLogLine = (line, markets) => {
   ) {
     throw selectionInvalid();
   }
+  // A pregame sample is strictly earlier than the game it contextualizes, which
+  // is what excludes the focal game itself rather than a flag claiming so.
+  if (!average && focalGame && line.game_date >= focalGame.gameDate) throw selectionInvalid();
   return {
     date: line.game_date,
     matchup: average ? null : requireSelectionString(line.matchup),
@@ -971,10 +993,10 @@ const decodeLogLine = (line, markets) => {
   };
 };
 
-const decodeLogTable = (table, markets) => {
+const decodeLogTable = (table, markets, focalGame) => {
   if (!isRecord(table) || !Array.isArray(table.rows) || typeof table.thin !== 'boolean')
     throw selectionInvalid();
-  const rows = table.rows.map((row) => decodeLogLine(row, markets));
+  const rows = table.rows.map((row) => decodeLogLine(row, markets, focalGame));
   if (rows.some((row, index) => row.average && index !== rows.length - 1)) {
     throw selectionInvalid();
   }
@@ -1043,8 +1065,24 @@ const decodeSelectionExperience = (experience, statCategories, expected) => {
     throw selectionInvalid();
   }
   const focalGame = decodeFocalGame(experience.focal_game, statCategories);
-  // The dossier contextualizes the focal game the client asked about.
+  // The dossier contextualizes the focal game the client asked about, and it
+  // cannot contradict the participant's own line for that game.
   if (focalGame !== null && expected.gameId !== undefined && focalGame.gameId !== expected.gameId) {
+    throw selectionInvalid();
+  }
+  const line = expected.focalGameLine;
+  if (
+    focalGame !== null &&
+    line &&
+    (focalGame.gameId !== line.gameId ||
+      focalGame.gameDate !== line.gameDate ||
+      focalGame.matchup !== line.matchup ||
+      focalGame.minutes !== line.minutes ||
+      Object.entries(line.stats).some(
+        ([category, value]) =>
+          focalGame.stats[category] !== undefined && focalGame.stats[category] !== value,
+      ))
+  ) {
     throw selectionInvalid();
   }
   return {
@@ -1070,11 +1108,13 @@ export const decodeMatchupSelection = (data, statCategories, expectedPlayerId, e
   if (!Number.isInteger(data.player_id) || data.player_id !== expectedPlayerId) {
     throw selectionInvalid();
   }
+  const experience = decodeSelectionExperience(data.experience, statCategories, expected);
+  const focalGame = experience?.mode === 'historical' ? experience.focalGame : null;
   return {
     playerId: data.player_id,
-    experience: decodeSelectionExperience(data.experience, statCategories, expected),
-    h2h: decodeLogTable(data.h2h, statCategories),
-    archetype: decodeLogTable(data.archetype, statCategories),
+    experience,
+    h2h: decodeLogTable(data.h2h, statCategories, focalGame),
+    archetype: decodeLogTable(data.archetype, statCategories, focalGame),
   };
 };
 
@@ -1082,7 +1122,7 @@ export const fetchMatchupSelection = async (
   gameId,
   playerId,
   statCategories,
-  { signal, mode } = {},
+  { signal, mode, focalGameLine } = {},
 ) => {
   if (
     typeof gameId !== 'string' ||
@@ -1096,5 +1136,9 @@ export const fetchMatchupSelection = async (
     params: { game_id: gameId, player_id: playerId },
     signal,
   });
-  return decodeMatchupSelection(response.data, statCategories, playerId, { gameId, mode });
+  return decodeMatchupSelection(response.data, statCategories, playerId, {
+    gameId,
+    mode,
+    focalGameLine,
+  });
 };

--- a/src/matchups/matchupApi.js
+++ b/src/matchups/matchupApi.js
@@ -976,14 +976,18 @@ export const decodeMatchup = (data) => {
     throw invalid();
   const experience = decodeExperience(data.experience);
   const game = decodeGame(data.game);
-  // The sheets the toggle switches between are this game's two teams, away
-  // then home, under the identities the game header records.
+  // The sheets the toggle switches between are this game's own two teams, under
+  // the identities the game header records. Their delivered order is the live
+  // contract's business; only a historical response is held to away-then-home.
+  const focalTeams = [game.away, game.home];
   if (
     teams.some(
-      (team, index) =>
-        team.teamId !== [game.away, game.home][index].teamId ||
-        team.tricode !== [game.away, game.home][index].tricode,
-    )
+      (team) =>
+        !focalTeams.some((focal) => focal.teamId === team.teamId && focal.tricode === team.tricode),
+    ) ||
+    new Set(teams.map((team) => team.teamId)).size !== teams.length ||
+    (experience.mode === 'historical' &&
+      teams.some((team, index) => team.teamId !== focalTeams[index].teamId))
   ) {
     throw invalid();
   }

--- a/src/matchups/matchupApi.js
+++ b/src/matchups/matchupApi.js
@@ -55,6 +55,33 @@ const MARKET_CATEGORIES = new Set([
 ]);
 
 const DEFENSE_BASES = ['play_types', 'shot_zones', 'shot_types', 'assist_locations', 'traditional'];
+const EXPERIENCE_MODES = ['historical', 'current'];
+const PLAYER_SOURCES = ['game_logs', 'player_pool'];
+const EXPERIENCE_SECTIONS = [
+  'schedule',
+  'participants',
+  'season_defense',
+  'last_15_defense',
+  'injuries',
+];
+const SECTION_SOURCES = [
+  'event_catalog',
+  'player_game_logs',
+  'player_pool',
+  'team_matchup_publication',
+  'rotowire',
+];
+const SECTION_CONTEXTS = [
+  'completed_season_catalog',
+  'current_season_catalog',
+  'completed_season',
+  'pregame',
+  'posted_markets',
+  'current',
+];
+const MISSING_INPUT_PATTERN = new RegExp(
+  `^(?:player_season_rate|(?:team_defense|player_diet):(?:${DEFENSE_BASES.join('|')}))$`,
+);
 const PLAY_TYPE_SLICES = new Set([
   'Transition',
   'Isolation',
@@ -143,6 +170,55 @@ const decodeSheetIdentity = (base, key) => {
     (base === 'traditional' && TRADITIONAL_SLICES.has(sliceKey));
   if (!valid) throw invalid();
   return { sliceKey, markets: expectedSheetMarkets(base, sliceKey, statKey) };
+};
+
+const decodeExperienceSection = (section) => {
+  if (
+    !isRecord(section) ||
+    Object.keys(section).sort().join() !==
+      ['status', 'source', 'context', 'unavailable_reason'].sort().join() ||
+    !['available', 'unavailable', 'missing'].includes(section.status) ||
+    (section.source !== null && !SECTION_SOURCES.includes(section.source)) ||
+    (section.context !== null && !SECTION_CONTEXTS.includes(section.context)) ||
+    (section.status === 'available'
+      ? section.unavailable_reason !== null
+      : typeof section.unavailable_reason !== 'string' || !section.unavailable_reason)
+  ) {
+    throw invalid();
+  }
+  return {
+    status: section.status,
+    source: section.source,
+    context: section.context,
+    unavailableReason: section.unavailable_reason,
+  };
+};
+
+// The rollout is backend-first, so an absent block means the pre-historical
+// live contract rather than an unreadable response.
+const decodeExperience = (experience) => {
+  if (experience === undefined || experience === null) {
+    return { mode: 'current', playerSource: 'player_pool', sections: null };
+  }
+  if (
+    !isRecord(experience) ||
+    !EXPERIENCE_MODES.includes(experience.mode) ||
+    !PLAYER_SOURCES.includes(experience.player_source) ||
+    !isRecord(experience.sections) ||
+    Object.keys(experience.sections).sort().join() !== [...EXPERIENCE_SECTIONS].sort().join()
+  ) {
+    throw invalid();
+  }
+  return {
+    mode: experience.mode,
+    playerSource: experience.player_source,
+    sections: Object.fromEntries(
+      EXPERIENCE_SECTIONS.map((section) => [
+        camelKey(section),
+        decodeExperienceSection(experience.sections[section]),
+      ]),
+    ),
+  };
 };
 
 const decodeAvailabilityState = (value) => {
@@ -330,29 +406,64 @@ const decodeDietShares = (dietShares) => {
   );
 };
 
-const decodePlayer = (player) => {
+const decodeCategoryList = (value) => {
+  const categories = requireStringList(value);
+  if (
+    new Set(categories).size !== categories.length ||
+    categories.some((category) => !MARKET_CATEGORIES.has(category))
+  ) {
+    throw invalid();
+  }
+  return categories;
+};
+
+const decodeFocalGameLine = (line, statCategories) => {
+  if (line === null || line === undefined) return null;
+  if (!isRecord(line) || !isRecord(line.stats)) throw invalid();
+  if (statCategories.some((category) => !Object.hasOwn(line.stats, category))) throw invalid();
+  return {
+    gameId: requireString(line.game_id),
+    gameDate: requireString(line.game_date),
+    matchup: requireString(line.matchup),
+    minutes: requireNumber(line.minutes),
+    stats: Object.fromEntries(
+      Object.entries(line.stats).map(([category, value]) => [category, requireNumber(value)]),
+    ),
+  };
+};
+
+const decodePlayer = (player, experience) => {
   if (!isRecord(player) || !Number.isInteger(player.team_id)) throw invalid();
   if (!Array.isArray(player.last_10_minutes)) throw invalid();
-  const postedMarkets = requireStringList(player.posted_markets);
-  if (
-    postedMarkets.length === 0 ||
-    new Set(postedMarkets).size !== postedMarkets.length ||
-    postedMarkets.some((market) => !MARKET_CATEGORIES.has(market))
-  )
+  const playerSource = player.player_source ?? experience.playerSource;
+  if (!PLAYER_SOURCES.includes(playerSource)) throw invalid();
+  const gameLogSourced = playerSource === 'game_logs';
+  const postedMarkets = decodeCategoryList(player.posted_markets);
+  // A game-log participant carries no posted-market claim at all.
+  if (gameLogSourced ? postedMarkets.length !== 0 : postedMarkets.length === 0) throw invalid();
+  const statCategories =
+    player.stat_categories === undefined
+      ? postedMarkets
+      : decodeCategoryList(player.stat_categories);
+  if (statCategories.length === 0) throw invalid();
+  if (gameLogSourced && (!isRecord(player.provenance) || Object.keys(player.provenance).length))
     throw invalid();
   return {
     id: requireInteger(player.canonical_id),
     name: requireString(player.name),
     teamId: player.team_id,
     tricode: requireString(player.tricode),
+    playerSource,
     postedMarkets,
-    provenance: decodeProvenance(player.provenance, postedMarkets),
+    statCategories,
+    provenance: gameLogSourced ? {} : decodeProvenance(player.provenance, postedMarkets),
+    focalGameLine: decodeFocalGameLine(player.focal_game_line, statCategories),
     seasonScoring: player.season_scoring === null ? null : requireNumber(player.season_scoring),
     last10Minutes: player.last_10_minutes.map(requireNumber),
     dietShares: decodeDietShares(player.diet_shares),
     injuryBadgeRef:
       player.injury_badge_ref === null ? null : requireString(player.injury_badge_ref),
-    scores: decodeScores(player.scores, postedMarkets),
+    scores: decodeScores(player.scores, statCategories),
   };
 };
 
@@ -528,6 +639,14 @@ const decodeScoreWindow = (window, market) => {
   if ((!defensive && !validOffensiveBlend) || (defensive && window.blend != null)) {
     throw invalid();
   }
+  const missingInputs =
+    window.missing_inputs === undefined ? [] : requireStringList(window.missing_inputs);
+  if (
+    new Set(missingInputs).size !== missingInputs.length ||
+    missingInputs.some((input) => !MISSING_INPUT_PATTERN.test(input))
+  ) {
+    throw invalid();
+  }
   return {
     components: Object.fromEntries(
       Object.entries(window.components).map(([base, cell]) => [
@@ -536,27 +655,28 @@ const decodeScoreWindow = (window, market) => {
       ]),
     ),
     blend: defensive || window.blend === null ? null : decodeScoreCell(window.blend),
+    missingInputs,
   };
 };
 
-function decodeScores(scores, postedMarkets) {
+function decodeScores(scores, statCategories) {
   if (
     !isRecord(scores) ||
-    Object.keys(scores).sort().join() !== [...postedMarkets].sort().join() ||
-    postedMarkets.some(
-      (market) =>
-        !isRecord(scores[market]) ||
-        Object.keys(scores[market]).sort().join() !== ['season', 'last_15'].sort().join(),
+    Object.keys(scores).sort().join() !== [...statCategories].sort().join() ||
+    statCategories.some(
+      (category) =>
+        !isRecord(scores[category]) ||
+        Object.keys(scores[category]).sort().join() !== ['season', 'last_15'].sort().join(),
     )
   ) {
     throw invalid();
   }
   return Object.fromEntries(
-    postedMarkets.map((market) => [
-      market,
+    statCategories.map((category) => [
+      category,
       {
-        season: decodeScoreWindow(scores[market].season, market),
-        last15: decodeScoreWindow(scores[market].last_15, market),
+        season: decodeScoreWindow(scores[category].season, category),
+        last15: decodeScoreWindow(scores[category].last_15, category),
       },
     ]),
   );
@@ -759,11 +879,13 @@ export const decodeMatchup = (data) => {
     freshness.injuries.retrievedAt !== injuries.retrievedAt
   )
     throw invalid();
+  const experience = decodeExperience(data.experience);
   return {
     game: decodeGame(data.game),
+    experience,
     league,
     teams,
-    players: data.players.map(decodePlayer),
+    players: data.players.map((player) => decodePlayer(player, experience)),
     injuries,
     freshness,
   };
@@ -823,31 +945,72 @@ const decodeLogTable = (table, markets) => {
   };
 };
 
-export const decodeMatchupSelection = (data, postedMarkets, expectedPlayerId) => {
-  if (!isRecord(data) || !Array.isArray(postedMarkets) || postedMarkets.length === 0)
+const decodeFocalGame = (focalGame, statCategories) => {
+  if (focalGame === null || focalGame === undefined) return null;
+  if (!isRecord(focalGame) || !isRecord(focalGame.stats)) throw selectionInvalid();
+  return {
+    gameId: requireSelectionString(focalGame.game_id),
+    gameDate: requireSelectionString(focalGame.game_date),
+    matchup: requireSelectionString(focalGame.matchup),
+    minutes: requireSelectionNumber(focalGame.minutes),
+    stats: decodeSelectionStatMap(focalGame.stats, statCategories),
+  };
+};
+
+const decodeSelectionExperience = (experience, statCategories) => {
+  if (experience === undefined || experience === null) return null;
+  if (
+    !isRecord(experience) ||
+    !EXPERIENCE_MODES.includes(experience.mode) ||
+    !PLAYER_SOURCES.includes(experience.player_source) ||
+    !isRecord(experience.samples) ||
+    !isRecord(experience.baseline) ||
+    typeof experience.samples.excludes_focal_game !== 'boolean' ||
+    typeof experience.baseline.hindsight !== 'boolean'
+  ) {
+    throw selectionInvalid();
+  }
+  return {
+    mode: experience.mode,
+    playerSource: experience.player_source,
+    focalGame: decodeFocalGame(experience.focal_game, statCategories),
+    samples: {
+      context: requireSelectionString(experience.samples.context),
+      excludesFocalGame: experience.samples.excludes_focal_game,
+    },
+    baseline: {
+      context: requireSelectionString(experience.baseline.context),
+      hindsight: experience.baseline.hindsight,
+    },
+  };
+};
+
+export const decodeMatchupSelection = (data, statCategories, expectedPlayerId) => {
+  if (!isRecord(data) || !Array.isArray(statCategories) || statCategories.length === 0)
     throw selectionInvalid();
   if (!Number.isInteger(data.player_id) || data.player_id !== expectedPlayerId) {
     throw selectionInvalid();
   }
   return {
     playerId: data.player_id,
-    h2h: decodeLogTable(data.h2h, postedMarkets),
-    archetype: decodeLogTable(data.archetype, postedMarkets),
+    experience: decodeSelectionExperience(data.experience, statCategories),
+    h2h: decodeLogTable(data.h2h, statCategories),
+    archetype: decodeLogTable(data.archetype, statCategories),
   };
 };
 
-export const fetchMatchupSelection = async (gameId, playerId, postedMarkets, { signal } = {}) => {
+export const fetchMatchupSelection = async (gameId, playerId, statCategories, { signal } = {}) => {
   if (
     typeof gameId !== 'string' ||
     !gameId ||
     !Number.isInteger(playerId) ||
-    !Array.isArray(postedMarkets) ||
-    postedMarkets.length === 0
+    !Array.isArray(statCategories) ||
+    statCategories.length === 0
   )
     throw selectionInvalid();
   const response = await apiClient.get(getApiUrl('MATCHUP_SELECTION'), {
     params: { game_id: gameId, player_id: playerId },
     signal,
   });
-  return decodeMatchupSelection(response.data, postedMarkets, playerId);
+  return decodeMatchupSelection(response.data, statCategories, playerId);
 };

--- a/src/matchups/matchupApi.js
+++ b/src/matchups/matchupApi.js
@@ -172,11 +172,24 @@ const decodeSheetIdentity = (base, key) => {
   return { sliceKey, markets: expectedSheetMarkets(base, sliceKey, statKey) };
 };
 
-const decodeExperienceSection = (section) => {
+const decodeRetrievedAt = (value) => {
+  if (value === null) return null;
+  const date = new Date(requireString(value));
+  if (Number.isNaN(date.getTime())) throw invalid();
+  return date.toISOString();
+};
+
+const SECTION_STATE_KEYS = ['status', 'source', 'context', 'unavailable_reason'];
+
+// Only the schedule section carries collection provenance. It is immutable
+// evidence of a completed season, never an age-based staleness signal.
+const decodeExperienceSection = (section, name) => {
+  const allowedKeys =
+    name === 'schedule' ? [...SECTION_STATE_KEYS, 'collected_at'] : SECTION_STATE_KEYS;
   if (
     !isRecord(section) ||
-    Object.keys(section).sort().join() !==
-      ['status', 'source', 'context', 'unavailable_reason'].sort().join() ||
+    SECTION_STATE_KEYS.some((key) => !Object.hasOwn(section, key)) ||
+    Object.keys(section).some((key) => !allowedKeys.includes(key)) ||
     !['available', 'unavailable', 'missing'].includes(section.status) ||
     (section.source !== null && !SECTION_SOURCES.includes(section.source)) ||
     (section.context !== null && !SECTION_CONTEXTS.includes(section.context)) ||
@@ -191,6 +204,7 @@ const decodeExperienceSection = (section) => {
     source: section.source,
     context: section.context,
     unavailableReason: section.unavailable_reason,
+    collectedAt: decodeRetrievedAt(section.collected_at ?? null),
   };
 };
 
@@ -215,7 +229,7 @@ const decodeExperience = (experience) => {
     sections: Object.fromEntries(
       EXPERIENCE_SECTIONS.map((section) => [
         camelKey(section),
-        decodeExperienceSection(experience.sections[section]),
+        decodeExperienceSection(experience.sections[section], section),
       ]),
     ),
   };
@@ -417,20 +431,29 @@ const decodeCategoryList = (value) => {
   return categories;
 };
 
-const decodeFocalGameLine = (line, statCategories) => {
+// The focal line has one shape. The matchup and selection responses only differ
+// in which rejection they raise, so they share this translation.
+const decodeFocalLine = (line, statCategories, { fail, requireText, requireValue }) => {
   if (line === null || line === undefined) return null;
-  if (!isRecord(line) || !isRecord(line.stats)) throw invalid();
-  if (statCategories.some((category) => !Object.hasOwn(line.stats, category))) throw invalid();
+  if (!isRecord(line) || !isRecord(line.stats)) throw fail();
+  if (statCategories.some((category) => !Object.hasOwn(line.stats, category))) throw fail();
   return {
-    gameId: requireString(line.game_id),
-    gameDate: requireString(line.game_date),
-    matchup: requireString(line.matchup),
-    minutes: requireNumber(line.minutes),
+    gameId: requireText(line.game_id),
+    gameDate: requireText(line.game_date),
+    matchup: requireText(line.matchup),
+    minutes: requireValue(line.minutes),
     stats: Object.fromEntries(
-      Object.entries(line.stats).map(([category, value]) => [category, requireNumber(value)]),
+      Object.entries(line.stats).map(([category, value]) => [category, requireValue(value)]),
     ),
   };
 };
+
+const decodeFocalGameLine = (line, statCategories) =>
+  decodeFocalLine(line, statCategories, {
+    fail: invalid,
+    requireText: requireString,
+    requireValue: requireNumber,
+  });
 
 const decodePlayer = (player, experience) => {
   if (!isRecord(player) || !Number.isInteger(player.team_id)) throw invalid();
@@ -681,13 +704,6 @@ function decodeScores(scores, statCategories) {
     ]),
   );
 }
-
-const decodeRetrievedAt = (value) => {
-  if (value === null) return null;
-  const date = new Date(requireString(value));
-  if (Number.isNaN(date.getTime())) throw invalid();
-  return date.toISOString();
-};
 
 const decodeFreshnessSurface = (surface, surfaceName) => {
   if (!isRecord(surface) || !isStatusAllowed(surface.status, surfaceName)) throw invalid();
@@ -945,17 +961,12 @@ const decodeLogTable = (table, markets) => {
   };
 };
 
-const decodeFocalGame = (focalGame, statCategories) => {
-  if (focalGame === null || focalGame === undefined) return null;
-  if (!isRecord(focalGame) || !isRecord(focalGame.stats)) throw selectionInvalid();
-  return {
-    gameId: requireSelectionString(focalGame.game_id),
-    gameDate: requireSelectionString(focalGame.game_date),
-    matchup: requireSelectionString(focalGame.matchup),
-    minutes: requireSelectionNumber(focalGame.minutes),
-    stats: decodeSelectionStatMap(focalGame.stats, statCategories),
-  };
-};
+const decodeFocalGame = (focalGame, statCategories) =>
+  decodeFocalLine(focalGame, statCategories, {
+    fail: selectionInvalid,
+    requireText: requireSelectionString,
+    requireValue: requireSelectionNumber,
+  });
 
 const decodeSelectionExperience = (experience, statCategories) => {
   if (experience === undefined || experience === null) return null;

--- a/src/matchups/matchupApi.js
+++ b/src/matchups/matchupApi.js
@@ -180,10 +180,20 @@ const decodeRetrievedAt = (value) => {
 };
 
 const SECTION_STATE_KEYS = ['status', 'source', 'context', 'unavailable_reason'];
+// The mode owns its evidence vocabulary. A completed season cannot be described
+// as pregame, and a live slate cannot be described as hindsight, so a response
+// that mixes them is incoherent rather than merely unusual.
+const MODE_PLAYER_SOURCES = { historical: 'game_logs', current: 'player_pool' };
+const MODE_ONLY_CONTEXTS = {
+  historical: ['completed_season_catalog', 'completed_season'],
+  current: ['current_season_catalog', 'pregame', 'posted_markets', 'current'],
+};
+const MODE_ONLY_SOURCES = { historical: ['player_game_logs'], current: ['player_pool'] };
+const otherMode = (mode) => (mode === 'historical' ? 'current' : 'historical');
 
 // Only the schedule section carries collection provenance. It is immutable
 // evidence of a completed season, never an age-based staleness signal.
-const decodeExperienceSection = (section, name) => {
+const decodeExperienceSection = (section, name, mode) => {
   const allowedKeys =
     name === 'schedule' ? [...SECTION_STATE_KEYS, 'collected_at'] : SECTION_STATE_KEYS;
   if (
@@ -193,6 +203,8 @@ const decodeExperienceSection = (section, name) => {
     !['available', 'unavailable', 'missing'].includes(section.status) ||
     (section.source !== null && !SECTION_SOURCES.includes(section.source)) ||
     (section.context !== null && !SECTION_CONTEXTS.includes(section.context)) ||
+    MODE_ONLY_CONTEXTS[otherMode(mode)].includes(section.context) ||
+    MODE_ONLY_SOURCES[otherMode(mode)].includes(section.source) ||
     (section.status === 'available'
       ? section.unavailable_reason !== null
       : typeof section.unavailable_reason !== 'string' || !section.unavailable_reason)
@@ -218,6 +230,7 @@ const decodeExperience = (experience) => {
     !isRecord(experience) ||
     !EXPERIENCE_MODES.includes(experience.mode) ||
     !PLAYER_SOURCES.includes(experience.player_source) ||
+    experience.player_source !== MODE_PLAYER_SOURCES[experience.mode] ||
     !isRecord(experience.sections) ||
     Object.keys(experience.sections).sort().join() !== [...EXPERIENCE_SECTIONS].sort().join()
   ) {
@@ -229,7 +242,7 @@ const decodeExperience = (experience) => {
     sections: Object.fromEntries(
       EXPERIENCE_SECTIONS.map((section) => [
         camelKey(section),
-        decodeExperienceSection(experience.sections[section], section),
+        decodeExperienceSection(experience.sections[section], section, experience.mode),
       ]),
     ),
   };
@@ -458,8 +471,10 @@ const decodeFocalGameLine = (line, statCategories) =>
 const decodePlayer = (player, experience) => {
   if (!isRecord(player) || !Number.isInteger(player.team_id)) throw invalid();
   if (!Array.isArray(player.last_10_minutes)) throw invalid();
+  // A participant cannot claim a different source than its own experience.
   const playerSource = player.player_source ?? experience.playerSource;
-  if (!PLAYER_SOURCES.includes(playerSource)) throw invalid();
+  if (!PLAYER_SOURCES.includes(playerSource) || playerSource !== experience.playerSource)
+    throw invalid();
   const gameLogSourced = playerSource === 'game_logs';
   const postedMarkets = decodeCategoryList(player.posted_markets);
   // A game-log participant carries no posted-market claim at all.
@@ -469,8 +484,14 @@ const decodePlayer = (player, experience) => {
       ? postedMarkets
       : decodeCategoryList(player.stat_categories);
   if (statCategories.length === 0) throw invalid();
+  // Current-mode categories are the posted markets. Keeping them identical is
+  // what lets the live Player Pool controls and selection stay unchanged.
+  if (!gameLogSourced && statCategories.join() !== postedMarkets.join()) throw invalid();
   if (gameLogSourced && (!isRecord(player.provenance) || Object.keys(player.provenance).length))
     throw invalid();
+  const focalGameLine = decodeFocalGameLine(player.focal_game_line, statCategories);
+  // A historical participant always has a focal line; a pool player never does.
+  if (gameLogSourced ? focalGameLine === null : focalGameLine !== null) throw invalid();
   return {
     id: requireInteger(player.canonical_id),
     name: requireString(player.name),
@@ -480,7 +501,7 @@ const decodePlayer = (player, experience) => {
     postedMarkets,
     statCategories,
     provenance: gameLogSourced ? {} : decodeProvenance(player.provenance, postedMarkets),
-    focalGameLine: decodeFocalGameLine(player.focal_game_line, statCategories),
+    focalGameLine,
     seasonScoring: player.season_scoring === null ? null : requireNumber(player.season_scoring),
     last10Minutes: player.last_10_minutes.map(requireNumber),
     dietShares: decodeDietShares(player.diet_shares),
@@ -968,16 +989,45 @@ const decodeFocalGame = (focalGame, statCategories) =>
     requireValue: requireSelectionNumber,
   });
 
+// The dossier's separation labels are driven by these fields, so a response
+// that mislabels them would silently drop a required disclosure.
+const SELECTION_MODE_CONTRACT = {
+  historical: {
+    focalGame: true,
+    samplesContext: 'pregame',
+    excludesFocalGame: true,
+    baselineContext: 'completed_season',
+    hindsight: true,
+  },
+  current: {
+    focalGame: false,
+    samplesContext: 'season_to_date',
+    excludesFocalGame: false,
+    baselineContext: 'season_to_date',
+    hindsight: false,
+  },
+};
+
 const decodeSelectionExperience = (experience, statCategories) => {
   if (experience === undefined || experience === null) return null;
   if (
     !isRecord(experience) ||
     !EXPERIENCE_MODES.includes(experience.mode) ||
-    !PLAYER_SOURCES.includes(experience.player_source) ||
+    experience.player_source !== MODE_PLAYER_SOURCES[experience.mode] ||
     !isRecord(experience.samples) ||
     !isRecord(experience.baseline) ||
     typeof experience.samples.excludes_focal_game !== 'boolean' ||
     typeof experience.baseline.hindsight !== 'boolean'
+  ) {
+    throw selectionInvalid();
+  }
+  const required = SELECTION_MODE_CONTRACT[experience.mode];
+  if (
+    isRecord(experience.focal_game) !== required.focalGame ||
+    experience.samples.context !== required.samplesContext ||
+    experience.samples.excludes_focal_game !== required.excludesFocalGame ||
+    experience.baseline.context !== required.baselineContext ||
+    experience.baseline.hindsight !== required.hindsight
   ) {
     throw selectionInvalid();
   }

--- a/src/matchups/matchupApi.js
+++ b/src/matchups/matchupApi.js
@@ -205,8 +205,10 @@ const decodeExperienceSection = (section, name, mode) => {
     (section.context !== null && !SECTION_CONTEXTS.includes(section.context)) ||
     MODE_ONLY_CONTEXTS[otherMode(mode)].includes(section.context) ||
     MODE_ONLY_SOURCES[otherMode(mode)].includes(section.source) ||
+    // An available section owns its evidence, so it must name where that
+    // evidence came from and what it describes.
     (section.status === 'available'
-      ? section.unavailable_reason !== null
+      ? section.unavailable_reason !== null || section.source === null || section.context === null
       : typeof section.unavailable_reason !== 'string' || !section.unavailable_reason)
   ) {
     throw invalid();
@@ -468,7 +470,7 @@ const decodeFocalGameLine = (line, statCategories) =>
     requireValue: requireNumber,
   });
 
-const decodePlayer = (player, experience) => {
+const decodePlayer = (player, experience, gameId) => {
   if (!isRecord(player) || !Number.isInteger(player.team_id)) throw invalid();
   if (!Array.isArray(player.last_10_minutes)) throw invalid();
   // A participant cannot claim a different source than its own experience.
@@ -491,7 +493,9 @@ const decodePlayer = (player, experience) => {
     throw invalid();
   const focalGameLine = decodeFocalGameLine(player.focal_game_line, statCategories);
   // A historical participant always has a focal line; a pool player never does.
+  // The line is evidence about this game, so it cannot describe another one.
   if (gameLogSourced ? focalGameLine === null : focalGameLine !== null) throw invalid();
+  if (focalGameLine !== null && focalGameLine.gameId !== gameId) throw invalid();
   return {
     id: requireInteger(player.canonical_id),
     name: requireString(player.name),
@@ -917,12 +921,13 @@ export const decodeMatchup = (data) => {
   )
     throw invalid();
   const experience = decodeExperience(data.experience);
+  const game = decodeGame(data.game);
   return {
-    game: decodeGame(data.game),
+    game,
     experience,
     league,
     teams,
-    players: data.players.map((player) => decodePlayer(player, experience)),
+    players: data.players.map((player) => decodePlayer(player, experience, game.gameId)),
     injuries,
     freshness,
   };
@@ -1008,11 +1013,17 @@ const SELECTION_MODE_CONTRACT = {
   },
 };
 
-const decodeSelectionExperience = (experience, statCategories) => {
-  if (experience === undefined || experience === null) return null;
+const decodeSelectionExperience = (experience, statCategories, expected) => {
+  if (experience === undefined || experience === null) {
+    // A historical dossier must carry its own evidence, or its strict-before
+    // and hindsight disclosures would silently disappear.
+    if (expected.mode === 'historical') throw selectionInvalid();
+    return null;
+  }
   if (
     !isRecord(experience) ||
     !EXPERIENCE_MODES.includes(experience.mode) ||
+    (expected.mode !== undefined && experience.mode !== expected.mode) ||
     experience.player_source !== MODE_PLAYER_SOURCES[experience.mode] ||
     !isRecord(experience.samples) ||
     !isRecord(experience.baseline) ||
@@ -1031,10 +1042,15 @@ const decodeSelectionExperience = (experience, statCategories) => {
   ) {
     throw selectionInvalid();
   }
+  const focalGame = decodeFocalGame(experience.focal_game, statCategories);
+  // The dossier contextualizes the focal game the client asked about.
+  if (focalGame !== null && expected.gameId !== undefined && focalGame.gameId !== expected.gameId) {
+    throw selectionInvalid();
+  }
   return {
     mode: experience.mode,
     playerSource: experience.player_source,
-    focalGame: decodeFocalGame(experience.focal_game, statCategories),
+    focalGame,
     samples: {
       context: requireSelectionString(experience.samples.context),
       excludesFocalGame: experience.samples.excludes_focal_game,
@@ -1046,7 +1062,9 @@ const decodeSelectionExperience = (experience, statCategories) => {
   };
 };
 
-export const decodeMatchupSelection = (data, statCategories, expectedPlayerId) => {
+// `expected` binds the response to the matchup the client asked about: the
+// game it must contextualize, and the experience it must disclose.
+export const decodeMatchupSelection = (data, statCategories, expectedPlayerId, expected = {}) => {
   if (!isRecord(data) || !Array.isArray(statCategories) || statCategories.length === 0)
     throw selectionInvalid();
   if (!Number.isInteger(data.player_id) || data.player_id !== expectedPlayerId) {
@@ -1054,13 +1072,18 @@ export const decodeMatchupSelection = (data, statCategories, expectedPlayerId) =
   }
   return {
     playerId: data.player_id,
-    experience: decodeSelectionExperience(data.experience, statCategories),
+    experience: decodeSelectionExperience(data.experience, statCategories, expected),
     h2h: decodeLogTable(data.h2h, statCategories),
     archetype: decodeLogTable(data.archetype, statCategories),
   };
 };
 
-export const fetchMatchupSelection = async (gameId, playerId, statCategories, { signal } = {}) => {
+export const fetchMatchupSelection = async (
+  gameId,
+  playerId,
+  statCategories,
+  { signal, mode } = {},
+) => {
   if (
     typeof gameId !== 'string' ||
     !gameId ||
@@ -1073,5 +1096,5 @@ export const fetchMatchupSelection = async (gameId, playerId, statCategories, { 
     params: { game_id: gameId, player_id: playerId },
     signal,
   });
-  return decodeMatchupSelection(response.data, statCategories, playerId);
+  return decodeMatchupSelection(response.data, statCategories, playerId, { gameId, mode });
 };

--- a/src/matchups/matchupApi.js
+++ b/src/matchups/matchupApi.js
@@ -731,6 +731,10 @@ const decodeScoreWindow = (window, market, historical) => {
     throw invalid();
   }
   if (historical && isRecord(window.blend) && missingInputs.length > 0) throw invalid();
+  // A withheld historical score has to say what it was missing, or the page has
+  // nothing truthful to explain the gap with.
+  const withheldScore = defensive ? componentCount === 0 : window.blend === null;
+  if (historical && withheldScore && missingInputs.length === 0) throw invalid();
   return {
     components: Object.fromEntries(
       Object.entries(window.components).map(([base, cell]) => [

--- a/src/matchups/matchupApi.test.js
+++ b/src/matchups/matchupApi.test.js
@@ -1275,7 +1275,8 @@ const historicalPayload = () => {
   participant.player_source = 'game_logs';
   participant.stat_categories = ['PTS', 'FGA'];
   participant.focal_game_line = {
-    game_id: '0022501082',
+    // The focal line is evidence about this matchup's own game.
+    game_id: candidate.game.game_id,
     game_date: '2026-03-29',
     matchup: 'LAC @ MIL',
     minutes: 34.5,
@@ -1369,7 +1370,7 @@ test('reads a game-log participant that carries no posted-market claim', () => {
   expect(participant.provenance).toEqual({});
   expect(participant.statCategories).toEqual(['PTS', 'FGA']);
   expect(participant.focalGameLine).toEqual({
-    gameId: '0022501082',
+    gameId: payload.game.game_id,
     gameDate: '2026-03-29',
     matchup: 'LAC @ MIL',
     minutes: 34.5,
@@ -1556,6 +1557,102 @@ test.each([
   expect(() => decodeMatchup(candidate)).not.toThrow();
   mutate(candidate);
   expect(() => decodeMatchup(candidate)).toThrow('invalid response');
+});
+
+test.each([
+  [
+    'a focal game line from a different game',
+    (candidate) => {
+      candidate.players[0].focal_game_line.game_id = '0022509999';
+    },
+  ],
+  [
+    'an available section with no source',
+    (candidate) => {
+      candidate.experience.sections.participants.source = null;
+    },
+  ],
+  [
+    'an available section with no context',
+    (candidate) => {
+      candidate.experience.sections.season_defense.context = null;
+    },
+  ],
+])('rejects %s', (_name, mutate) => {
+  const candidate = historicalPayload();
+  mutate(candidate);
+  expect(() => decodeMatchup(candidate)).toThrow('invalid response');
+});
+
+test('binds the focal game line to the decoded matchup game', () => {
+  const candidate = historicalPayload();
+  candidate.players[0].focal_game_line.game_id = candidate.game.game_id;
+
+  expect(decodeMatchup(candidate).players[0].focalGameLine.gameId).toBe(candidate.game.game_id);
+});
+
+const historicalSelection = (overrides = {}) => ({
+  player_id: 2544,
+  experience: {
+    mode: 'historical',
+    player_source: 'game_logs',
+    focal_game: {
+      game_id: '0022500584',
+      game_date: '2026-03-29',
+      matchup: 'LAC @ MIL',
+      minutes: 34.5,
+      stats: { PTS: 24, FGA: 18 },
+    },
+    samples: { context: 'pregame', excludes_focal_game: true },
+    baseline: { context: 'completed_season', hindsight: true },
+  },
+  h2h: { thin: false, rows: [] },
+  archetype: { thin: false, rows: [] },
+  ...overrides,
+});
+
+test('binds historical selection evidence to the requested matchup', () => {
+  const expected = { gameId: '0022500584', mode: 'historical' };
+  const selection = decodeMatchupSelection(historicalSelection(), ['PTS', 'FGA'], 2544, expected);
+  expect(selection.experience.focalGame.gameId).toBe('0022500584');
+
+  // A historical dossier without its experience would silently drop the
+  // strict-before and hindsight disclosures the outcome requires.
+  expect(() =>
+    decodeMatchupSelection(historicalSelection({ experience: undefined }), ['PTS', 'FGA'], 2544, {
+      ...expected,
+    }),
+  ).toThrow('selection endpoint returned an invalid response');
+
+  const otherGame = historicalSelection();
+  otherGame.experience.focal_game.game_id = '0022509999';
+  expect(() => decodeMatchupSelection(otherGame, ['PTS', 'FGA'], 2544, expected)).toThrow(
+    'selection endpoint returned an invalid response',
+  );
+
+  const currentDossier = historicalSelection();
+  currentDossier.experience.mode = 'current';
+  currentDossier.experience.player_source = 'player_pool';
+  currentDossier.experience.focal_game = null;
+  currentDossier.experience.samples = { context: 'season_to_date', excludes_focal_game: false };
+  currentDossier.experience.baseline = { context: 'season_to_date', hindsight: false };
+  expect(() => decodeMatchupSelection(currentDossier, ['PTS', 'FGA'], 2544, expected)).toThrow(
+    'selection endpoint returned an invalid response',
+  );
+});
+
+test('leaves the current selection contract unbound to historical evidence', () => {
+  const raw = {
+    player_id: 2544,
+    h2h: { thin: false, rows: [] },
+    archetype: { thin: false, rows: [] },
+  };
+
+  expect(decodeMatchupSelection(raw, ['PTS'], 2544).experience).toBeNull();
+  expect(
+    decodeMatchupSelection(raw, ['PTS'], 2544, { gameId: '0022500584', mode: 'current' })
+      .experience,
+  ).toBeNull();
 });
 
 test('keeps live Player Pool categories identical to the posted markets', () => {

--- a/src/matchups/matchupApi.test.js
+++ b/src/matchups/matchupApi.test.js
@@ -1274,11 +1274,12 @@ const historicalPayload = () => {
   participant.provenance = {};
   participant.player_source = 'game_logs';
   participant.stat_categories = ['PTS', 'FGA'];
+  // The focal line is evidence about this matchup's own game, so its game,
+  // date, and matchup identity all have to be that game's.
   participant.focal_game_line = {
-    // The focal line is evidence about this matchup's own game.
     game_id: candidate.game.game_id,
-    game_date: '2026-03-29',
-    matchup: 'LAC @ MIL',
+    game_date: '2026-01-15',
+    matchup: 'LAL @ BOS',
     minutes: 34.5,
     stats: { PTS: 24, FGA: 18 },
   };
@@ -1371,8 +1372,8 @@ test('reads a game-log participant that carries no posted-market claim', () => {
   expect(participant.statCategories).toEqual(['PTS', 'FGA']);
   expect(participant.focalGameLine).toEqual({
     gameId: payload.game.game_id,
-    gameDate: '2026-03-29',
-    matchup: 'LAC @ MIL',
+    gameDate: '2026-01-15',
+    matchup: 'LAL @ BOS',
     minutes: 34.5,
     stats: { PTS: 24, FGA: 18 },
   });
@@ -1653,6 +1654,255 @@ test('leaves the current selection contract unbound to historical evidence', () 
     decodeMatchupSelection(raw, ['PTS'], 2544, { gameId: '0022500584', mode: 'current' })
       .experience,
   ).toBeNull();
+});
+
+const focalLineOf = (candidate) => candidate.players[0].focal_game_line;
+
+test.each([
+  [
+    'a participant on neither focal team',
+    (candidate) => {
+      candidate.players[0].team_id = 99;
+    },
+  ],
+  [
+    'a participant whose tricode contradicts its focal team',
+    (candidate) => {
+      candidate.players[0].tricode = 'BOS';
+    },
+  ],
+  [
+    'a focal line naming a matchup other than the decoded one',
+    (candidate) => {
+      focalLineOf(candidate).matchup = 'LAC @ MIL';
+    },
+  ],
+  [
+    'a focal line dated away from the decoded game',
+    (candidate) => {
+      focalLineOf(candidate).game_date = '2026-03-29';
+    },
+  ],
+])('rejects %s', (_name, mutate) => {
+  const candidate = historicalPayload();
+  mutate(candidate);
+  expect(() => decodeMatchup(candidate)).toThrow('invalid response');
+});
+
+test('rejects participants that disagree about which game is focal', () => {
+  const candidate = historicalPayload();
+  const second = JSON.parse(JSON.stringify(candidate.players[0]));
+  second.canonical_id = 1630559;
+  second.name = 'Austin Reaves';
+  second.focal_game_line.game_date = '2026-01-14';
+  candidate.players.push(second);
+
+  expect(() => decodeMatchup(candidate)).toThrow('invalid response');
+});
+
+const historicalDossier = (overrides = {}) => ({
+  player_id: 2544,
+  experience: {
+    mode: 'historical',
+    player_source: 'game_logs',
+    focal_game: {
+      game_id: '0022500584',
+      game_date: '2026-01-15',
+      matchup: 'LAL @ BOS',
+      minutes: 34.5,
+      stats: { PTS: 24, FGA: 18 },
+    },
+    samples: { context: 'pregame', excludes_focal_game: true },
+    baseline: { context: 'completed_season', hindsight: true },
+  },
+  h2h: {
+    thin: false,
+    rows: [
+      {
+        row_type: 'game',
+        game_date: '2025-12-25',
+        matchup: 'LAL vs. BOS',
+        minutes: 33,
+        stats: { PTS: 21, FGA: 17 },
+        deltas: { PTS: 0.06, FGA: 0.01 },
+      },
+      {
+        row_type: 'average',
+        game_date: null,
+        matchup: null,
+        minutes: 33,
+        stats: { PTS: 21, FGA: 17 },
+        deltas: { PTS: 0.06, FGA: 0.01 },
+      },
+    ],
+  },
+  archetype: { thin: false, rows: [] },
+  ...overrides,
+});
+
+const focalExpectation = {
+  gameId: '0022500584',
+  mode: 'historical',
+  focalGameLine: {
+    gameId: '0022500584',
+    gameDate: '2026-01-15',
+    matchup: 'LAL @ BOS',
+    minutes: 34.5,
+    stats: { PTS: 24, FGA: 18 },
+  },
+};
+
+test('keeps historical samples strictly before the focal game', () => {
+  expect(
+    decodeMatchupSelection(historicalDossier(), ['PTS', 'FGA'], 2544, focalExpectation).h2h.rows,
+  ).toHaveLength(2);
+
+  const onFocalDay = historicalDossier();
+  onFocalDay.h2h.rows[0].game_date = '2026-01-15';
+  expect(() => decodeMatchupSelection(onFocalDay, ['PTS', 'FGA'], 2544, focalExpectation)).toThrow(
+    'selection endpoint returned an invalid response',
+  );
+
+  const afterFocal = historicalDossier();
+  afterFocal.archetype = {
+    thin: false,
+    rows: [{ ...onFocalDay.h2h.rows[0], game_date: '2026-02-02' }, { ...onFocalDay.h2h.rows[1] }],
+  };
+  expect(() => decodeMatchupSelection(afterFocal, ['PTS', 'FGA'], 2544, focalExpectation)).toThrow(
+    'selection endpoint returned an invalid response',
+  );
+});
+
+test.each([
+  [
+    'a dossier focal game dated away from the participant evidence',
+    (dossier) => {
+      dossier.experience.focal_game.game_date = '2026-01-14';
+    },
+  ],
+  [
+    'a dossier focal game naming a different matchup',
+    (dossier) => {
+      dossier.experience.focal_game.matchup = 'LAC @ MIL';
+    },
+  ],
+  [
+    'a dossier focal game contradicting the participant minutes',
+    (dossier) => {
+      dossier.experience.focal_game.minutes = 12;
+    },
+  ],
+  [
+    'a dossier focal game contradicting the participant stat line',
+    (dossier) => {
+      dossier.experience.focal_game.stats.PTS = 41;
+    },
+  ],
+])('rejects %s', (_name, mutate) => {
+  const dossier = historicalDossier();
+  mutate(dossier);
+  expect(() => decodeMatchupSelection(dossier, ['PTS', 'FGA'], 2544, focalExpectation)).toThrow(
+    'selection endpoint returned an invalid response',
+  );
+});
+
+test('leaves current selection samples unbound to a focal game', () => {
+  const raw = {
+    player_id: 2544,
+    h2h: {
+      thin: false,
+      rows: [
+        {
+          row_type: 'game',
+          game_date: '2026-02-02',
+          matchup: 'LAL vs. BOS',
+          minutes: 33,
+          stats: { PTS: 21 },
+          deltas: { PTS: 0.06 },
+        },
+        {
+          row_type: 'average',
+          game_date: null,
+          matchup: null,
+          minutes: 33,
+          stats: { PTS: 21 },
+          deltas: { PTS: 0.06 },
+        },
+      ],
+    },
+    archetype: { thin: false, rows: [] },
+  };
+
+  expect(
+    decodeMatchupSelection(raw, ['PTS'], 2544, { gameId: '0022500584', mode: 'current' }).h2h.rows,
+  ).toHaveLength(2);
+});
+
+test.each([
+  [
+    'season defense sourced from game logs',
+    (candidate) => {
+      candidate.experience.sections.season_defense.source = 'player_game_logs';
+    },
+  ],
+  [
+    'schedule sourced from a defense publication',
+    (candidate) => {
+      candidate.experience.sections.schedule.source = 'team_matchup_publication';
+    },
+  ],
+  [
+    'participants sourced from the Event Catalog',
+    (candidate) => {
+      candidate.experience.sections.participants.source = 'event_catalog';
+    },
+  ],
+  [
+    'an archived Last-15 snapshot sourced from game logs',
+    (candidate) => {
+      candidate.experience.sections.last_15_defense = experienceSection(
+        'available',
+        'player_game_logs',
+        'pregame',
+      );
+    },
+  ],
+  [
+    'an archived injury snapshot described as completed-season context',
+    (candidate) => {
+      candidate.experience.sections.injuries = experienceSection(
+        'available',
+        'rotowire',
+        'completed_season',
+      );
+    },
+  ],
+])('rejects %s', (_name, mutate) => {
+  const candidate = historicalPayload();
+  mutate(candidate);
+  expect(() => decodeMatchup(candidate)).toThrow('invalid response');
+});
+
+test('accepts truthful archived pregame Last-15 and injury evidence in historical mode', () => {
+  const candidate = historicalPayload();
+  candidate.experience.sections.last_15_defense = experienceSection(
+    'available',
+    'team_matchup_publication',
+    'pregame',
+  );
+  candidate.experience.sections.injuries = experienceSection('available', 'rotowire', 'pregame');
+
+  const { sections } = decodeMatchup(candidate).experience;
+  expect(sections.last15Defense).toEqual(
+    expect.objectContaining({
+      status: 'available',
+      source: 'team_matchup_publication',
+      context: 'pregame',
+    }),
+  );
+  expect(sections.injuries).toEqual(
+    expect.objectContaining({ status: 'available', source: 'rotowire', context: 'pregame' }),
+  );
 });
 
 test('keeps live Player Pool categories identical to the posted markets', () => {

--- a/src/matchups/matchupApi.test.js
+++ b/src/matchups/matchupApi.test.js
@@ -1969,6 +1969,45 @@ test.each([
   expect(() => decodeMatchup(candidate)).toThrow('invalid response');
 });
 
+test.each([
+  [
+    'a withheld historical offensive score that names no missing input',
+    (candidate) => {
+      candidate.players[0].scores.PTS.season = {
+        components: {},
+        blend: null,
+        missing_inputs: [],
+      };
+    },
+  ],
+  [
+    'a withheld historical defensive score that names no missing input',
+    (candidate) => {
+      candidate.players[0].stat_categories = ['PTS', 'FGA', 'TOV'];
+      candidate.players[0].scores.TOV = {
+        season: { components: {}, missing_inputs: [] },
+        last_15: { components: {}, missing_inputs: ['team_defense:traditional'] },
+      };
+      candidate.players[0].focal_game_line.stats.TOV = 2;
+    },
+  ],
+])('rejects %s', (_name, mutate) => {
+  const candidate = historicalPayload();
+  mutate(candidate);
+  expect(() => decodeMatchup(candidate)).toThrow('invalid response');
+});
+
+test('leaves the legacy zero-component window decodable in current mode', () => {
+  const candidate = JSON.parse(JSON.stringify(payload));
+  candidate.players[0].scores.FGA.last_15 = { components: {}, blend: null };
+
+  expect(decodeMatchup(candidate).players[0].scores.FGA.last15).toEqual({
+    components: {},
+    blend: null,
+    missingInputs: [],
+  });
+});
+
 test('leaves the current-mode blend contract unchanged', () => {
   const candidate = JSON.parse(JSON.stringify(payload));
   candidate.players[0].scores.PTS.season.missing_inputs = ['team_defense:play_types'];

--- a/src/matchups/matchupApi.test.js
+++ b/src/matchups/matchupApi.test.js
@@ -1294,15 +1294,57 @@ test('reads the additive Historical Matchup mode and section-owned evidence', ()
     source: 'team_matchup_publication',
     context: 'completed_season',
     unavailableReason: null,
+    collectedAt: null,
   });
   expect(decoded.experience.sections.last15Defense).toEqual({
     status: 'unavailable',
     source: null,
     context: null,
     unavailableReason: 'no_point_in_time_snapshot',
+    collectedAt: null,
   });
   expect(decoded.experience.sections.participants.source).toBe('player_game_logs');
   expect(decoded.experience.sections.injuries.unavailableReason).toBe('no_pregame_snapshot');
+});
+
+test('reads schedule collection provenance without letting it govern any section', () => {
+  const candidate = historicalPayload();
+  candidate.experience.sections.schedule.collected_at = '2026-03-30T04:10:00Z';
+
+  const { sections } = decodeMatchup(candidate).experience;
+  expect(sections.schedule.collectedAt).toBe('2026-03-30T04:10:00.000Z');
+  expect(sections.schedule.status).toBe('available');
+  // Only schedule carries collection provenance.
+  expect(sections.participants.collectedAt).toBeNull();
+  expect(sections.seasonDefense.collectedAt).toBeNull();
+
+  const absent = historicalPayload();
+  expect(decodeMatchup(absent).experience.sections.schedule.collectedAt).toBeNull();
+});
+
+test.each([
+  [
+    'an unparseable schedule collection time',
+    (candidate) => {
+      candidate.experience.sections.schedule.collected_at = 'not-a-timestamp';
+    },
+  ],
+  [
+    'collection provenance on a section that does not carry it',
+    (candidate) => {
+      candidate.experience.sections.participants.collected_at = '2026-03-30T04:10:00Z';
+    },
+  ],
+  [
+    'an undocumented schedule key',
+    (candidate) => {
+      candidate.experience.sections.schedule.published_at = '2026-03-30T04:10:00Z';
+    },
+  ],
+])('rejects %s', (_name, mutate) => {
+  const candidate = historicalPayload();
+  mutate(candidate);
+  expect(() => decodeMatchup(candidate)).toThrow('invalid response');
 });
 
 test('treats an absent experience block as the pre-historical live contract', () => {
@@ -1455,6 +1497,27 @@ test('reads the additive selection experience and its separated focal game', () 
   expect(
     decodeMatchupSelection({ ...raw, experience: undefined }, ['PTS', 'FGA'], 2544).experience,
   ).toBeNull();
+  expect(
+    decodeMatchupSelection(
+      { ...raw, experience: { ...raw.experience, focal_game: null } },
+      ['PTS', 'FGA'],
+      2544,
+    ).experience.focalGame,
+  ).toBeNull();
+  // The focal line rejects a missing governed category on both response seams.
+  expect(() =>
+    decodeMatchupSelection(
+      {
+        ...raw,
+        experience: {
+          ...raw.experience,
+          focal_game: { ...raw.experience.focal_game, stats: { PTS: 24 } },
+        },
+      },
+      ['PTS', 'FGA'],
+      2544,
+    ),
+  ).toThrow('selection endpoint returned an invalid response');
   expect(() =>
     decodeMatchupSelection(
       { ...raw, experience: { ...raw.experience, baseline: { context: 'completed_season' } } },

--- a/src/matchups/matchupApi.test.js
+++ b/src/matchups/matchupApi.test.js
@@ -2161,6 +2161,23 @@ test('rejects an impossible focal date rather than comparing it as a string', ()
   ).toThrow('selection endpoint returned an invalid response');
 });
 
+test('accepts either team ordering in current mode', () => {
+  const candidate = JSON.parse(JSON.stringify(payload));
+  candidate.teams.reverse();
+
+  expect(decodeMatchup(candidate).teams.map((team) => team.tricode)).toEqual(['BOS', 'LAL']);
+});
+
+test('still binds current-mode defense sheets to the two teams that played', () => {
+  const candidate = JSON.parse(JSON.stringify(payload));
+  candidate.teams[1].team_id = 99;
+  expect(() => decodeMatchup(candidate)).toThrow('invalid response');
+
+  const swappedTricode = JSON.parse(JSON.stringify(payload));
+  swappedTricode.teams[0].tricode = 'BOS';
+  expect(() => decodeMatchup(swappedTricode)).toThrow('invalid response');
+});
+
 test('keeps live Player Pool categories identical to the posted markets', () => {
   const [player] = decodeMatchup(payload).players;
 

--- a/src/matchups/matchupApi.test.js
+++ b/src/matchups/matchupApi.test.js
@@ -1459,10 +1459,111 @@ test.each([
       candidate.players[0].scores.PTS.season.missing_inputs = ['vibes'];
     },
   ],
+  // Cross-field coherence: the declared mode owns its evidence vocabulary.
+  [
+    'a historical mode that claims a Player Pool source',
+    (candidate) => {
+      candidate.experience.player_source = 'player_pool';
+    },
+  ],
+  [
+    'a historical section described as pregame',
+    (candidate) => {
+      candidate.experience.sections.season_defense.context = 'pregame';
+    },
+  ],
+  [
+    'a historical schedule described as a current-season catalog',
+    (candidate) => {
+      candidate.experience.sections.schedule.context = 'current_season_catalog';
+    },
+  ],
+  [
+    'historical participants sourced from a Player Pool',
+    (candidate) => {
+      candidate.experience.sections.participants.source = 'player_pool';
+    },
+  ],
+  [
+    'a participant that overrides its experience player source',
+    (candidate) => {
+      candidate.players[0].player_source = 'player_pool';
+    },
+  ],
+  [
+    'a historical participant with no focal game line',
+    (candidate) => {
+      candidate.players[0].focal_game_line = null;
+    },
+  ],
 ])('rejects %s', (_name, mutate) => {
   const candidate = historicalPayload();
   mutate(candidate);
   expect(() => decodeMatchup(candidate)).toThrow('invalid response');
+});
+
+test.each([
+  [
+    'a current mode that claims game-log participants',
+    (candidate) => {
+      candidate.experience.player_source = 'game_logs';
+    },
+  ],
+  [
+    'a current section described as completed-season hindsight',
+    (candidate) => {
+      candidate.experience.sections.season_defense.context = 'completed_season';
+    },
+  ],
+  [
+    'current participants sourced from game logs',
+    (candidate) => {
+      candidate.experience.sections.participants.source = 'player_game_logs';
+    },
+  ],
+  [
+    'a pool player carrying a focal game line',
+    (candidate) => {
+      candidate.players[0].focal_game_line = {
+        game_id: '0022500584',
+        game_date: '2026-01-15',
+        matchup: 'LAL @ BOS',
+        minutes: 34,
+        stats: { PTS: 24, FGA: 18 },
+      };
+    },
+  ],
+  [
+    'current stat categories that diverge from the posted markets',
+    (candidate) => {
+      candidate.players[0].stat_categories = ['FGA', 'PTS'];
+    },
+  ],
+])('rejects %s', (_name, mutate) => {
+  const candidate = JSON.parse(JSON.stringify(payload));
+  candidate.experience = {
+    mode: 'current',
+    player_source: 'player_pool',
+    sections: {
+      schedule: experienceSection('available', 'event_catalog', 'current_season_catalog'),
+      participants: experienceSection('available', 'player_pool', 'posted_markets'),
+      season_defense: experienceSection('available', 'team_matchup_publication', 'pregame'),
+      last_15_defense: experienceSection('available', 'team_matchup_publication', 'pregame'),
+      injuries: experienceSection('unavailable', 'rotowire', 'current', 'disabled'),
+    },
+  };
+  // The unmutated current-mode payload must stay decodable.
+  expect(() => decodeMatchup(candidate)).not.toThrow();
+  mutate(candidate);
+  expect(() => decodeMatchup(candidate)).toThrow('invalid response');
+});
+
+test('keeps live Player Pool categories identical to the posted markets', () => {
+  const [player] = decodeMatchup(payload).players;
+
+  expect(player.playerSource).toBe('player_pool');
+  expect(player.statCategories).toEqual(player.postedMarkets);
+  expect(player.focalGameLine).toBeNull();
 });
 
 test('reads the additive selection experience and its separated focal game', () => {
@@ -1497,13 +1598,6 @@ test('reads the additive selection experience and its separated focal game', () 
   expect(
     decodeMatchupSelection({ ...raw, experience: undefined }, ['PTS', 'FGA'], 2544).experience,
   ).toBeNull();
-  expect(
-    decodeMatchupSelection(
-      { ...raw, experience: { ...raw.experience, focal_game: null } },
-      ['PTS', 'FGA'],
-      2544,
-    ).experience.focalGame,
-  ).toBeNull();
   // The focal line rejects a missing governed category on both response seams.
   expect(() =>
     decodeMatchupSelection(
@@ -1525,4 +1619,68 @@ test('reads the additive selection experience and its separated focal game', () 
       2544,
     ),
   ).toThrow('selection endpoint returned an invalid response');
+
+  const current = decodeMatchupSelection(
+    {
+      ...raw,
+      experience: {
+        mode: 'current',
+        player_source: 'player_pool',
+        focal_game: null,
+        samples: { context: 'season_to_date', excludes_focal_game: false },
+        baseline: { context: 'season_to_date', hindsight: false },
+      },
+    },
+    ['PTS', 'FGA'],
+    2544,
+  );
+  expect(current.experience.focalGame).toBeNull();
+  expect(current.experience.baseline.hindsight).toBe(false);
+});
+
+// The dossier renders its separation labels from these fields, so a mislabelled
+// response must fail closed rather than quietly drop a required disclosure.
+test.each([
+  ['a historical selection with no focal game', { focal_game: null }],
+  [
+    'a historical selection whose samples do not exclude the focal game',
+    { samples: { context: 'pregame', excludes_focal_game: false } },
+  ],
+  [
+    'a historical selection with a season-to-date sample context',
+    { samples: { context: 'season_to_date', excludes_focal_game: true } },
+  ],
+  [
+    'a historical selection whose baseline is not marked hindsight',
+    { baseline: { context: 'completed_season', hindsight: false } },
+  ],
+  [
+    'a historical selection with a season-to-date baseline context',
+    { baseline: { context: 'season_to_date', hindsight: true } },
+  ],
+  ['a historical selection sourced from a Player Pool', { player_source: 'player_pool' }],
+  ['a current selection that still carries a focal game', { mode: 'current' }],
+])('rejects %s', (_name, override) => {
+  const raw = {
+    player_id: 2544,
+    experience: {
+      mode: 'historical',
+      player_source: 'game_logs',
+      focal_game: {
+        game_id: '0022501082',
+        game_date: '2026-03-29',
+        matchup: 'LAC @ MIL',
+        minutes: 34.5,
+        stats: { PTS: 24, FGA: 18 },
+      },
+      samples: { context: 'pregame', excludes_focal_game: true },
+      baseline: { context: 'completed_season', hindsight: true },
+      ...override,
+    },
+    h2h: { thin: false, rows: [] },
+    archetype: { thin: false, rows: [] },
+  };
+  expect(() => decodeMatchupSelection(raw, ['PTS', 'FGA'], 2544)).toThrow(
+    'selection endpoint returned an invalid response',
+  );
 });

--- a/src/matchups/matchupApi.test.js
+++ b/src/matchups/matchupApi.test.js
@@ -1252,8 +1252,29 @@ const experienceSection = (status, source, context, unavailableReason = null) =>
   unavailable_reason: unavailableReason,
 });
 
-const historicalPayload = () => {
-  const candidate = JSON.parse(JSON.stringify(payload));
+// A completed game with no point-in-time snapshot: the Last-15 Surfaces are
+// unavailable, so the Last-15 section can truthfully say so.
+const withoutPointInTimeWindow = (candidate) => {
+  Object.values(candidate.league.surface_availability).forEach((windows) => {
+    windows.last_15 = { status: 'unavailable', unavailable_reason: 'no_point_in_time_snapshot' };
+  });
+  [candidate.league, ...candidate.teams].forEach((holder) => {
+    Object.values(holder.defense_sheet).forEach((rows) =>
+      rows.forEach((row) => {
+        row.last_15 = null;
+      }),
+    );
+    Object.values(holder.defensive_columns).forEach((column) => {
+      column.last_15 = null;
+    });
+  });
+  return candidate;
+};
+
+const historicalPayload = ({ pointInTime = false } = {}) => {
+  const raw = JSON.parse(JSON.stringify(payload));
+  const candidate = pointInTime ? raw : withoutPointInTimeWindow(raw);
+  candidate.game.status = { state: 'final', label: 'Final' };
   candidate.experience = {
     mode: 'historical',
     player_source: 'game_logs',
@@ -1657,6 +1678,10 @@ test('leaves the current selection contract unbound to historical evidence', () 
 });
 
 const focalLineOf = (candidate) => candidate.players[0].focal_game_line;
+const withOneParticipant = (candidate, participant) => ({
+  ...JSON.parse(JSON.stringify(candidate)),
+  players: [JSON.parse(JSON.stringify(participant))],
+});
 
 test.each([
   [
@@ -1694,7 +1719,11 @@ test('rejects participants that disagree about which game is focal', () => {
   const second = JSON.parse(JSON.stringify(candidate.players[0]));
   second.canonical_id = 1630559;
   second.name = 'Austin Reaves';
-  second.focal_game_line.game_date = '2026-01-14';
+  // Both dates are individually allowed for a 2026-01-16T00:30Z tip, so only
+  // the cross-participant agreement guard can reject this pair.
+  expect(candidate.players[0].focal_game_line.game_date).toBe('2026-01-15');
+  second.focal_game_line.game_date = '2026-01-16';
+  expect(() => decodeMatchup(withOneParticipant(candidate, second))).not.toThrow();
   candidate.players.push(second);
 
   expect(() => decodeMatchup(candidate)).toThrow('invalid response');
@@ -1884,7 +1913,8 @@ test.each([
 });
 
 test('accepts truthful archived pregame Last-15 and injury evidence in historical mode', () => {
-  const candidate = historicalPayload();
+  // A point-in-time snapshot was captured, so its Surfaces are delivered too.
+  const candidate = historicalPayload({ pointInTime: true });
   candidate.experience.sections.last_15_defense = experienceSection(
     'available',
     'team_matchup_publication',
@@ -1903,6 +1933,193 @@ test('accepts truthful archived pregame Last-15 and injury evidence in historica
   expect(sections.injuries).toEqual(
     expect.objectContaining({ status: 'available', source: 'rotowire', context: 'pregame' }),
   );
+});
+
+test('keeps historical component evidence while withholding an incomplete blend', () => {
+  const candidate = historicalPayload();
+  candidate.players[0].scores.PTS.season = {
+    components: { shot_zones: { value: 0.07, thin: true } },
+    blend: null,
+    missing_inputs: ['team_defense:play_types'],
+  };
+
+  expect(decodeMatchup(candidate).players[0].scores.PTS.season).toEqual({
+    components: { shotZones: { value: 0.07, thin: true } },
+    blend: null,
+    missingInputs: ['team_defense:play_types'],
+  });
+});
+
+test.each([
+  [
+    'a historical blend presented complete despite named missing inputs',
+    (candidate) => {
+      candidate.players[0].scores.PTS.season.missing_inputs = ['team_defense:play_types'];
+    },
+  ],
+  [
+    'a historical offensive window that withholds a computable blend',
+    (candidate) => {
+      candidate.players[0].scores.PTS.season.blend = null;
+    },
+  ],
+])('rejects %s', (_name, mutate) => {
+  const candidate = historicalPayload();
+  mutate(candidate);
+  expect(() => decodeMatchup(candidate)).toThrow('invalid response');
+});
+
+test('leaves the current-mode blend contract unchanged', () => {
+  const candidate = JSON.parse(JSON.stringify(payload));
+  candidate.players[0].scores.PTS.season.missing_inputs = ['team_defense:play_types'];
+
+  expect(decodeMatchup(candidate).players[0].scores.PTS.season.blend).toEqual({
+    value: 0.12,
+    thin: false,
+  });
+});
+
+test.each([
+  [
+    'a defense sheet for a team outside the focal game',
+    (candidate) => {
+      candidate.teams[1].team_id = 99;
+    },
+  ],
+  [
+    'a defense sheet whose tricode contradicts the game header',
+    (candidate) => {
+      candidate.teams[0].tricode = 'BOS';
+    },
+  ],
+  [
+    'defense sheets delivered home before away',
+    (candidate) => {
+      candidate.teams.reverse();
+    },
+  ],
+])('rejects %s', (_name, mutate) => {
+  const candidate = historicalPayload();
+  mutate(candidate);
+  expect(() => decodeMatchup(candidate)).toThrow('invalid response');
+});
+
+test.each([
+  [
+    'an available Season Surface alongside an unavailable Season defense section',
+    (candidate) => {
+      candidate.experience.sections.season_defense = experienceSection(
+        'unavailable',
+        null,
+        null,
+        'not_stored',
+      );
+    },
+  ],
+  [
+    'an available Season defense section with no available Season Surface',
+    (candidate) => {
+      // The Season windows go away with their Surfaces, so only the section's
+      // own claim of availability is left to reject.
+      Object.values(candidate.league.surface_availability).forEach((windows) => {
+        windows.season = { status: 'unavailable', unavailable_reason: 'not_stored' };
+      });
+      [candidate.league, ...candidate.teams].forEach((holder) => {
+        Object.values(holder.defense_sheet).forEach((rows) =>
+          rows.forEach((row) => {
+            row.season = null;
+          }),
+        );
+        Object.values(holder.defensive_columns).forEach((column) => {
+          column.season = null;
+        });
+      });
+    },
+  ],
+])('rejects %s', (_name, mutate) => {
+  const candidate = historicalPayload();
+  mutate(candidate);
+  expect(() => decodeMatchup(candidate)).toThrow('invalid response');
+});
+
+test('rejects an available Last-15 Surface alongside an unavailable Last-15 section', () => {
+  // Traditional keeps its delivered Last-15 window; the other Bases lose theirs.
+  const candidate = historicalPayload();
+  const restored = JSON.parse(JSON.stringify(payload));
+  candidate.league.surface_availability.traditional.last_15 = {
+    status: 'available',
+    unavailable_reason: null,
+  };
+  [
+    [candidate.league, restored.league],
+    ...candidate.teams.map((team, index) => [team, restored.teams[index]]),
+  ].forEach(([holder, source]) => {
+    holder.defense_sheet.traditional = source.defense_sheet.traditional;
+    Object.entries(holder.defensive_columns).forEach(([key, column]) => {
+      column.last_15 = source.defensive_columns[key].last_15;
+    });
+  });
+
+  expect(() => decodeMatchup(candidate)).toThrow('invalid response');
+});
+
+test('keeps section independence when a window is genuinely unavailable', () => {
+  const { sections } = decodeMatchup(historicalPayload()).experience;
+
+  expect(sections.seasonDefense.status).toBe('available');
+  expect(sections.last15Defense.status).toBe('unavailable');
+  expect(sections.injuries.status).toBe('unavailable');
+  expect(sections.participants.status).toBe('available');
+});
+
+test.each([
+  [
+    'a historical experience on a game that has not been played',
+    (candidate) => {
+      candidate.game.status = { state: 'scheduled', label: 'Scheduled' };
+    },
+  ],
+  [
+    'a historical experience on a postponed game',
+    (candidate) => {
+      candidate.game.status = { state: 'postponed', label: 'Postponed' };
+    },
+  ],
+  [
+    'a historical experience on a preseason game',
+    (candidate) => {
+      candidate.game.preseason = true;
+    },
+  ],
+])('rejects %s', (_name, mutate) => {
+  const candidate = historicalPayload();
+  mutate(candidate);
+  expect(() => decodeMatchup(candidate)).toThrow('invalid response');
+});
+
+test('still reads the backend-declared mode rather than inferring it from a final game', () => {
+  const finalCurrent = JSON.parse(JSON.stringify(payload));
+  finalCurrent.game.status = { state: 'final', label: 'Final' };
+
+  expect(decodeMatchup(finalCurrent).experience.mode).toBe('current');
+});
+
+test('rejects an impossible focal date rather than comparing it as a string', () => {
+  const candidate = historicalPayload();
+  focalLineOf(candidate).game_date = '2025-99-99';
+  expect(() => decodeMatchup(candidate)).toThrow('invalid response');
+
+  const dossier = historicalDossier();
+  dossier.h2h.rows[0].game_date = '2025-99-99';
+  expect(() => decodeMatchupSelection(dossier, ['PTS', 'FGA'], 2544, focalExpectation)).toThrow(
+    'selection endpoint returned an invalid response',
+  );
+
+  const impossibleFocal = historicalDossier();
+  impossibleFocal.experience.focal_game.game_date = '2026-02-30';
+  expect(() =>
+    decodeMatchupSelection(impossibleFocal, ['PTS', 'FGA'], 2544, focalExpectation),
+  ).toThrow('selection endpoint returned an invalid response');
 });
 
 test('keeps live Player Pool categories identical to the posted markets', () => {

--- a/src/matchups/matchupApi.test.js
+++ b/src/matchups/matchupApi.test.js
@@ -971,6 +971,7 @@ test('accepts a null offensive Blend only when zero components are computable', 
   expect(decodeMatchup(zeroComponents).players[0].scores.FGA.last15).toEqual({
     components: {},
     blend: null,
+    missingInputs: [],
   });
 
   const componentWithoutBlend = JSON.parse(JSON.stringify(zeroComponents));
@@ -1242,4 +1243,223 @@ test('selection requests keep the game string and canonical player integer disti
     'selection endpoint returned an invalid response',
   );
   expect(apiClient.get).toHaveBeenCalledTimes(1);
+});
+
+const experienceSection = (status, source, context, unavailableReason = null) => ({
+  status,
+  source,
+  context,
+  unavailable_reason: unavailableReason,
+});
+
+const historicalPayload = () => {
+  const candidate = JSON.parse(JSON.stringify(payload));
+  candidate.experience = {
+    mode: 'historical',
+    player_source: 'game_logs',
+    sections: {
+      schedule: experienceSection('available', 'event_catalog', 'completed_season_catalog'),
+      participants: experienceSection('available', 'player_game_logs', 'completed_season'),
+      season_defense: experienceSection(
+        'available',
+        'team_matchup_publication',
+        'completed_season',
+      ),
+      last_15_defense: experienceSection('unavailable', null, null, 'no_point_in_time_snapshot'),
+      injuries: experienceSection('unavailable', null, null, 'no_pregame_snapshot'),
+    },
+  };
+  const participant = candidate.players[0];
+  participant.posted_markets = [];
+  participant.provenance = {};
+  participant.player_source = 'game_logs';
+  participant.stat_categories = ['PTS', 'FGA'];
+  participant.focal_game_line = {
+    game_id: '0022501082',
+    game_date: '2026-03-29',
+    matchup: 'LAC @ MIL',
+    minutes: 34.5,
+    stats: { PTS: 24, FGA: 18 },
+  };
+  return candidate;
+};
+
+test('reads the additive Historical Matchup mode and section-owned evidence', () => {
+  const decoded = decodeMatchup(historicalPayload());
+
+  expect(decoded.experience.mode).toBe('historical');
+  expect(decoded.experience.playerSource).toBe('game_logs');
+  expect(decoded.experience.sections.seasonDefense).toEqual({
+    status: 'available',
+    source: 'team_matchup_publication',
+    context: 'completed_season',
+    unavailableReason: null,
+  });
+  expect(decoded.experience.sections.last15Defense).toEqual({
+    status: 'unavailable',
+    source: null,
+    context: null,
+    unavailableReason: 'no_point_in_time_snapshot',
+  });
+  expect(decoded.experience.sections.participants.source).toBe('player_game_logs');
+  expect(decoded.experience.sections.injuries.unavailableReason).toBe('no_pregame_snapshot');
+});
+
+test('treats an absent experience block as the pre-historical live contract', () => {
+  const decoded = decodeMatchup(payload);
+
+  expect(decoded.experience).toEqual({
+    mode: 'current',
+    playerSource: 'player_pool',
+    sections: null,
+  });
+  expect(decoded.players[0].playerSource).toBe('player_pool');
+  expect(decoded.players[0].statCategories).toEqual(['PTS', 'FGA']);
+  expect(decoded.players[0].focalGameLine).toBeNull();
+  expect(decoded.players[0].scores.PTS.season.missingInputs).toEqual([]);
+});
+
+test('reads a game-log participant that carries no posted-market claim', () => {
+  const [participant] = decodeMatchup(historicalPayload()).players;
+
+  expect(participant.playerSource).toBe('game_logs');
+  expect(participant.postedMarkets).toEqual([]);
+  expect(participant.provenance).toEqual({});
+  expect(participant.statCategories).toEqual(['PTS', 'FGA']);
+  expect(participant.focalGameLine).toEqual({
+    gameId: '0022501082',
+    gameDate: '2026-03-29',
+    matchup: 'LAC @ MIL',
+    minutes: 34.5,
+    stats: { PTS: 24, FGA: 18 },
+  });
+});
+
+test('names the missing inputs of an incomplete Matchup Score', () => {
+  const candidate = historicalPayload();
+  candidate.players[0].scores.PTS.last_15 = {
+    components: {},
+    blend: null,
+    missing_inputs: ['team_defense:play_types', 'player_diet:shot_zones', 'player_season_rate'],
+  };
+
+  expect(decodeMatchup(candidate).players[0].scores.PTS.last15).toEqual({
+    components: {},
+    blend: null,
+    missingInputs: ['team_defense:play_types', 'player_diet:shot_zones', 'player_season_rate'],
+  });
+});
+
+test.each([
+  [
+    'an unknown experience mode',
+    (candidate) => {
+      candidate.experience.mode = 'archived';
+    },
+  ],
+  [
+    'a missing experience section',
+    (candidate) => {
+      delete candidate.experience.sections.injuries;
+    },
+  ],
+  [
+    'an experience section missing a key',
+    (candidate) => {
+      delete candidate.experience.sections.schedule.context;
+    },
+  ],
+  [
+    'an available section that still names an unavailable reason',
+    (candidate) => {
+      candidate.experience.sections.schedule.unavailable_reason = 'no_pregame_snapshot';
+    },
+  ],
+  [
+    'an unavailable section with no reason',
+    (candidate) => {
+      candidate.experience.sections.last_15_defense.unavailable_reason = null;
+    },
+  ],
+  [
+    'an ungoverned section source',
+    (candidate) => {
+      candidate.experience.sections.participants.source = 'roster_guess';
+    },
+  ],
+  [
+    'a posted-market claim on a game-log participant',
+    (candidate) => {
+      candidate.players[0].posted_markets = ['PTS'];
+    },
+  ],
+  [
+    'provenance on a game-log participant',
+    (candidate) => {
+      candidate.players[0].provenance = { prizepicks: ['PTS'] };
+    },
+  ],
+  [
+    'stat categories that disagree with the delivered scores',
+    (candidate) => {
+      candidate.players[0].stat_categories = ['PTS', 'FGA', 'AST'];
+    },
+  ],
+  [
+    'a focal game line missing a governed category',
+    (candidate) => {
+      delete candidate.players[0].focal_game_line.stats.FGA;
+    },
+  ],
+  [
+    'an ungoverned missing-input name',
+    (candidate) => {
+      candidate.players[0].scores.PTS.season.missing_inputs = ['vibes'];
+    },
+  ],
+])('rejects %s', (_name, mutate) => {
+  const candidate = historicalPayload();
+  mutate(candidate);
+  expect(() => decodeMatchup(candidate)).toThrow('invalid response');
+});
+
+test('reads the additive selection experience and its separated focal game', () => {
+  const raw = {
+    player_id: 2544,
+    experience: {
+      mode: 'historical',
+      player_source: 'game_logs',
+      focal_game: {
+        game_id: '0022501082',
+        game_date: '2026-03-29',
+        matchup: 'LAC @ MIL',
+        minutes: 34.5,
+        stats: { PTS: 24, FGA: 18 },
+      },
+      samples: { context: 'pregame', excludes_focal_game: true },
+      baseline: { context: 'completed_season', hindsight: true },
+    },
+    h2h: { thin: false, rows: [] },
+    archetype: { thin: false, rows: [] },
+  };
+
+  const selection = decodeMatchupSelection(raw, ['PTS', 'FGA'], 2544);
+  expect(selection.experience.mode).toBe('historical');
+  expect(selection.experience.focalGame.matchup).toBe('LAC @ MIL');
+  expect(selection.experience.samples).toEqual({ context: 'pregame', excludesFocalGame: true });
+  expect(selection.experience.baseline).toEqual({
+    context: 'completed_season',
+    hindsight: true,
+  });
+
+  expect(
+    decodeMatchupSelection({ ...raw, experience: undefined }, ['PTS', 'FGA'], 2544).experience,
+  ).toBeNull();
+  expect(() =>
+    decodeMatchupSelection(
+      { ...raw, experience: { ...raw.experience, baseline: { context: 'completed_season' } } },
+      ['PTS', 'FGA'],
+      2544,
+    ),
+  ).toThrow('selection endpoint returned an invalid response');
 });


### PR DESCRIPTION
Closes #60
Part of crf04/statsplus#42
Merge after: crf04/statsplus-backend#208

Renders completed-season defense evidence independently, game-log participants, focal lines, historical provenance, unavailable scores, and the historical dossier without changing the current Matchup journey.

Verification: lint and format passed; 446 Jest tests passed; production build passed; full Playwright gate passed twice (82 passed, 2 production-smoke skips each run); coordination contract check passed.