### PR TITLE
Accept home-side historical matchup labels

### DIFF
--- a/e2e/fixtures/courtai.js
+++ b/e2e/fixtures/courtai.js
@@ -679,13 +679,18 @@ const historicalScores = (base, unavailable = []) =>
     ]),
   );
 
-const historicalFocalLine = (minutes, stats) => ({
-  game_id: HISTORICAL_GAME_ID,
-  game_date: '2026-03-29',
-  matchup: 'LAC @ MIL',
-  minutes,
-  stats: Object.fromEntries(HISTORICAL_CATEGORIES.map((category) => [category, stats[category]])),
-});
+const historicalFocalLine = (team, minutes, stats) => {
+  const away = historicalGame.away_team;
+  const home = historicalGame.home_team;
+  const isHome = team.team_id === home.team_id;
+  return {
+    game_id: HISTORICAL_GAME_ID,
+    game_date: '2026-03-29',
+    matchup: isHome ? `${home.tricode} vs. ${away.tricode}` : `${away.tricode} @ ${home.tricode}`,
+    minutes,
+    stats: Object.fromEntries(HISTORICAL_CATEGORIES.map((category) => [category, stats[category]])),
+  };
+};
 
 const historicalParticipant = ({
   id,
@@ -706,7 +711,7 @@ const historicalParticipant = ({
   posted_markets: [],
   provenance: {},
   stat_categories: HISTORICAL_CATEGORIES,
-  focal_game_line: historicalFocalLine(minutes, focalStats),
+  focal_game_line: historicalFocalLine(team, minutes, focalStats),
   season_scoring: seasonScoring,
   last_10_minutes: [34, 33, 36, 32, 35, 34, 33, 36, 35, 34],
   diet_shares: dietShares,

--- a/e2e/specs/matchup-detail.spec.js
+++ b/e2e/specs/matchup-detail.spec.js
@@ -134,6 +134,11 @@ test('@critical a completed-season matchup renders section-owned evidence and ga
   await expect(page.getByRole('article', { name: 'Giannis Antetokounmpo player' })).toBeVisible();
   await expect(page.getByRole('article', { name: 'Damian Lillard player' })).toBeVisible();
   await expect(page.getByRole('article', { name: 'Kawhi Leonard player' })).toHaveCount(0);
+  await expect(
+    page
+      .getByRole('article', { name: 'Giannis Antetokounmpo player' })
+      .getByText('Focal game MIL vs. LAC · 35.1 MIN · 33.0 PTS'),
+  ).toBeVisible();
   await page.getByRole('button', { name: 'MIL defense' }).click();
 
   // Selecting a game-log participant opens the stored-data dossier.

--- a/src/matchups/matchupApi.js
+++ b/src/matchups/matchupApi.js
@@ -518,10 +518,12 @@ const decodePlayer = (player, experience, game) => {
   // The line is evidence about this game, so its game, matchup identity, and
   // date must all be this game's.
   if (gameLogSourced ? focalGameLine === null : focalGameLine !== null) throw invalid();
+  const opposingTeam = player.team_id === game.away.teamId ? game.home : game.away;
+  const expectedMatchup = `${tricode} ${player.team_id === game.home.teamId ? 'vs.' : '@'} ${opposingTeam.tricode}`;
   if (
     focalGameLine !== null &&
     (focalGameLine.gameId !== game.gameId ||
-      focalGameLine.matchup !== `${game.away.tricode} @ ${game.home.tricode}` ||
+      focalGameLine.matchup !== expectedMatchup ||
       !focalDateFits(focalGameLine.gameDate, game.scheduledAt))
   ) {
     throw invalid();

--- a/src/matchups/matchupApi.js
+++ b/src/matchups/matchupApi.js
@@ -518,8 +518,9 @@ const decodePlayer = (player, experience, game) => {
   // The line is evidence about this game, so its game, matchup identity, and
   // date must all be this game's.
   if (gameLogSourced ? focalGameLine === null : focalGameLine !== null) throw invalid();
-  const opposingTeam = player.team_id === game.away.teamId ? game.home : game.away;
-  const expectedMatchup = `${tricode} ${player.team_id === game.home.teamId ? 'vs.' : '@'} ${opposingTeam.tricode}`;
+  const isHome = focalTeam.teamId === game.home.teamId;
+  const opposingTeam = isHome ? game.away : game.home;
+  const expectedMatchup = `${tricode} ${isHome ? 'vs.' : '@'} ${opposingTeam.tricode}`;
   if (
     focalGameLine !== null &&
     (focalGameLine.gameId !== game.gameId ||

--- a/src/matchups/matchupApi.test.js
+++ b/src/matchups/matchupApi.test.js
@@ -1726,6 +1726,27 @@ test('accepts the home participant game-log matchup identity', () => {
   expect(() => decodeMatchup(withOneParticipant(candidate, homeParticipant))).not.toThrow();
 });
 
+test.each([
+  [
+    'a home participant carrying the away matchup form',
+    (candidate) => {
+      candidate.players[0].team_id = candidate.game.home_team.team_id;
+      candidate.players[0].tricode = candidate.game.home_team.tricode;
+      candidate.players[0].focal_game_line.matchup = 'LAL @ BOS';
+    },
+  ],
+  [
+    'an away participant carrying the home matchup form',
+    (candidate) => {
+      candidate.players[0].focal_game_line.matchup = 'BOS vs. LAL';
+    },
+  ],
+])('rejects %s', (_name, mutate) => {
+  const candidate = historicalPayload();
+  mutate(candidate);
+  expect(() => decodeMatchup(candidate)).toThrow('invalid response');
+});
+
 test('rejects participants that disagree about which game is focal', () => {
   const candidate = historicalPayload();
   const second = JSON.parse(JSON.stringify(candidate.players[0]));

--- a/src/matchups/matchupApi.test.js
+++ b/src/matchups/matchupApi.test.js
@@ -1714,6 +1714,18 @@ test.each([
   expect(() => decodeMatchup(candidate)).toThrow('invalid response');
 });
 
+test('accepts the home participant game-log matchup identity', () => {
+  const candidate = historicalPayload();
+  const homeParticipant = JSON.parse(JSON.stringify(candidate.players[0]));
+  homeParticipant.canonical_id = 1630559;
+  homeParticipant.name = 'Home Participant';
+  homeParticipant.team_id = candidate.game.home_team.team_id;
+  homeParticipant.tricode = candidate.game.home_team.tricode;
+  homeParticipant.focal_game_line.matchup = 'BOS vs. LAL';
+
+  expect(() => decodeMatchup(withOneParticipant(candidate, homeParticipant))).not.toThrow();
+});
+
 test('rejects participants that disagree about which game is focal', () => {
   const candidate = historicalPayload();
   const second = JSON.parse(JSON.stringify(candidate.players[0]));


### PR DESCRIPTION
## Summary

Fix the issue 42 production decoder mismatch: historical player lines are participant-relative (`LAC @ MIL` for LAC and `MIL vs. LAC` for MIL), but the frontend previously required the away-oriented label for every participant. The decoder, deterministic fixture, unit coverage, and browser journey now enforce the backend contract for both teams.

Follow-up to crf04/statsplus#42 and crf04/statsplus-frontend#60.

## Verification

- `npm run lint`
- `npm run format:check`
- `npm run test:ci` (449 tests passed)
- `npm run build`
- `npm run test:e2e` (82 passed, 2 production-only skips)
- Exact production game `0022501082` payload reproduces the former decoder error before the fix and decodes after it
- Mutation proof: a loose game-level label check fails the new participant-binding tests
- Cross-repository contract check passed
- Fresh cross-vendor review: no remaining findings