### PR TITLE
Describe a Saved Filter Set by the parameters it carries

### DIFF
--- a/e2e/specs/core-flows.spec.js
+++ b/e2e/specs/core-flows.spec.js
@@ -1293,6 +1293,8 @@ test('@critical a saved Filter Set is a name that reopens the same Log Workspace
   await page.getByRole('button', { name: 'Back to search' }).click();
   await expect(page).toHaveURL(/\/$/);
   await page.getByRole('button', { name: 'Saved Filter Sets' }).click();
+  // The row says what the Filter Set asks for, not only what it was called.
+  await expect(page.getByRole('dialog').getByText('last 10', { exact: true })).toBeVisible();
   await page.getByRole('button', { name: 'Open saved Filter Set LeBron last 10' }).click();
 
   await expect(page).toHaveURL(/player_name=LeBron\+James/);
@@ -1314,7 +1316,9 @@ test('@critical a saved Filter Set is a name that reopens the same Log Workspace
     page.getByRole('button', { name: 'Open saved Filter Set LeBron recent form' }),
   ).toBeVisible();
 
+  // Deleting is not undoable, so the row asks before it goes.
   await page.getByRole('button', { name: 'Delete LeBron recent form' }).click();
+  await page.getByRole('button', { name: 'Confirm deleting LeBron recent form' }).click();
   await expect(page.getByText('You have not saved any Filter Sets yet')).toBeVisible();
 });
 

--- a/src/SavedFilterSetsModal.css
+++ b/src/SavedFilterSetsModal.css
@@ -1,0 +1,161 @@
+/* The saved list, built on the design tokens in theme.css. */
+
+.saved-filter-sets-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.saved-filter-set-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.7rem 0.65rem;
+  border-bottom: 1px solid var(--ct-line);
+  border-left: 2px solid transparent;
+}
+
+.saved-filter-set-row:hover,
+.saved-filter-set-row:focus-within {
+  background: var(--ct-surface-2);
+  border-left-color: var(--ct-gold);
+}
+
+.saved-filter-set-row-confirming {
+  border-left-color: var(--ct-miss);
+  background: var(--ct-miss-soft);
+}
+
+.saved-filter-set-open {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  text-align: left;
+  background: none;
+  border: 0;
+  padding: 0;
+  color: inherit;
+}
+
+.saved-filter-set-name {
+  font-family: var(--ct-display);
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: 0.015em;
+  line-height: 1.1;
+}
+
+.saved-filter-set-row:hover .saved-filter-set-name {
+  color: var(--ct-gold);
+}
+
+.saved-filter-set-parameters {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+
+.saved-filter-set-parameter {
+  font-family: var(--ct-mono);
+  font-size: 0.78rem;
+  color: var(--ct-text);
+  border: 1px solid var(--ct-line-strong);
+  border-radius: 999px;
+  padding: 0.14rem 0.55rem;
+  white-space: nowrap;
+}
+
+/* The player is a parameter like any other, but it is the one that identifies
+   a Saved Filter Set fastest, so it leads and keeps the accent. */
+.saved-filter-set-player {
+  color: var(--ct-gold);
+  background: var(--ct-gold-soft);
+  border-color: transparent;
+}
+
+/* Green and red are reserved for semantic pairs; on-court and off-court
+   teammates are one, and must not be read for each other. */
+.saved-filter-set-parameter-on {
+  color: var(--ct-hit);
+  background: var(--ct-hit-soft);
+  border-color: transparent;
+}
+
+.saved-filter-set-parameter-off {
+  color: var(--ct-miss);
+  background: var(--ct-miss-soft);
+  border-color: transparent;
+}
+
+.saved-filter-set-refusal {
+  font-size: 0.8rem;
+  color: var(--ct-miss);
+  font-style: italic;
+}
+
+/* Hidden by opacity rather than by not being rendered, so the controls stay in
+   the accessibility tree and reachable by keyboard. */
+.saved-filter-set-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.15rem;
+  opacity: 0;
+}
+
+.saved-filter-set-row:hover .saved-filter-set-actions,
+.saved-filter-set-row:focus-within .saved-filter-set-actions,
+.saved-filter-set-actions-shown {
+  opacity: 1;
+}
+
+/* A touch device never hovers, so hiding the actions there would hide them for
+   good. Show them always where there is no pointer to reveal them with. */
+@media (hover: none) {
+  .saved-filter-set-actions {
+    opacity: 1;
+  }
+}
+
+.saved-filter-set-action {
+  background: none;
+  border: 0;
+  color: var(--ct-dim);
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.3rem;
+}
+
+.saved-filter-set-action:hover,
+.saved-filter-set-action:focus-visible {
+  color: var(--ct-gold);
+}
+
+.saved-filter-set-action-danger:hover,
+.saved-filter-set-action-danger:focus-visible {
+  color: var(--ct-miss);
+}
+
+.saved-filter-set-confirm {
+  font-size: 0.72rem;
+  color: var(--ct-miss);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+}
+
+.saved-filter-set-rename {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  width: 100%;
+}
+
+.saved-filter-set-rename .form-control {
+  background: var(--ct-ink);
+  border-color: var(--ct-gold);
+  color: var(--ct-text);
+}

