### PR TITLE
Omit Misc Points from matchup play types

### DIFF
--- a/src/matchups/matchupApi.js
+++ b/src/matchups/matchupApi.js
@@ -77,7 +77,6 @@ const PLAY_TYPE_SLICES = new Set([
   'Cut',
   'Handoff',
   'OffScreen',
-  'Misc',
   'Postup',
 ]);
 const TWO_POINT_SHOT_ZONE_SLICES = new Set([

--- a/src/matchups/matchupApi.test.js
+++ b/src/matchups/matchupApi.test.js
@@ -398,6 +398,17 @@ test('ignores undisplayed additive rows from backend-projected Bases', () => {
         last_15: teamWindow,
       },
     },
+    {
+      base: 'play_types',
+      league: { key: 'Misc:PTS', season: leagueWindow, last_15: leagueWindow },
+      team: {
+        key: 'Misc:PTS',
+        label: 'Misc PTS',
+        markets: ['PTS', 'PA', 'PR', 'PRA'],
+        season: teamWindow,
+        last_15: teamWindow,
+      },
+    },
   ];
   extras.forEach(({ base, league, team }) => {
     candidate.league.defense_sheet[base].push(league);
@@ -412,6 +423,7 @@ test('ignores undisplayed additive rows from backend-projected Bases', () => {
   expect(decoded.league.defenseSheet.playTypes.map((row) => row.key)).not.toContain(
     'Backcourt:PTS',
   );
+  expect(decoded.league.defenseSheet.playTypes.map((row) => row.key)).not.toContain('Misc:PTS');
   expect(decoded.teams[0].defenseSheet.traditional.map((row) => row.key)).not.toContain('OPP_PF');
   expect(decoded.teams[0].defenseSheet.assistLocations.map((row) => row.key)).not.toContain(
     'Assists',
@@ -419,6 +431,7 @@ test('ignores undisplayed additive rows from backend-projected Bases', () => {
   expect(decoded.teams[0].defenseSheet.playTypes.map((row) => row.key)).not.toContain(
     'Backcourt:PTS',
   );
+  expect(decoded.teams[0].defenseSheet.playTypes.map((row) => row.key)).not.toContain('Misc:PTS');
 });
 
 test.each([


### PR DESCRIPTION
## Summary

- omit backend-projected Misc Points rows from the Matchups Play types display model
- keep the backend contract unchanged and continue tolerating the projected row
- cover omission from both league and team defense sheets

## Verification

- `npm run lint`
- `npm run format:check`
- `npm run test:ci` — 461 passed
- `npm run build`
- `npm run test:e2e` — 82 passed, 2 production-only smokes skipped
- independent cross-vendor review — no material findings; mutation check confirmed both new assertions fail against the old behavior

## Screenshots

Pending authenticated live-data capture from the local frontend connected directly to the production Railway backend.

Closes #77
Part of crf04/statsplus#48