### PR TITLE
Add game log links to matchup players

### DIFF
--- a/src/matchups/MatchupDetailPage.css
+++ b/src/matchups/MatchupDetailPage.css
@@ -395,6 +395,13 @@
   font-size: 0.64rem;
 }
 
+.player-game-logs {
+  display: inline-block;
+  margin-top: 2px;
+  color: var(--ct-gold);
+  font-size: 0.62rem;
+}
+
 .select-player {
   margin-top: 5px;
   color: var(--ct-text);

--- a/src/matchups/MatchupDetailPage.js
+++ b/src/matchups/MatchupDetailPage.js
@@ -3,6 +3,7 @@ import { Link, useParams, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { getRequestErrorMessage, isRequestCancelled } from '../gameLogsApi';
 import { formatAge, useMinuteNow } from '../freshness';
+import { filterSetToSearchParams } from '../filterUtils';
 import { getSurfaceFreshnessPresentation } from '../slateStatus';
 import { fetchMatchup, fetchMatchupSelection } from './matchupApi';
 import { formatFocalGameLine, getDisplayableDietShare } from './displayConfig';
@@ -246,6 +247,9 @@ function PlayerRail({
             const focalLine = player.focalGameLine;
             const unscored = market !== 'All' && scoreFor(player) === null;
             const missingInputs = unscored ? (windowScoreFor(player)?.missingInputs ?? []) : [];
+            const gameLogsPath = `/?${filterSetToSearchParams({
+              player_name: player.name,
+            })}`;
             return (
               <article
                 key={player.id}
@@ -262,6 +266,13 @@ function PlayerRail({
                       ? ' · completed-season context'
                       : ''}
                   </p>
+                  <Link
+                    aria-label={`${player.name} game logs`}
+                    className="player-game-logs"
+                    to={gameLogsPath}
+                  >
+                    Game logs
+                  </Link>
                 </div>
                 {injury && (
                   <span className="injury-badge">{injury.status || injury.rawStatus}</span>

--- a/src/matchups/MatchupDetailPage.test.js
+++ b/src/matchups/MatchupDetailPage.test.js
@@ -232,6 +232,27 @@ beforeEach(() => {
   });
 });
 
+test('links every displayed player to that player’s game logs', async () => {
+  render(
+    <MemoryRouter initialEntries={['/matchups/game-1']}>
+      <Routes>
+        <Route path="/matchups/:gameId" element={<MatchupDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+  const lebronCard = await screen.findByRole('article', { name: 'LeBron James player' });
+  const reavesCard = screen.getByRole('article', { name: 'Austin Reaves player' });
+  expect(within(lebronCard).getByRole('link', { name: 'LeBron James game logs' })).toHaveAttribute(
+    'href',
+    '/?player_name=LeBron+James',
+  );
+  expect(within(reavesCard).getByRole('link', { name: 'Austin Reaves game logs' })).toHaveAttribute(
+    'href',
+    '/?player_name=Austin+Reaves',
+  );
+});
+
 test('shows the matchup-detail preseason caveat only for preseason games', async () => {
   const regular = render(
     <MemoryRouter initialEntries={['/matchups/game-1']}>


### PR DESCRIPTION
## What

Every player card on the matchup detail page (`/matchups/:gameId`) now has a **Game logs** link that opens that player's game logs on the home page.

- Link target is built with the canonical Filter Set encoder (`filterSetToSearchParams`), so it is the same URL contract the game-log page reads back: `/?player_name=LeBron+James`.
- Accessible name is per player (`LeBron James game logs`) so screen-reader link lists are distinguishable; visible text stays `Game logs`.
- Styled as the page's existing secondary-link treatment (matches `.injury-list a`).

## Files

- `src/matchups/MatchupDetailPage.js` — link in `PlayerRail` player card
- `src/matchups/MatchupDetailPage.css` — `.player-game-logs`
- `src/matchups/MatchupDetailPage.test.js` — new test: every displayed player links to their own game logs with the encoded `player_name`

## Verification

- `npm test -- --ci`: 28 suites / 461 tests pass
- `npm run lint`, `npm run format:check`, `npm run build`: clean
- Cross-vendor review (opus): 2 findings, both resolved (per-player aria-label; use canonical URL encoder)
- Mutation check: removing the link makes the new test fail for the intended reason

## Screenshots

**Pending.** Live-data screenshots (local frontend → production Railway backend, authenticated) could not be captured yet: the OMP Browser Relay extension connects, but its `chrome.debugger` calls hang in Chrome 152, so the logged-in session couldn't be driven. No fixture/mock screenshots substituted. Will add desktop + phone captures once the relay issue is resolved.