--- a/src/SavedFilterSetsModal.js
+++ b/src/SavedFilterSetsModal.js
@@ -66,10 +66,12 @@ const SavedFilterSetRow = ({ savedFilterSet, isMutating, onOpen, onRename, onDel
       <li className="saved-filter-set-row">
         <Form
           className="saved-filter-set-rename"
-          onSubmit={(event) => {
+          onSubmit={async (event) => {
             event.preventDefault();
-            onRename(draftName.trim());
-            setInteraction(null);
+            // The form closes only once the backend has taken the name. A
+            // rejected rename keeps the field and what was typed in it, so a
+            // duplicate name is one edit away rather than a retype.
+            if (await onRename(draftName.trim())) setInteraction(null);
           }}
         >
           <Form.Control
@@ -202,8 +204,10 @@ const SavedFilterSetsModal = ({ show, onHide }) => {
     try {
       await mutate();
       await loadSavedFilterSets();
+      return true;
     } catch (mutationError) {
       setError(getRequestErrorMessage(mutationError, fallbackMessage));
+      return false;
     } finally {
       setIsMutating(false);
     }

--- a/src/SavedFilterSetsModal.js
+++ b/src/SavedFilterSetsModal.js
@@ -1,12 +1,14 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Alert, Button, Form, ListGroup, Modal, Spinner } from 'react-bootstrap';
+import { Alert, Button, Form, Modal, Spinner } from 'react-bootstrap';
 import { useNavigate } from 'react-router-dom';
 import { getRequestErrorMessage } from './gameLogsApi';
+import { describeSavedFilterSet } from './savedFilterSetDescription';
 import {
   deleteSavedFilterSet,
   fetchSavedFilterSets,
   renameSavedFilterSet,
 } from './savedFilterSetsApi';
+import './SavedFilterSetsModal.css';
 
 /*
  * The saved list is the same list wherever it is opened from: the Query Prompt,
@@ -14,14 +16,160 @@ import {
  * query string and stops there — the effect watching the URL is what applies
  * the Filter Set, so a saved link and a pasted link travel the same path, down
  * to the error a link we can no longer honour produces.
+ *
+ * A row says what its Filter Set asks for rather than only what it was called.
+ * The name is typed in a hurry and the prose of a Parsed Query is never stored,
+ * so the parameters are the only description that can be relied on.
  */
+
+const Parameters = ({ described }) => (
+  <span className="saved-filter-set-parameters">
+    {/* A refused link decodes to no Filter Set at all, so it has no parameters
+        to show. Its player is still read off the raw URL, because a row has to
+        stay identifiable enough to delete. */}
+    {described.player && (
+      <span className="saved-filter-set-parameter saved-filter-set-player">{described.player}</span>
+    )}
+    {described.refused ? (
+      <span className="saved-filter-set-refusal">this link can no longer be opened</span>
+    ) : (
+      <>
+        {described.parameters.length === 0 && (
+          <span className="saved-filter-set-parameter">every logged game</span>
+        )}
+        {described.parameters.map((parameter) => (
+          <span
+            key={parameter.key}
+            className={`saved-filter-set-parameter${
+              parameter.tone ? ` saved-filter-set-parameter-${parameter.tone}` : ''
+            }`}
+          >
+            {parameter.label}
+          </span>
+        ))}
+      </>
+    )}
+  </span>
+);
+
+/*
+ * A row owns only the state of its own interaction. Renaming and deleting go
+ * back through the list's single mutation path, so what a rejection does is the
+ * same wherever it came from.
+ */
+const SavedFilterSetRow = ({ savedFilterSet, isMutating, onOpen, onRename, onDelete }) => {
+  const [interaction, setInteraction] = useState(null);
+  const [draftName, setDraftName] = useState(savedFilterSet.name);
+
+  if (interaction === 'rename') {
+    return (
+      <li className="saved-filter-set-row">
+        <Form
+          className="saved-filter-set-rename"
+          onSubmit={(event) => {
+            event.preventDefault();
+            onRename(draftName.trim());
+            setInteraction(null);
+          }}
+        >
+          <Form.Control
+            autoFocus
+            size="sm"
+            value={draftName}
+            maxLength={100}
+            aria-label={`New name for ${savedFilterSet.name}`}
+            onChange={(event) => setDraftName(event.target.value)}
+          />
+          <Button type="submit" size="sm" disabled={isMutating || !draftName.trim()}>
+            Save name
+          </Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={isMutating}
+            onClick={() => setInteraction(null)}
+          >
+            Cancel
+          </Button>
+        </Form>
+      </li>
+    );
+  }
+
+  const isConfirming = interaction === 'confirm-delete';
+
+  return (
+    <li className={`saved-filter-set-row${isConfirming ? ' saved-filter-set-row-confirming' : ''}`}>
+      <button
+        type="button"
+        className="saved-filter-set-open"
+        aria-label={`Open saved Filter Set ${savedFilterSet.name}`}
+        onClick={() => onOpen()}
+      >
+        <span className="saved-filter-set-name">{savedFilterSet.name}</span>
+        <Parameters described={describeSavedFilterSet(savedFilterSet.queryString)} />
+      </button>
+      {isConfirming ? (
+        // Deleting is not undoable, so it asks on the row rather than removing
+        // an item on the press that reached for it.
+        <div className="saved-filter-set-actions saved-filter-set-actions-shown">
+          <span className="saved-filter-set-confirm">Delete?</span>
+          <button
+            type="button"
+            className="saved-filter-set-action saved-filter-set-action-danger"
+            aria-label={`Confirm deleting ${savedFilterSet.name}`}
+            disabled={isMutating}
+            onClick={() => {
+              setInteraction(null);
+              onDelete();
+            }}
+          >
+            Yes
+          </button>
+          <button
+            type="button"
+            className="saved-filter-set-action"
+            aria-label={`Keep ${savedFilterSet.name}`}
+            disabled={isMutating}
+            onClick={() => setInteraction(null)}
+          >
+            No
+          </button>
+        </div>
+      ) : (
+        <div className="saved-filter-set-actions">
+          <button
+            type="button"
+            className="saved-filter-set-action"
+            aria-label={`Rename ${savedFilterSet.name}`}
+            disabled={isMutating}
+            onClick={() => {
+              setDraftName(savedFilterSet.name);
+              setInteraction('rename');
+            }}
+          >
+            Rename
+          </button>
+          <button
+            type="button"
+            className="saved-filter-set-action saved-filter-set-action-danger"
+            aria-label={`Delete ${savedFilterSet.name}`}
+            disabled={isMutating}
+            onClick={() => setInteraction('confirm-delete')}
+          >
+            Delete
+          </button>
+        </div>
+      )}
+    </li>
+  );
+};
+
 const SavedFilterSetsModal = ({ show, onHide }) => {
   const navigate = useNavigate();
   const [savedFilterSets, setSavedFilterSets] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
-  const [renamingId, setRenamingId] = useState(null);
-  const [draftName, setDraftName] = useState('');
   const [isMutating, setIsMutating] = useState(false);
 
   const loadSavedFilterSets = useCallback(async () => {
@@ -43,7 +191,6 @@ const SavedFilterSetsModal = ({ show, onHide }) => {
 
   useEffect(() => {
     if (!show) return;
-    setRenamingId(null);
     loadSavedFilterSets();
   }, [show, loadSavedFilterSets]);
 
@@ -54,7 +201,6 @@ const SavedFilterSetsModal = ({ show, onHide }) => {
     setError(null);
     try {
       await mutate();
-      setRenamingId(null);
       await loadSavedFilterSets();
     } catch (mutationError) {
       setError(getRequestErrorMessage(mutationError, fallbackMessage));
@@ -68,16 +214,12 @@ const SavedFilterSetsModal = ({ show, onHide }) => {
     onHide();
   };
 
-  const startRename = (savedFilterSet) => {
-    setRenamingId(savedFilterSet.id);
-    setDraftName(savedFilterSet.name);
-  };
-
   return (
     <Modal
       show={show}
       onHide={onHide}
       centered
+      size="lg"
       contentClassName="dark-card"
       aria-labelledby="saved-filter-sets-title"
     >
@@ -105,80 +247,30 @@ const SavedFilterSetsModal = ({ show, onHide }) => {
           </p>
         )}
         {savedFilterSets.length > 0 && (
-          <ListGroup variant="flush">
+          <ul className="saved-filter-sets-list">
             {savedFilterSets.map((savedFilterSet) => (
-              <ListGroup.Item
+              <SavedFilterSetRow
+                // Keyed by id so a row's own interaction state cannot survive
+                // onto a different item when the list reloads.
                 key={savedFilterSet.id}
-                className="bg-transparent text-white px-0 border-secondary"
-              >
-                <div className="d-flex align-items-center justify-content-between gap-2">
-                  <Button
-                    variant="link"
-                    className="p-0 text-start text-decoration-none flex-grow-1"
-                    aria-label={`Open saved Filter Set ${savedFilterSet.name}`}
-                    onClick={() => handleOpen(savedFilterSet)}
-                  >
-                    {savedFilterSet.name}
-                  </Button>
-                  <Button
-                    variant="outline-primary"
-                    size="sm"
-                    aria-label={`Rename ${savedFilterSet.name}`}
-                    disabled={isMutating}
-                    onClick={() => startRename(savedFilterSet)}
-                  >
-                    Rename
-                  </Button>
-                  <Button
-                    variant="outline-danger"
-                    size="sm"
-                    aria-label={`Delete ${savedFilterSet.name}`}
-                    disabled={isMutating}
-                    onClick={() =>
-                      runMutation(
-                        () => deleteSavedFilterSet({ id: savedFilterSet.id }),
-                        'Unable to delete this saved Filter Set. Please try again.',
-                      )
-                    }
-                  >
-                    Delete
-                  </Button>
-                </div>
-                {renamingId === savedFilterSet.id && (
-                  <Form
-                    className="d-flex align-items-center gap-2 mt-2"
-                    onSubmit={(event) => {
-                      event.preventDefault();
-                      runMutation(
-                        () =>
-                          renameSavedFilterSet({ id: savedFilterSet.id, name: draftName.trim() }),
-                        'Unable to rename this saved Filter Set. Please try again.',
-                      );
-                    }}
-                  >
-                    <Form.Control
-                      size="sm"
-                      value={draftName}
-                      maxLength={100}
-                      aria-label={`New name for ${savedFilterSet.name}`}
-                      onChange={(event) => setDraftName(event.target.value)}
-                    />
-                    <Button type="submit" size="sm" disabled={isMutating || !draftName.trim()}>
-                      Save name
-                    </Button>
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      disabled={isMutating}
-                      onClick={() => setRenamingId(null)}
-                    >
-                      Cancel
-                    </Button>
-                  </Form>
-                )}
-              </ListGroup.Item>
+                savedFilterSet={savedFilterSet}
+                isMutating={isMutating}
+                onOpen={() => handleOpen(savedFilterSet)}
+                onRename={(name) =>
+                  runMutation(
+                    () => renameSavedFilterSet({ id: savedFilterSet.id, name }),
+                    'Unable to rename this saved Filter Set. Please try again.',
+                  )
+                }
+                onDelete={() =>
+                  runMutation(
+                    () => deleteSavedFilterSet({ id: savedFilterSet.id }),
+                    'Unable to delete this saved Filter Set. Please try again.',
+                  )
+                }
+              />
             ))}
-          </ListGroup>
+          </ul>
         )}
       </Modal.Body>
     </Modal>

--- a/src/SavedFilterSetsModal.test.js
+++ b/src/SavedFilterSetsModal.test.js
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, useLocation } from 'react-router-dom';
 import SavedFilterSetsModal from './SavedFilterSetsModal';
 import {
@@ -47,10 +47,9 @@ test('lists saved Filter Sets in the order the backend returned them', async () 
   renderModal();
 
   const names = await screen.findAllByRole('button', { name: /Open saved Filter Set/ });
-  expect(names.map((button) => button.getAttribute('aria-label'))).toEqual([
-    'Open saved Filter Set Curry at home',
-    'Open saved Filter Set LeBron last 10',
-  ]);
+  expect(names).toHaveLength(2);
+  expect(names[0]).toHaveAccessibleName('Open saved Filter Set Curry at home');
+  expect(names[1]).toHaveAccessibleName('Open saved Filter Set LeBron last 10');
 });
 
 /*
@@ -74,21 +73,24 @@ test('describes a Saved Filter Set by every parameter its URL carries', async ()
   ]);
   renderModal();
 
-  const row = (await screen.findByRole('button', { name: /Open saved Filter Set/ })).closest('li');
-  [
-    'Luka Doncic',
-    '2025-26',
-    'last 10',
-    'away',
-    'vs top 5 Isolation D',
-    'vs bottom 8 Transition D',
-    '32–48 min',
-    'since 2026-02-01',
-    'with Kyrie Irving',
-    'without Anthony Davis',
-    'AST ≥ 8',
-    'PLAYTYPE_RTG 40–90',
-  ].forEach((parameter) => expect(within(row).getByText(parameter)).toBeVisible());
+  const row = await screen.findByRole('button', { name: /Open saved Filter Set/ });
+  expect(row).toHaveTextContent(
+    [
+      'everything at once',
+      'Luka Doncic',
+      '2025-26',
+      'last 10',
+      'away',
+      'vs top 5 Isolation D',
+      'vs bottom 8 Transition D',
+      '32–48 min',
+      'since 2026-02-01',
+      'with Kyrie Irving',
+      'without Anthony Davis',
+      'AST ≥ 8',
+      'PLAYTYPE_RTG 40–90',
+    ].join(''),
+  );
 });
 
 test('says a Filter Set with no parameters covers every logged game', async () => {
@@ -178,7 +180,24 @@ test('surfaces a duplicate-name conflict and keeps the item in the list', async 
   expect(await screen.findByRole('alert')).toHaveTextContent(
     'You already have a saved set by that name.',
   );
-  expect(screen.getByRole('button', { name: 'Open saved Filter Set Curry at home' })).toBeVisible();
+  // The rejection is answerable in place: the field and the attempted name stay
+  // put, so fixing a duplicate is one edit rather than a retype.
+  expect(screen.getByLabelText('New name for Curry at home')).toHaveValue('LeBron last 10');
+});
+
+test('a rename the backend takes closes the field', async () => {
+  renameSavedFilterSet.mockResolvedValue(undefined);
+  renderModal();
+
+  fireEvent.click(await screen.findByRole('button', { name: 'Rename Curry at home' }));
+  fireEvent.change(screen.getByLabelText('New name for Curry at home'), {
+    target: { value: 'Curry home splits' },
+  });
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Save name' }));
+  });
+
+  expect(screen.queryByLabelText('New name for Curry at home')).not.toBeInTheDocument();
 });
 
 test('deletes an item once the row confirms, and reloads the list', async () => {

--- a/src/SavedFilterSetsModal.test.js
+++ b/src/SavedFilterSetsModal.test.js
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter, useLocation } from 'react-router-dom';
 import SavedFilterSetsModal from './SavedFilterSetsModal';
 import {
@@ -47,7 +47,73 @@ test('lists saved Filter Sets in the order the backend returned them', async () 
   renderModal();
 
   const names = await screen.findAllByRole('button', { name: /Open saved Filter Set/ });
-  expect(names.map((button) => button.textContent)).toEqual(['Curry at home', 'LeBron last 10']);
+  expect(names.map((button) => button.getAttribute('aria-label'))).toEqual([
+    'Open saved Filter Set Curry at home',
+    'Open saved Filter Set LeBron last 10',
+  ]);
+});
+
+/*
+ * A name is typed in a hurry and the prose of a Parsed Query is never stored,
+ * so the parameters are the only description of a saved item that can be
+ * relied on. One Filter Set carrying every kind of parameter says them all.
+ */
+test('describes a Saved Filter Set by every parameter its URL carries', async () => {
+  fetchSavedFilterSets.mockResolvedValue([
+    {
+      id: 9,
+      name: 'everything at once',
+      queryString:
+        'player_name=Luka+Doncic&season_filter=2025-26&game_filter=10&location_filter=Away' +
+        '&teams_against%5B%5D=Isolation&rank_filter%5B%5D=5' +
+        '&teams_against%5B%5D=Transition&rank_filter%5B%5D=-8' +
+        '&minutes_filter=32,48&date_filter=2026-02-01' +
+        '&players_on%5B%5D=Kyrie+Irving&players_off%5B%5D=Anthony+Davis' +
+        '&self_filters%5BAST%5D=8,999&playstyle_RTG_min=40&playstyle_RTG_max=90',
+    },
+  ]);
+  renderModal();
+
+  const row = (await screen.findByRole('button', { name: /Open saved Filter Set/ })).closest('li');
+  [
+    'Luka Doncic',
+    '2025-26',
+    'last 10',
+    'away',
+    'vs top 5 Isolation D',
+    'vs bottom 8 Transition D',
+    '32–48 min',
+    'since 2026-02-01',
+    'with Kyrie Irving',
+    'without Anthony Davis',
+    'AST ≥ 8',
+    'PLAYTYPE_RTG 40–90',
+  ].forEach((parameter) => expect(within(row).getByText(parameter)).toBeVisible());
+});
+
+test('says a Filter Set with no parameters covers every logged game', async () => {
+  fetchSavedFilterSets.mockResolvedValue([
+    { id: 3, name: 'all of it', queryString: 'player_name=Stephen+Curry' },
+  ]);
+  renderModal();
+
+  expect(await screen.findByText('every logged game')).toBeVisible();
+});
+
+/*
+ * The decoder withholds the whole Filter Set when one parameter is
+ * unhonourable, so a refused item has no parameters to show. It still has to be
+ * identifiable enough to delete, so its player is read off the raw URL.
+ */
+test('says on the row when a saved link can no longer be opened', async () => {
+  fetchSavedFilterSets.mockResolvedValue([
+    { id: 4, name: 'old link', queryString: 'player_name=Kawhi+Leonard&game_filter=0' },
+  ]);
+  renderModal();
+
+  expect(await screen.findByText('this link can no longer be opened')).toBeVisible();
+  expect(screen.getByText('Kawhi Leonard')).toBeVisible();
+  expect(screen.getByRole('button', { name: 'Delete old link' })).toBeInTheDocument();
 });
 
 test('opening a saved Filter Set navigates to its query string and closes the list', async () => {
@@ -115,22 +181,35 @@ test('surfaces a duplicate-name conflict and keeps the item in the list', async 
   expect(screen.getByRole('button', { name: 'Open saved Filter Set Curry at home' })).toBeVisible();
 });
 
-test('deletes an item and reloads the list', async () => {
+test('deletes an item once the row confirms, and reloads the list', async () => {
   deleteSavedFilterSet.mockResolvedValue(undefined);
   fetchSavedFilterSets
     .mockResolvedValueOnce(savedFilterSets)
     .mockResolvedValueOnce([savedFilterSets[1]]);
   renderModal();
 
-  const deleteButton = await screen.findByRole('button', { name: 'Delete Curry at home' });
+  fireEvent.click(await screen.findByRole('button', { name: 'Delete Curry at home' }));
+  expect(deleteSavedFilterSet).not.toHaveBeenCalled();
+
   await act(async () => {
-    fireEvent.click(deleteButton);
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm deleting Curry at home' }));
   });
 
   expect(deleteSavedFilterSet).toHaveBeenCalledWith({ id: 2 });
   expect(
     screen.queryByRole('button', { name: 'Open saved Filter Set Curry at home' }),
   ).not.toBeInTheDocument();
+});
+
+// Deleting is not undoable, so backing out of it has to keep the item.
+test('a delete the row backs out of removes nothing', async () => {
+  renderModal();
+
+  fireEvent.click(await screen.findByRole('button', { name: 'Delete Curry at home' }));
+  fireEvent.click(screen.getByRole('button', { name: 'Keep Curry at home' }));
+
+  expect(deleteSavedFilterSet).not.toHaveBeenCalled();
+  expect(screen.getByRole('button', { name: 'Open saved Filter Set Curry at home' })).toBeVisible();
 });
 
 test('reports a failed load and says when nothing is saved yet', async () => {

--- a/src/linkPreview.js
+++ b/src/linkPreview.js
@@ -1,4 +1,5 @@
 import { filterSetFromSearchParams } from './filterUtils';
+import { describeDefensiveFilter } from './savedFilterSetDescription';
 
 export const SITE_NAME = 'CourtAI';
 export const DEFAULT_TITLE = 'CourtAI | NBA Game Log Analytics';
@@ -15,7 +16,12 @@ const describeFilters = (filters) => {
   if (filters.location_filter && filters.location_filter !== 'Both') {
     parts.push(`${filters.location_filter.toLowerCase()} games`);
   }
-  if (filters['teams_against[]']?.length) parts.push(`vs ${listNames(filters['teams_against[]'])}`);
+  // The defensive filter is one condition across two parameters, and the rank's
+  // sign is the whole meaning. Naming the category alone described a link as
+  // asking about isolation defense in general when it asked for the best five.
+  filters['teams_against[]']?.forEach((category, index) => {
+    parts.push(describeDefensiveFilter(category, filters['rank_filter[]']?.[index]));
+  });
   if (filters.minutes_filter) {
     const [low, high] = filters.minutes_filter.split(',');
     parts.push(`${low}-${high} minutes`);

--- a/src/linkPreview.test.js
+++ b/src/linkPreview.test.js
@@ -8,14 +8,28 @@ describe('linkPreviewFor', () => {
   test('names the player and the filters a link carries', () => {
     const preview = linkPreviewFor(
       new URLSearchParams(
-        'player_name=LeBron+James&season_filter=2024-25&game_filter=10&location_filter=Home&teams_against[]=BOS&rank_filter[]=30',
+        'player_name=LeBron+James&season_filter=2024-25&game_filter=10&location_filter=Home&teams_against[]=Isolation&rank_filter[]=30',
       ),
     );
 
     expect(preview).toEqual({
       title: 'LeBron James Game Logs | CourtAI',
-      description: '2024-25 season, last 10 games, home games, vs BOS. Explore on CourtAI.',
+      description:
+        '2024-25 season, last 10 games, home games, vs top 30 Isolation D. Explore on CourtAI.',
     });
+  });
+
+  // The rank is half of the defensive filter, and its sign is the whole
+  // meaning. Naming the category alone described a link as asking about
+  // isolation defense in general when it asked for the worst eight.
+  test('states which end of the league a defensive filter asks for', () => {
+    expect(
+      linkPreviewFor(
+        new URLSearchParams(
+          'player_name=Anthony+Edwards&teams_against[]=Transition&rank_filter[]=-8&teams_against[]=Spotup&rank_filter[]=10',
+        ),
+      ).description,
+    ).toBe('Vs bottom 8 Transition D, vs top 10 Spotup D. Explore on CourtAI.');
   });
 
   test('describes a bare player link as every logged game', () => {

--- a/src/savedFilterSetDescription.js
+++ b/src/savedFilterSetDescription.js
@@ -1,0 +1,98 @@
+import { filterSetFromSearchParams } from './filterUtils';
+
+/*
+ * Describe a Saved Filter Set by the parameters it carries.
+ *
+ * A Saved Filter Set stores a name and a query string and nothing else, and the
+ * name is typed in a hurry, so the parameters are the only reliable account of
+ * what an item points at. They are read back through the decoder the Log
+ * Workspace itself uses, so a row is described by exactly the rules that decide
+ * whether the link will be honoured.
+ */
+
+const listNames = (names) =>
+  names.length === 1 ? names[0] : `${names.slice(0, -1).join(', ')} and ${names.at(-1)}`;
+
+const SELF_FILTER_KEY = /^self_filters\[(.+)\]$/;
+
+/** A self filter arrives as a "low,high" pair, with 0 and 999 as open ends. */
+const describeSelfFilter = (stat, value) => {
+  const [low, high] = String(value).split(',');
+  if (high === '999') return `${stat} ≥ ${low}`;
+  if (low === '0') return `${stat} ≤ ${high}`;
+  if (low === high) return `${stat} = ${low}`;
+  return `${stat} ${low}–${high}`;
+};
+
+/*
+ * The defensive filter is one condition carried by two parameters. Despite its
+ * name, `teams_against[]` holds a defensive category rather than a team, and
+ * `rank_filter[]` is a league position whose sign is the whole meaning:
+ * positive counts from the best defenses, negative from the worst. A bare
+ * "(5)" says none of that, so the description spells out top or bottom.
+ */
+export const describeDefensiveFilter = (category, rank) =>
+  rank === undefined || rank === null
+    ? `vs ${category} D`
+    : `vs ${rank > 0 ? 'top' : 'bottom'} ${Math.abs(rank)} ${category} D`;
+
+/**
+ * Read a saved query string back as the facts a list row shows.
+ *
+ * Returns the player, the parameters in reading order, and whether this is a
+ * link the app now refuses. The decoder withholds the whole Filter Set when any
+ * one parameter is unhonourable, so a refused link has no parameters to show;
+ * its player is read back off the raw query string instead, because a row still
+ * has to be identifiable enough to rename or delete.
+ */
+export const describeSavedFilterSet = (queryString) => {
+  const searchParams = new URLSearchParams(queryString || '');
+  const { filters, invalid } = filterSetFromSearchParams(searchParams);
+  const parameters = [];
+  const add = (key, label, tone) => parameters.push(tone ? { key, label, tone } : { key, label });
+
+  if (filters.season_filter) add('season_filter', filters.season_filter);
+  if (filters.game_filter) add('game_filter', `last ${filters.game_filter}`);
+  // "Both" is the absence of a location filter, so it earns no parameter.
+  if (filters.location_filter && filters.location_filter !== 'Both') {
+    add('location_filter', filters.location_filter.toLowerCase());
+  }
+  filters['teams_against[]']?.forEach((category, index) => {
+    add(
+      `teams_against[]-${index}`,
+      describeDefensiveFilter(category, filters['rank_filter[]']?.[index]),
+    );
+  });
+  if (filters.minutes_filter) {
+    const [low, high] = String(filters.minutes_filter).split(',');
+    add('minutes_filter', `${low}–${high} min`);
+  }
+  if (filters.date_filter) add('date_filter', `since ${filters.date_filter}`);
+  if (filters['players_on[]']?.length) {
+    add('players_on[]', `with ${listNames(filters['players_on[]'])}`, 'on');
+  }
+  if (filters['players_off[]']?.length) {
+    add('players_off[]', `without ${listNames(filters['players_off[]'])}`, 'off');
+  }
+  Object.entries(filters).forEach(([key, value]) => {
+    const match = key.match(SELF_FILTER_KEY);
+    if (match && value) add(key, describeSelfFilter(match[1], value));
+  });
+  const ratingMin = filters.playstyle_RTG_min;
+  const ratingMax = filters.playstyle_RTG_max;
+  if (ratingMin !== undefined || ratingMax !== undefined) {
+    if (ratingMin !== undefined && ratingMax !== undefined) {
+      add('playstyle_RTG', `PLAYTYPE_RTG ${ratingMin}–${ratingMax}`);
+    } else if (ratingMin !== undefined) {
+      add('playstyle_RTG_min', `PLAYTYPE_RTG ≥ ${ratingMin}`);
+    } else {
+      add('playstyle_RTG_max', `PLAYTYPE_RTG ≤ ${ratingMax}`);
+    }
+  }
+
+  return {
+    player: filters.player_name || searchParams.get('player_name')?.trim() || null,
+    parameters,
+    refused: invalid.length > 0,
+  };
+};


### PR DESCRIPTION
Part of crf04/statsplus#43

A Saved Filter Set row showed nothing but the name typed at save time. That name is the weakest description available — typed in a hurry, and with the prose of a Parsed Query never stored, there is nothing to fall back on when it turns out to be vague. The parameters were already in the saved query string; they were just never shown.

## What changes

- The given name keeps the top of the row and gains the player plus one chip per parameter beneath it, decoded through `filterSetFromSearchParams` — the same decoder that decides whether the Log Workspace will honour the link.
- A link the app now refuses says so on its row, and keeps the player read off the raw URL so the row stays identifiable enough to delete.
- The defensive filter now says which end of the league it means. `teams_against[]` carries a defensive category, not a team, and `rank_filter[]` is a signed league position; both this list and `linkPreview` named the category and dropped the rank, so a link asking for the best five isolation defenses was described as "vs Isolation". It now reads `vs top 5 Isolation D` / `vs bottom 8 Transition D`, in the list and in tab titles and unfurls alike.
- Deleting confirms on the row instead of removing an item on the press that reached for it.
- Row actions wait for a hover or focus, and are always shown where there is no pointer to reveal them with.
- List order is untouched: the backend's, newest first.

No backend change — everything shown is decoded from the `query_string` already stored.

## Verification

- `npm run test:ci` — 451 passed
- `npx playwright test --grep "saved Filter Set"` — 3 passed
- `npm run lint`, `npm run format:check` — clean

New coverage at existing seams only: the modal test gains a Saved Filter Set exercising every parameter kind at once, both rank signs, the no-parameters case, the refused case, and delete confirmed vs. backed out. `linkPreview.test.js` gains the rank assertion. The browser journey gains the confirmation press and one assertion that a row states its parameters.

Design chosen from a throwaway prototype on `prototype/saved-filter-sets-look`, which also holds the three rejected alternatives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)