### PR TITLE
Group the defensive filter dropdown and offer the whole backend vocabulary

### DIFF
--- a/e2e/specs/core-flows.spec.js
+++ b/e2e/specs/core-flows.spec.js
@@ -320,7 +320,10 @@ test('@critical a manual defensive filter reaches the game-log request seam', as
   await expect(page.getByRole('heading', { name: 'Game Logs', exact: true })).toBeVisible();
 
   const defensiveFilter = page.getByPlaceholder('Number').locator('xpath=..');
-  await defensiveFilter.getByRole('combobox').selectOption('Isolation');
+  // Isolation and Transition are both Play type filters, and the category
+  // persists across the two selections below, so one pill click covers both.
+  await page.getByRole('button', { name: 'Play type' }).click();
+  await page.getByLabel('Defensive Filter:').selectOption('Isolation');
   await page.getByPlaceholder('Number').fill('5');
   await defensiveFilter.getByRole('button', { name: 'Add' }).click();
   await expect(page.getByRole('button', { name: 'Remove Isolation filter' })).toBeVisible();
@@ -335,7 +338,10 @@ test('@critical a manual defensive filter reaches the game-log request seam', as
   // A filter is only addable with a usable rank. A blank rank would be stripped
   // on the way out and desynchronise rank_filter[] from teams_against[]; a rank
   // of zero asks for the top nothing and silently returns an empty table.
-  await defensiveFilter.getByRole('combobox').selectOption('Transition');
+  // Applying filters re-renders the panel from appliedFilters and resets the
+  // category pill back to its default, so it needs clicking again here.
+  await page.getByRole('button', { name: 'Play type' }).click();
+  await page.getByLabel('Defensive Filter:').selectOption('Transition');
   await page.getByPlaceholder('Number').fill('');
   await expect(defensiveFilter.getByRole('button', { name: 'Add' })).toBeDisabled();
   await page.getByPlaceholder('Number').fill('0');

--- a/src/AppliedFilters.js
+++ b/src/AppliedFilters.js
@@ -1,4 +1,5 @@
 import { Badge } from 'react-bootstrap';
+import { opponentFilterLabel } from './opponentFilters';
 
 const AppliedFilters = ({ filters }) => {
   const renderBadge = (key, value, bg = 'primary') => (
@@ -15,7 +16,7 @@ const AppliedFilters = ({ filters }) => {
         : [filters['rank_filter[]']];
       return teamsArray.map((team, index) => {
         const rank = ranksArray[index];
-        return renderBadge(`${key}-${index}`, `${team} (${rank})`);
+        return renderBadge(`${key}-${index}`, `${opponentFilterLabel(team)} (${rank})`);
       });
     } else if (key === 'player_name') {
       return renderBadge(key, `Player: ${value}`);

--- a/src/FilterOptions.css
+++ b/src/FilterOptions.css
@@ -1,7 +1,8 @@
 /*
  * The defensive filter control: a row of category pills scoping a flat select,
- * then the rank input and its helper line. Colours come from the theme tokens
- * in theme.css so the control reads as part of the filter panel.
+ * then a single row combining the select, rank input, and Add button, and a
+ * helper line below. Colours come from the theme tokens in theme.css so the
+ * control reads as part of the filter panel.
  */
 
 .defensive-category-pills {

--- a/src/FilterOptions.css
+++ b/src/FilterOptions.css
@@ -1,0 +1,61 @@
+/*
+ * The defensive filter control: a row of category pills scoping a flat select,
+ * then the rank input and its helper line. Colours come from the theme tokens
+ * in theme.css so the control reads as part of the filter panel.
+ */
+
+.defensive-category-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.defensive-category-pill {
+  padding: 3px 10px;
+  font-size: 0.75rem;
+  border-radius: 999px;
+  background: transparent;
+  border: 1px solid var(--ct-line);
+  color: var(--ct-dim);
+}
+
+.defensive-category-pill:hover {
+  border-color: var(--ct-gold);
+  color: var(--ct-gold-hover);
+}
+
+.defensive-category-pill.is-active {
+  background: var(--ct-gold);
+  border-color: var(--ct-gold);
+  color: var(--ct-ink);
+}
+
+.defensive-category-pill.is-active:hover {
+  background: var(--ct-gold-hover);
+  border-color: var(--ct-gold-hover);
+  color: var(--ct-ink);
+}
+
+/*
+ * Bootstrap's own chevron is a fixed grey; this one carries the gold accent.
+ * `url()` cannot interpolate a custom property, so the stroke repeats the
+ * literal value of --ct-gold and has to be changed with it.
+ */
+.defensive-filter-select {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 8'%3E%3Cpath fill='none' stroke='%23e8a33d' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round' d='M1 1l5 5 5-5'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 14px center;
+  background-size: 11px 7px;
+}
+
+/* A rank is at most two digits and a sign, so the input yields room to Add. */
+.defensive-filter-rank {
+  max-width: 96px;
+}
+
+.defensive-filter-rank-helper {
+  margin-top: 8px;
+  color: var(--ct-dim);
+  font-size: 11px;
+}

--- a/src/FilterOptions.js
+++ b/src/FilterOptions.js
@@ -13,7 +13,7 @@ import {
   ListGroup,
 } from 'react-bootstrap';
 import ReactSlider from 'react-slider';
-import { defensiveOptions } from './utils';
+import { OPPONENT_FILTERS, opponentFilterLabel } from './opponentFilters';
 import { formatNumber, toFiniteNumber } from './numberUtils';
 
 const hasFilterValue = (value) => value !== null && value !== undefined && value !== '';
@@ -650,19 +650,27 @@ const FilterOptions = ({
           />
         </Form.Group>
         <Form.Group className="mb-4">
-          <Form.Label>Defensive Filter:</Form.Label>
+          <Form.Label htmlFor="defensive-filter">Defensive Filter:</Form.Label>
           <InputGroup>
             <Form.Select
+              id="defensive-filter"
               value={selectedDefensiveFilter}
               onChange={(e) => setSelectedDefensiveFilter(e.target.value)}
             >
-              {defensiveOptions.map((option) => (
-                <option key={option} value={option}>
-                  {option}
-                </option>
+              <option value="None">None</option>
+              {OPPONENT_FILTERS.map((group) => (
+                <optgroup key={group.category} label={group.category}>
+                  {group.items.map((item) => (
+                    <option key={item.token} value={item.token}>
+                      {item.label}
+                    </option>
+                  ))}
+                </optgroup>
               ))}
             </Form.Select>
             <FormControl
+              id="defensive-filter-rank"
+              aria-label="Defensive filter rank"
               type="text"
               value={filterNumber}
               onChange={(e) => {
@@ -693,10 +701,10 @@ const FilterOptions = ({
           <div className="mt-2">
             {activeFilters.map((filter, index) => (
               <Badge key={index} bg="primary" className="me-1 mb-1 p-2">
-                {filter.filter} ({filter.number})
+                {opponentFilterLabel(filter.filter)} ({filter.number})
                 <Button
                   type="button"
-                  aria-label={`Remove ${filter.filter} filter`}
+                  aria-label={`Remove ${opponentFilterLabel(filter.filter)} filter`}
                   title="Remove filter"
                   variant="link"
                   size="sm"

--- a/src/FilterOptions.js
+++ b/src/FilterOptions.js
@@ -696,20 +696,20 @@ const FilterOptions = ({
               </button>
             ))}
           </div>
-          <Form.Select
-            id="defensive-filter"
-            className="defensive-filter-select mb-2"
-            value={selectedDefensiveFilter}
-            onChange={(e) => setSelectedDefensiveFilter(e.target.value)}
-          >
-            <option value="None">None</option>
-            {defensiveCategoryItems(activeDefensiveCategory).map((item) => (
-              <option key={item.token} value={item.token}>
-                {item.label}
-              </option>
-            ))}
-          </Form.Select>
           <InputGroup>
+            <Form.Select
+              id="defensive-filter"
+              className="defensive-filter-select"
+              value={selectedDefensiveFilter}
+              onChange={(e) => setSelectedDefensiveFilter(e.target.value)}
+            >
+              <option value="None">None</option>
+              {defensiveCategoryItems(activeDefensiveCategory).map((item) => (
+                <option key={item.token} value={item.token}>
+                  {item.label}
+                </option>
+              ))}
+            </Form.Select>
             <FormControl
               id="defensive-filter-rank"
               aria-label="Defensive filter rank"

--- a/src/FilterOptions.js
+++ b/src/FilterOptions.js
@@ -30,6 +30,9 @@ const DEFENSIVE_CATEGORY_PILL_LABELS = {
 
 const DEFAULT_DEFENSIVE_CATEGORY = 'General defense';
 
+const defensiveCategoryItems = (category) =>
+  OPPONENT_FILTERS.find((group) => group.category === category)?.items ?? [];
+
 const FilterOptions = ({
   playerList,
   onApplyFilters,
@@ -119,6 +122,7 @@ const FilterOptions = ({
   useEffect(() => {
     // Always reset all form fields to their defaults first
     setSelectedDefensiveFilter('None');
+    setActiveDefensiveCategory(DEFAULT_DEFENSIVE_CATEGORY);
     setFilterNumber('');
     setActiveFilters([]);
     setPlayerInput('');
@@ -280,7 +284,7 @@ const FilterOptions = ({
   // when the new category is the one it came from.
   const handleDefensiveCategoryChange = (category) => {
     setActiveDefensiveCategory(category);
-    const items = OPPONENT_FILTERS.find((group) => group.category === category).items;
+    const items = defensiveCategoryItems(category);
     if (!items.some((item) => item.token === selectedDefensiveFilter)) {
       setSelectedDefensiveFilter('None');
     }
@@ -699,13 +703,11 @@ const FilterOptions = ({
             onChange={(e) => setSelectedDefensiveFilter(e.target.value)}
           >
             <option value="None">None</option>
-            {OPPONENT_FILTERS.find((group) => group.category === activeDefensiveCategory).items.map(
-              (item) => (
-                <option key={item.token} value={item.token}>
-                  {item.label}
-                </option>
-              ),
-            )}
+            {defensiveCategoryItems(activeDefensiveCategory).map((item) => (
+              <option key={item.token} value={item.token}>
+                {item.label}
+              </option>
+            ))}
           </Form.Select>
           <InputGroup>
             <FormControl

--- a/src/FilterOptions.js
+++ b/src/FilterOptions.js
@@ -15,8 +15,20 @@ import {
 import ReactSlider from 'react-slider';
 import { OPPONENT_FILTERS, opponentFilterLabel } from './opponentFilters';
 import { formatNumber, toFiniteNumber } from './numberUtils';
+import './FilterOptions.css';
 
 const hasFilterValue = (value) => value !== null && value !== undefined && value !== '';
+
+// The pills sit in a single row inside a narrow panel, so each category wears a
+// shortened name. A category without an entry falls back to its full name.
+const DEFENSIVE_CATEGORY_PILL_LABELS = {
+  'General defense': 'General',
+  'Shot type defense': 'Shot type',
+  'Play type defense': 'Play type',
+  'Assists allowed': 'Assists',
+};
+
+const DEFAULT_DEFENSIVE_CATEGORY = 'General defense';
 
 const FilterOptions = ({
   playerList,
@@ -29,6 +41,9 @@ const FilterOptions = ({
   appliedFilters,
 }) => {
   const [selectedDefensiveFilter, setSelectedDefensiveFilter] = useState('None');
+  const [activeDefensiveCategory, setActiveDefensiveCategory] = useState(
+    DEFAULT_DEFENSIVE_CATEGORY,
+  );
   const [filterNumber, setFilterNumber] = useState('');
   const [activeFilters, setActiveFilters] = useState([]);
   const [playerInput, setPlayerInput] = useState('');
@@ -258,6 +273,17 @@ const FilterOptions = ({
 
   const handleRemoveFilter = (index) => {
     setActiveFilters(activeFilters.filter((_, i) => i !== index));
+  };
+
+  // The select only ever offers one category, so a selection made under the old
+  // category would otherwise stay applied while invisible. It survives only
+  // when the new category is the one it came from.
+  const handleDefensiveCategoryChange = (category) => {
+    setActiveDefensiveCategory(category);
+    const items = OPPONENT_FILTERS.find((group) => group.category === category).items;
+    if (!items.some((item) => item.token === selectedDefensiveFilter)) {
+      setSelectedDefensiveFilter('None');
+    }
   };
 
   const handlePlayerSearchChange = (e) => {
@@ -651,26 +677,41 @@ const FilterOptions = ({
         </Form.Group>
         <Form.Group className="mb-4">
           <Form.Label htmlFor="defensive-filter">Defensive Filter:</Form.Label>
+          <div className="defensive-category-pills">
+            {OPPONENT_FILTERS.map((group) => (
+              <button
+                key={group.category}
+                type="button"
+                className={`defensive-category-pill${
+                  group.category === activeDefensiveCategory ? ' is-active' : ''
+                }`}
+                aria-pressed={group.category === activeDefensiveCategory}
+                onClick={() => handleDefensiveCategoryChange(group.category)}
+              >
+                {DEFENSIVE_CATEGORY_PILL_LABELS[group.category] || group.category}
+              </button>
+            ))}
+          </div>
+          <Form.Select
+            id="defensive-filter"
+            className="defensive-filter-select mb-2"
+            value={selectedDefensiveFilter}
+            onChange={(e) => setSelectedDefensiveFilter(e.target.value)}
+          >
+            <option value="None">None</option>
+            {OPPONENT_FILTERS.find((group) => group.category === activeDefensiveCategory).items.map(
+              (item) => (
+                <option key={item.token} value={item.token}>
+                  {item.label}
+                </option>
+              ),
+            )}
+          </Form.Select>
           <InputGroup>
-            <Form.Select
-              id="defensive-filter"
-              value={selectedDefensiveFilter}
-              onChange={(e) => setSelectedDefensiveFilter(e.target.value)}
-            >
-              <option value="None">None</option>
-              {OPPONENT_FILTERS.map((group) => (
-                <optgroup key={group.category} label={group.category}>
-                  {group.items.map((item) => (
-                    <option key={item.token} value={item.token}>
-                      {item.label}
-                    </option>
-                  ))}
-                </optgroup>
-              ))}
-            </Form.Select>
             <FormControl
               id="defensive-filter-rank"
               aria-label="Defensive filter rank"
+              className="defensive-filter-rank"
               type="text"
               value={filterNumber}
               onChange={(e) => {
@@ -698,6 +739,9 @@ const FilterOptions = ({
               Add
             </Button>
           </InputGroup>
+          <div className="defensive-filter-rank-helper">
+            Positive rank = top defenses, negative = bottom
+          </div>
           <div className="mt-2">
             {activeFilters.map((filter, index) => (
               <Badge key={index} bg="primary" className="me-1 mb-1 p-2">

--- a/src/FilterOptions.test.js
+++ b/src/FilterOptions.test.js
@@ -233,6 +233,33 @@ test('re-picking the category a selection belongs to leaves it selected', () => 
   expect(defensiveAddButton()).toBeEnabled();
 });
 
+// The pill state is form state like any other: the reset-all effect that runs
+// when a new applied-filters link arrives must snap it back to General too,
+// not just leave the last category from the previous player's panel active.
+const filterOptionsElement = (appliedFilters) => (
+  <FilterOptions
+    playerList={['LeBron James']}
+    onApplyFilters={jest.fn()}
+    selectedPlayer="LeBron James"
+    seasonGameLogs={[]}
+    seasonGameLogsLoading={false}
+    seasonGameLogsFailed={false}
+    onOpenSelfFilters={jest.fn()}
+    appliedFilters={appliedFilters}
+  />
+);
+
+test('a new applied-filters link resets the category pill back to General', () => {
+  const { rerender } = render(filterOptionsElement({}));
+
+  clickCategoryPill('Shot type');
+  expect(screen.getByRole('button', { name: 'Shot type' })).toHaveAttribute('aria-pressed', 'true');
+
+  rerender(filterOptionsElement({ player_name: 'LeBron James' }));
+
+  expect(screen.getByRole('button', { name: 'General' })).toHaveAttribute('aria-pressed', 'true');
+});
+
 test('an added defensive filter wears its label, and applies as its token', () => {
   const onApplyFilters = renderPanel();
 

--- a/src/FilterOptions.test.js
+++ b/src/FilterOptions.test.js
@@ -127,55 +127,122 @@ const BACKEND_DEFENSIVE_FILTER_TOKENS = [
   'LongMidRangeAssists',
 ];
 
-test('the defensive dropdown offers the whole vocabulary, grouped and labelled', () => {
+// The pill labels, paired with the slice of the literal token list above that
+// each pill's category is expected to scope the select down to. The four slices
+// partition BACKEND_DEFENSIVE_FILTER_TOKENS in order, so together they still
+// account for the whole backend vocabulary.
+const DEFENSIVE_CATEGORY_PILLS = [
+  { pill: 'General', tokens: BACKEND_DEFENSIVE_FILTER_TOKENS.slice(0, 8) },
+  { pill: 'Shot type', tokens: BACKEND_DEFENSIVE_FILTER_TOKENS.slice(8, 17) },
+  { pill: 'Play type', tokens: BACKEND_DEFENSIVE_FILTER_TOKENS.slice(17, 28) },
+  { pill: 'Assists', tokens: BACKEND_DEFENSIVE_FILTER_TOKENS.slice(28) },
+];
+
+const defensiveSelect = () => screen.getByLabelText('Defensive Filter:');
+
+const clickCategoryPill = (name) => fireEvent.click(screen.getByRole('button', { name }));
+
+// The player search carries an "Add" of its own, so the defensive one is
+// reached through the input group it shares with the rank field.
+const defensiveAddButton = () =>
+  within(screen.getByLabelText('Defensive filter rank').closest('.input-group')).getByRole(
+    'button',
+    { name: 'Add' },
+  );
+
+const labelForToken = (token) =>
+  OPPONENT_FILTERS.flatMap((group) => group.items).find((item) => item.token === token).label;
+
+test('each category pill scopes the defensive dropdown to its own slice of the vocabulary', () => {
   renderPanel();
 
-  const select = screen.getByLabelText('Defensive Filter:');
-  const options = within(select).getAllByRole('option');
-
-  // The bare "None" option leads, and sits outside any optgroup.
-  expect(options[0].value).toBe('None');
-  expect(options[0].textContent).toBe('None');
-  expect(options[0].closest('optgroup')).toBeNull();
-
-  // The rest of the options, in order, are exactly the backend's tokens.
-  expect(options.slice(1).map((option) => option.value)).toEqual(BACKEND_DEFENSIVE_FILTER_TOKENS);
-
-  const groups = within(select).getAllByRole('group');
-  expect(groups.map((group) => group.getAttribute('label'))).toEqual([
-    'General defense',
-    'Shot type defense',
-    'Play type defense',
-    'Assists allowed',
-  ]);
-
-  options.slice(1).forEach((option) => {
-    expect(option.textContent).not.toBe('');
+  // Every category is reachable, and exactly one is active at a time.
+  DEFENSIVE_CATEGORY_PILLS.forEach(({ pill }) => {
+    expect(screen.getByRole('button', { name: pill })).toHaveAttribute('aria-pressed');
   });
-  expect(within(select).getByRole('option', { name: 'Points Allowed' }).value).toBe('OPP_PTS');
-  expect(within(select).getByRole('option', { name: 'Spot-Up' }).value).toBe('Spotup');
+  expect(screen.getByRole('button', { name: 'General' })).toHaveAttribute('aria-pressed', 'true');
 
-  // Kept alongside the literal assertions above: still checks the component
-  // renders every group and item the vocabulary module currently declares.
-  expect(groups.map((group) => group.getAttribute('label'))).toEqual(
-    OPPONENT_FILTERS.map((group) => group.category),
+  // The four slices together are the whole backend vocabulary, so no token is
+  // left unreachable by the scoping.
+  expect(DEFENSIVE_CATEGORY_PILLS.flatMap(({ tokens }) => tokens)).toEqual(
+    BACKEND_DEFENSIVE_FILTER_TOKENS,
   );
-  OPPONENT_FILTERS.forEach((group, index) => {
-    expect(
-      within(groups[index])
-        .getAllByRole('option')
-        .map((option) => [option.value, option.textContent]),
-    ).toEqual(group.items.map((item) => [item.token, item.label]));
+
+  DEFENSIVE_CATEGORY_PILLS.forEach(({ pill, tokens }) => {
+    clickCategoryPill(pill);
+
+    expect(screen.getByRole('button', { name: pill })).toHaveAttribute('aria-pressed', 'true');
+
+    // The select is flat and scoped: a leading "None", then this category's
+    // tokens in order, each under its human label.
+    const options = within(defensiveSelect()).getAllByRole('option');
+    expect(options.map((option) => option.value)).toEqual(['None', ...tokens]);
+    expect(options.map((option) => option.textContent)).toEqual([
+      'None',
+      ...tokens.map(labelForToken),
+    ]);
+    expect(within(defensiveSelect()).queryAllByRole('group')).toEqual([]);
   });
+
+  // Spot-checks that the labels above are the human names, not the tokens.
+  clickCategoryPill('General');
+  expect(within(defensiveSelect()).getByRole('option', { name: 'Points Allowed' }).value).toBe(
+    'OPP_PTS',
+  );
+  clickCategoryPill('Play type');
+  expect(within(defensiveSelect()).getByRole('option', { name: 'Spot-Up' }).value).toBe('Spotup');
+});
+
+// A select whose value names no option of its own falls back to showing the
+// first one, so reading "None" off the select is not on its own proof the
+// selection was dropped — the stale token could still be the one Add would
+// apply. Each leg below also asserts Add has nothing left to offer.
+test('switching category drops a selection the new category cannot show', () => {
+  renderPanel();
+
+  // A General token does not survive the move to Shot type.
+  fireEvent.change(defensiveSelect(), { target: { value: 'OPP_PTS' } });
+  fireEvent.change(screen.getByLabelText('Defensive filter rank'), { target: { value: '5' } });
+  expect(defensiveSelect().value).toBe('OPP_PTS');
+  expect(defensiveAddButton()).toBeEnabled();
+
+  clickCategoryPill('Shot type');
+
+  expect(defensiveSelect().value).toBe('None');
+  expect(defensiveAddButton()).toBeDisabled();
+
+  // Nor does a Shot type token survive the move back to General.
+  fireEvent.change(defensiveSelect(), { target: { value: 'C&S PTS' } });
+  expect(defensiveSelect().value).toBe('C&S PTS');
+  expect(defensiveAddButton()).toBeEnabled();
+
+  clickCategoryPill('General');
+
+  expect(defensiveSelect().value).toBe('None');
+  expect(defensiveAddButton()).toBeDisabled();
+});
+
+test('re-picking the category a selection belongs to leaves it selected', () => {
+  renderPanel();
+
+  fireEvent.change(defensiveSelect(), { target: { value: 'OPP_PTS' } });
+  fireEvent.change(screen.getByLabelText('Defensive filter rank'), { target: { value: '5' } });
+  clickCategoryPill('General');
+
+  expect(defensiveSelect().value).toBe('OPP_PTS');
+  expect(defensiveAddButton()).toBeEnabled();
 });
 
 test('an added defensive filter wears its label, and applies as its token', () => {
   const onApplyFilters = renderPanel();
 
-  const select = screen.getByLabelText('Defensive Filter:');
-  fireEvent.change(select, { target: { value: 'OPP_PTS' } });
-  fireEvent.change(screen.getByPlaceholderText('Number'), { target: { value: '5' } });
-  fireEvent.click(within(select.closest('.input-group')).getByRole('button', { name: 'Add' }));
+  clickCategoryPill('General');
+  fireEvent.change(defensiveSelect(), { target: { value: 'OPP_PTS' } });
+  const rank = screen.getByLabelText('Defensive filter rank');
+  fireEvent.change(rank, { target: { value: '5' } });
+  // The player search carries an "Add" of its own, so this one is reached
+  // through the group it shares with the rank input.
+  fireEvent.click(within(rank.closest('.input-group')).getByRole('button', { name: 'Add' }));
 
   expect(screen.getByText('Points Allowed (5)')).toBeInTheDocument();
 

--- a/src/FilterOptions.test.js
+++ b/src/FilterOptions.test.js
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import FilterOptions from './FilterOptions';
+import { OPPONENT_FILTERS } from './opponentFilters';
 
 // jsdom has no ResizeObserver, and the range sliders observe their track on
 // mount. Nothing here asserts on pixel geometry, so an inert observer is enough
@@ -81,6 +82,109 @@ test('a single-bound link fills the other side with the API default and applies 
     player_name: 'LeBron James',
     playstyle_RTG_min: 0,
     playstyle_RTG_max: 80,
+  });
+});
+
+// Mirrors the backend catalog (statsplus-backend app/models/catalogs.py,
+// SUPPORTED_TEAM_FILTERS) in dropdown order. Deliberately not derived from
+// src/opponentFilters.js: a token dropped from that module should fail this
+// test rather than silently shrink alongside it.
+const BACKEND_DEFENSIVE_FILTER_TOKENS = [
+  'OPP_PTS',
+  'OPP_REB',
+  'OPP_AST',
+  'OPP_STOCKS',
+  'OPP_STL',
+  'OPP_BLK',
+  'OPP_FTA',
+  'OPP_TOV',
+  'C&S PTS',
+  'C&S 3s',
+  'C&S 3A',
+  'PU PTS',
+  'PU 2s',
+  'PU 3s',
+  'Less Than 10 ft',
+  'OPP_FG3M',
+  'OPP_FG3A',
+  'Transition',
+  'Isolation',
+  'Spotup',
+  'Handoff',
+  'OffScreen',
+  'Postup',
+  'PRBallHandler',
+  'PRRollMan',
+  'Cut',
+  'OffRebound',
+  'Misc',
+  'AtRimAssists',
+  'TwoPtAssists',
+  'ThreePtAssists',
+  'Arc3Assists',
+  'Corner3Assists',
+  'ShortMidRangeAssists',
+  'LongMidRangeAssists',
+];
+
+test('the defensive dropdown offers the whole vocabulary, grouped and labelled', () => {
+  renderPanel();
+
+  const select = screen.getByLabelText('Defensive Filter:');
+  const options = within(select).getAllByRole('option');
+
+  // The bare "None" option leads, and sits outside any optgroup.
+  expect(options[0].value).toBe('None');
+  expect(options[0].textContent).toBe('None');
+  expect(options[0].closest('optgroup')).toBeNull();
+
+  // The rest of the options, in order, are exactly the backend's tokens.
+  expect(options.slice(1).map((option) => option.value)).toEqual(BACKEND_DEFENSIVE_FILTER_TOKENS);
+
+  const groups = within(select).getAllByRole('group');
+  expect(groups.map((group) => group.getAttribute('label'))).toEqual([
+    'General defense',
+    'Shot type defense',
+    'Play type defense',
+    'Assists allowed',
+  ]);
+
+  options.slice(1).forEach((option) => {
+    expect(option.textContent).not.toBe('');
+  });
+  expect(within(select).getByRole('option', { name: 'Points Allowed' }).value).toBe('OPP_PTS');
+  expect(within(select).getByRole('option', { name: 'Spot-Up' }).value).toBe('Spotup');
+
+  // Kept alongside the literal assertions above: still checks the component
+  // renders every group and item the vocabulary module currently declares.
+  expect(groups.map((group) => group.getAttribute('label'))).toEqual(
+    OPPONENT_FILTERS.map((group) => group.category),
+  );
+  OPPONENT_FILTERS.forEach((group, index) => {
+    expect(
+      within(groups[index])
+        .getAllByRole('option')
+        .map((option) => [option.value, option.textContent]),
+    ).toEqual(group.items.map((item) => [item.token, item.label]));
+  });
+});
+
+test('an added defensive filter wears its label, and applies as its token', () => {
+  const onApplyFilters = renderPanel();
+
+  const select = screen.getByLabelText('Defensive Filter:');
+  fireEvent.change(select, { target: { value: 'OPP_PTS' } });
+  fireEvent.change(screen.getByPlaceholderText('Number'), { target: { value: '5' } });
+  fireEvent.click(within(select.closest('.input-group')).getByRole('button', { name: 'Add' }));
+
+  expect(screen.getByText('Points Allowed (5)')).toBeInTheDocument();
+
+  applyFilters();
+
+  expect(onApplyFilters).toHaveBeenCalledWith({
+    player_name: 'LeBron James',
+    'teams_against[]': ['OPP_PTS'],
+    'rank_filter[]': [5],
   });
 });
 

--- a/src/help/QueryReferencePage.test.js
+++ b/src/help/QueryReferencePage.test.js
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import QueryReferencePage from './QueryReferencePage';
 import { OPPONENT_FILTERS, KEYWORDS, STACKED_EXAMPLES } from './queryHelp';
-import { defensiveOptions } from '../utils';
+import { defensiveOptions } from '../opponentFilters';
 
 const renderPage = () =>
   render(

--- a/src/help/queryHelp.js
+++ b/src/help/queryHelp.js
@@ -40,65 +40,9 @@ export const OPPONENT_RANK_NOTE =
   'Use "top" for the best defenses and "bottom" for the worst. Bottom ranks are the better matchups for the player.';
 
 // The vocabulary is the backend's `SUPPORTED_TEAM_FILTERS`
-// (statsplus-backend app/models/catalogs.py), which is wider than the
-// frontend's own `defensiveOptions` dropdown in src/utils.js.
-export const OPPONENT_FILTERS = [
-  {
-    category: 'General defense',
-    items: [
-      { token: 'OPP_PTS', means: 'Overall defense' },
-      { token: 'OPP_REB', means: 'Rebounds allowed' },
-      { token: 'OPP_AST', means: 'Assists allowed' },
-      { token: 'OPP_STOCKS', means: 'Steals + blocks allowed' },
-      { token: 'OPP_STL', means: 'Steals allowed' },
-      { token: 'OPP_BLK', means: 'Blocks allowed' },
-      { token: 'OPP_FTA', means: 'Fouls (FT attempts)' },
-      { token: 'OPP_TOV', means: 'Turnovers forced' },
-    ],
-  },
-  {
-    category: 'Shot type defense',
-    items: [
-      { token: 'C&S PTS', means: 'Catch-and-shoot defense' },
-      { token: 'C&S 3s', means: 'Catch-and-shoot threes allowed' },
-      { token: 'C&S 3A', means: 'Catch-and-shoot 3PT attempts' },
-      { token: 'PU PTS', means: 'Pull-up shot defense' },
-      { token: 'PU 2s', means: 'Pull-up two defense' },
-      { token: 'PU 3s', means: 'Pull-up three defense' },
-      { token: 'Less Than 10 ft', means: 'Paint protection' },
-      { token: 'OPP_FG3M', means: 'Threes allowed' },
-      { token: 'OPP_FG3A', means: 'Three-point attempts allowed' },
-    ],
-  },
-  {
-    category: 'Play type defense',
-    items: [
-      { token: 'Transition', means: 'Fast-break defense' },
-      { token: 'Isolation', means: 'Iso defense' },
-      { token: 'Spotup', means: 'Spot-up defense' },
-      { token: 'Handoff', means: 'Handoff defense' },
-      { token: 'OffScreen', means: 'Off-screen defense' },
-      { token: 'Postup', means: 'Post-up defense' },
-      { token: 'PRBallHandler', means: 'Pick-and-roll ball-handler defense' },
-      { token: 'PRRollMan', means: 'Pick-and-roll roll-man defense' },
-      { token: 'Cut', means: 'Cutting defense' },
-      { token: 'OffRebound', means: 'Putback defense' },
-      { token: 'Misc', means: 'Everything the other play types do not cover' },
-    ],
-  },
-  {
-    category: 'Assists allowed',
-    items: [
-      { token: 'AtRimAssists', means: 'Assists on shots at the rim' },
-      { token: 'TwoPtAssists', means: 'Assists on two-point shots' },
-      { token: 'ThreePtAssists', means: 'Assists on three-point shots' },
-      { token: 'Arc3Assists', means: 'Assists on above-the-break threes' },
-      { token: 'Corner3Assists', means: 'Assists on corner threes' },
-      { token: 'ShortMidRangeAssists', means: 'Assists on short mid-range shots' },
-      { token: 'LongMidRangeAssists', means: 'Assists on long mid-range shots' },
-    ],
-  },
-];
+// (statsplus-backend app/models/catalogs.py); the grouped structure is shared
+// with the defensive filter dropdown and lives in src/opponentFilters.js.
+export { OPPONENT_FILTERS } from '../opponentFilters';
 
 export const STACKED_EXAMPLES = [
   'LeBron James games without Anthony Davis and with Austin Reaves last 15 games',

--- a/src/linkPreview.test.js
+++ b/src/linkPreview.test.js
@@ -29,7 +29,7 @@ describe('linkPreviewFor', () => {
           'player_name=Anthony+Edwards&teams_against[]=Transition&rank_filter[]=-8&teams_against[]=Spotup&rank_filter[]=10',
         ),
       ).description,
-    ).toBe('Vs bottom 8 Transition D, vs top 10 Spotup D. Explore on CourtAI.');
+    ).toBe('Vs bottom 8 Transition D, vs top 10 Spot-Up D. Explore on CourtAI.');
   });
 
   test('describes a bare player link as every logged game', () => {

--- a/src/opponentFilters.js
+++ b/src/opponentFilters.js
@@ -1,0 +1,101 @@
+/*
+ * The app-wide opponent (defensive) filter vocabulary, grouped by category.
+ *
+ * The vocabulary is the backend's `SUPPORTED_TEAM_FILTERS`
+ * (statsplus-backend app/models/catalogs.py); the defensive filter dropdown,
+ * the applied-filter badges, the Saved Filter Set descriptions, and the query
+ * reference page all render from this one structure so they cannot drift.
+ *
+ * `token` is the value the API speaks, `label` is the short name the controls
+ * show, and `means` is the description the reference page teaches.
+ */
+export const OPPONENT_FILTERS = [
+  {
+    category: 'General defense',
+    items: [
+      { token: 'OPP_PTS', label: 'Points Allowed', means: 'Overall defense' },
+      { token: 'OPP_REB', label: 'Rebounds Allowed', means: 'Rebounds allowed' },
+      { token: 'OPP_AST', label: 'Assists Allowed', means: 'Assists allowed' },
+      { token: 'OPP_STOCKS', label: 'Steals + Blocks', means: 'Steals + blocks allowed' },
+      { token: 'OPP_STL', label: 'Steals', means: 'Steals allowed' },
+      { token: 'OPP_BLK', label: 'Blocks', means: 'Blocks allowed' },
+      { token: 'OPP_FTA', label: 'Free Throws Allowed', means: 'Fouls (FT attempts)' },
+      { token: 'OPP_TOV', label: 'Turnovers Forced', means: 'Turnovers forced' },
+    ],
+  },
+  {
+    category: 'Shot type defense',
+    items: [
+      { token: 'C&S PTS', label: 'Catch & Shoot Points', means: 'Catch-and-shoot defense' },
+      { token: 'C&S 3s', label: 'Catch & Shoot 3s', means: 'Catch-and-shoot threes allowed' },
+      { token: 'C&S 3A', label: 'Catch & Shoot 3PA', means: 'Catch-and-shoot 3PT attempts' },
+      { token: 'PU PTS', label: 'Pull-Up Points', means: 'Pull-up shot defense' },
+      { token: 'PU 2s', label: 'Pull-Up 2s', means: 'Pull-up two defense' },
+      { token: 'PU 3s', label: 'Pull-Up 3s', means: 'Pull-up three defense' },
+      { token: 'Less Than 10 ft', label: 'Inside 10 ft', means: 'Paint protection' },
+      { token: 'OPP_FG3M', label: '3s Allowed', means: 'Threes allowed' },
+      { token: 'OPP_FG3A', label: '3PT Attempts Allowed', means: 'Three-point attempts allowed' },
+    ],
+  },
+  {
+    category: 'Play type defense',
+    items: [
+      { token: 'Transition', label: 'Transition', means: 'Fast-break defense' },
+      { token: 'Isolation', label: 'Isolation', means: 'Iso defense' },
+      { token: 'Spotup', label: 'Spot-Up', means: 'Spot-up defense' },
+      { token: 'Handoff', label: 'Handoff', means: 'Handoff defense' },
+      { token: 'OffScreen', label: 'Off-Screen', means: 'Off-screen defense' },
+      { token: 'Postup', label: 'Post-Up', means: 'Post-up defense' },
+      {
+        token: 'PRBallHandler',
+        label: 'P&R Ball-Handler',
+        means: 'Pick-and-roll ball-handler defense',
+      },
+      { token: 'PRRollMan', label: 'P&R Roll-Man', means: 'Pick-and-roll roll-man defense' },
+      { token: 'Cut', label: 'Cuts', means: 'Cutting defense' },
+      { token: 'OffRebound', label: 'Putbacks', means: 'Putback defense' },
+      {
+        token: 'Misc',
+        label: 'Miscellaneous',
+        means: 'Everything the other play types do not cover',
+      },
+    ],
+  },
+  {
+    category: 'Assists allowed',
+    items: [
+      { token: 'AtRimAssists', label: 'At-Rim Assists', means: 'Assists on shots at the rim' },
+      { token: 'TwoPtAssists', label: 'Two-Point Assists', means: 'Assists on two-point shots' },
+      {
+        token: 'ThreePtAssists',
+        label: 'Three-Point Assists',
+        means: 'Assists on three-point shots',
+      },
+      { token: 'Arc3Assists', label: 'Arc 3 Assists', means: 'Assists on above-the-break threes' },
+      { token: 'Corner3Assists', label: 'Corner 3 Assists', means: 'Assists on corner threes' },
+      {
+        token: 'ShortMidRangeAssists',
+        label: 'Short Mid-Range Assists',
+        means: 'Assists on short mid-range shots',
+      },
+      {
+        token: 'LongMidRangeAssists',
+        label: 'Long Mid-Range Assists',
+        means: 'Assists on long mid-range shots',
+      },
+    ],
+  },
+];
+
+const labelByToken = new Map(
+  OPPONENT_FILTERS.flatMap((group) => group.items).map((item) => [item.token, item.label]),
+);
+
+/** The short display name for an opponent filter token; unknown tokens pass through. */
+export const opponentFilterLabel = (token) => labelByToken.get(token) ?? token;
+
+/** The flat token list the dropdown accepts, with the `None` sentinel first. */
+export const defensiveOptions = [
+  'None',
+  ...OPPONENT_FILTERS.flatMap((group) => group.items.map((item) => item.token)),
+];

--- a/src/savedFilterSetDescription.js
+++ b/src/savedFilterSetDescription.js
@@ -1,4 +1,5 @@
 import { filterSetFromSearchParams } from './filterUtils';
+import { opponentFilterLabel } from './opponentFilters';
 
 /*
  * Describe a Saved Filter Set by the parameters it carries.
@@ -33,8 +34,8 @@ const describeSelfFilter = (stat, value) => {
  */
 export const describeDefensiveFilter = (category, rank) =>
   rank === undefined || rank === null
-    ? `vs ${category} D`
-    : `vs ${rank > 0 ? 'top' : 'bottom'} ${Math.abs(rank)} ${category} D`;
+    ? `vs ${opponentFilterLabel(category)} D`
+    : `vs ${rank > 0 ? 'top' : 'bottom'} ${Math.abs(rank)} ${opponentFilterLabel(category)} D`;
 
 /**
  * Read a saved query string back as the facts a list row shows.

--- a/src/utils.js
+++ b/src/utils.js
@@ -22,31 +22,6 @@ export const lineTypeOptions = [
   'TOV',
 ];
 
-export const defensiveOptions = [
-  'None',
-  'C&S 3s',
-  'C&S PTS',
-  'C&S 3A',
-  'PU 2s',
-  'PU 3s',
-  'PU PTS',
-  'Less Than 10 ft',
-  'PRRollMan',
-  'PRBallHandler',
-  'Isolation',
-  'Spotup',
-  'Transition',
-  'OPP_PTS',
-  'OPP_REB',
-  'OPP_AST',
-  'OPP_FTA',
-  'OPP_STOCKS',
-  'OPP_TOV',
-  'AtRimAssists',
-  'TwoPtAssists',
-  'ThreePtAssists',
-];
-
 export const RankCube = ({ rank }) => {
   const getColorForRank = (rank) => {
     const normalizedRank = (rank - 1) / 29;


### PR DESCRIPTION
## What

The defensive filter dropdown was a flat list of 21 raw tokens (`OPP_PTS`, `PRRollMan`, …), 14 filters short of the backend's `SUPPORTED_TEAM_FILTERS`. It now carries all 35 backend tokens with human-readable labels ("Points Allowed"), organised **category-first**: four pill buttons (General / Shot type / Play type / Assists) drive a compact select scoped to the active category — no scrolling through 35 options. API parameters keep the raw tokens.

- New `src/opponentFilters.js` is the single vocabulary source: 4 categories × 35 tokens, each `{token, label, means}`. The filter control, applied-filter badges, Saved Filter Set descriptions, link previews, and the query reference page all render from it.
- Newly exposed filters (all verified populated in the production database, 30/30 teams): `OPP_BLK`, `OPP_STL`, `OPP_FG3M`, `OPP_FG3A`, play types `OffRebound`, `Cut`, `Handoff`, `OffScreen`, `Misc`, `Postup`, and assists `Arc3Assists`, `Corner3Assists`, `ShortMidRangeAssists`, `LongMidRangeAssists`.
- The category-first design was chosen from a 6-variant UI prototype (grouped select, pills+chips, searchable picker, pills+scoped select, bottom sheet, sentence builder) reviewed live on device; primary source preserved on branch [`prototype/defensive-filter-look`](https://github.com/crf04/statsplus-frontend/tree/prototype/defensive-filter-look). Verdict: pills + scoped select (refined Variant D) — keeps the compact native select but kills the 35-option scroll.
- Switching category resets the selection unless the chosen token belongs to the new category; loading a Saved Filter Set resets the pill to General.
- The vocabulary test asserts against a hard-coded mirror of the backend catalog per category, so a token silently dropped from the module fails CI; reset behavior is regression-tested (asserting real state via the Add button, not the select's display fallback).
- Accessibility: pills are buttons with `aria-pressed`; label→select wired via `htmlFor`/`id`; rank input has its own id and `aria-label`; a muted helper explains the sign convention ("Positive rank = top defenses, negative = bottom").

## Verification

- `npm run lint`, `npm run format:check`, `CI=true npx jest` (460 tests), `npm run build`, `npm run test:e2e` — green.
- New tests mutation-tested (token deletion, missing `None`, broken category reset, unlabelled badge each fail).
- Cross-vendor reviews (gpt-5.6-sol, then Codex on the redesign): all findings fixed and re-verified; final verdict "ship".

Screenshots in comments below (original grouped-select design superseded by the category-pill design in the latest comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)