### PR TITLE
Prove the opponent rebound split in the Opposing Team Profile browser journey

### DIFF
--- a/e2e/fixtures/courtai.js
+++ b/e2e/fixtures/courtai.js
@@ -1315,6 +1315,29 @@ const applySelfFilters = (logs, url) =>
     return remaining.filter((log) => log[stat] >= min && log[stat] <= max);
   }, logs);
 
+/**
+ * The Traditional Opposing Team Profile, per-48 and ranked ascending so that
+ * rank 1 means the fewest allowed.
+ *
+ * The rebound split is canonical: the offensive and defensive values sum to the
+ * total the profile already published, so the three rows can never contradict
+ * each other on screen. The two splits sit on opposite sides of the league
+ * average, which keeps the comparison column honest in both directions.
+ */
+export const traditionalTeamStats = {
+  OPP_PTS: 112,
+  OPP_PTS_RANK: 18,
+  OPP_OREB: 10.62,
+  OPP_OREB_RANK: 7,
+  OPP_OREB_vs_avg_pct: -4.75,
+  OPP_DREB: 33.48,
+  OPP_DREB_RANK: 24,
+  OPP_DREB_vs_avg_pct: 3.86,
+  OPP_REB: 44.1,
+  OPP_REB_RANK: 19,
+  OPP_REB_vs_avg_pct: 1.72,
+};
+
 export const installApiContract = async (page, overrides = {}) => {
   const operationsJobs = [...operationsPayload.jobs];
   // Saved Filter Sets are account state rather than reference data, so the
@@ -1551,7 +1574,7 @@ export const installApiContract = async (page, overrides = {}) => {
     }
 
     if (url.pathname === '/api/teams/stats') {
-      await route.fulfill({ json: { OPP_PTS: 112, OPP_PTS_RANK: 18 } });
+      await route.fulfill({ json: traditionalTeamStats });
       return;
     }
 

--- a/e2e/fixtures/courtai.js
+++ b/e2e/fixtures/courtai.js
@@ -1324,7 +1324,7 @@ const applySelfFilters = (logs, url) =>
  * each other on screen. The two splits sit on opposite sides of the league
  * average, which keeps the comparison column honest in both directions.
  */
-export const traditionalTeamStats = {
+const traditionalTeamStats = {
   OPP_PTS: 112,
   OPP_PTS_RANK: 18,
   OPP_OREB: 10.62,

--- a/e2e/specs/core-flows.spec.js
+++ b/e2e/specs/core-flows.spec.js
@@ -1390,3 +1390,35 @@ test('saved Filter Set fixture answers the documented envelopes and rejections',
   });
   expect(contract.rejections).toEqual([400, 400, 404, 404]);
 });
+
+test('@critical the Traditional profile splits opponent rebounds into offensive and defensive', async ({
+  authenticatedPage: page,
+}) => {
+  await page.goto('/?player_name=LeBron+James');
+  await expect(page.getByRole('heading', { name: 'Opposing Team Profile' })).toBeVisible();
+
+  // The Traditional view is the default, and every stat renders as one row
+  // whose second cell carries the value, its rank, and its league-average
+  // comparison.
+  const statRow = (label) =>
+    page.getByRole('row').filter({ has: page.getByRole('cell', { name: label, exact: true }) });
+  const readout = (label) => statRow(label).getByRole('cell').nth(1);
+
+  const offensive = readout('OREB');
+  await expect(offensive.getByText('10.62', { exact: true })).toBeVisible();
+  await expect(offensive.getByText('7', { exact: true })).toBeVisible();
+  // A negative comparison reads as fewer offensive boards allowed than the
+  // league average, which is the whole point of an ascending defensive rank.
+  await expect(offensive.getByText('-4.75%', { exact: true })).toBeVisible();
+  await expect(offensive).not.toContainText('N/A');
+
+  const defensive = readout('DREB');
+  await expect(defensive.getByText('33.48', { exact: true })).toBeVisible();
+  await expect(defensive.getByText('24', { exact: true })).toBeVisible();
+  await expect(defensive.getByText('3.86%', { exact: true })).toBeVisible();
+  await expect(defensive).not.toContainText('N/A');
+
+  // The split has to agree with the total the profile already published, or the
+  // reader is looking at contradictory rebound data.
+  await expect(readout('REB').getByText('44.10', { exact: true })).toBeVisible();
+});


### PR DESCRIPTION
## Summary

- `e2e/fixtures/courtai.js`: the `/api/teams/stats` route now serves a `traditionalTeamStats` payload carrying the six contract fields (`OPP_OREB` 10.62 / rank 7 / −4.75%, `OPP_DREB` 33.48 / rank 24 / +3.86%) plus `OPP_REB` 44.10, chosen so the split sums exactly to the total and the two splits sit on opposite sides of the league average.
- `e2e/specs/core-flows.spec.js`: new `@critical` journey reaching the real Opposing Team Profile Traditional view and asserting both rebound rows show the exact numeric values, rank presentation, and league-average percentages — and no `N/A` — via accessible roles and visible text only.

No production component change was needed: `src/OpposingTeamProfile.js` already renders `OPP_OREB`/`OPP_DREB` generically; the rows showed `N/A` purely because the fixture supplied no values. Reviewed (two-axis, gpt-5.6-sol high) with zero spec findings; the one standards nit (unused export) is fixed in the second commit.

## Verification

Full gate: `npm run lint`, `npm run format:check`, `npm run test:ci` (28 suites, 467 tests), `npm run build`, `npm run test:e2e` (83 passed, 2 pre-existing deployment-gated skips) — all green.

Closes #82
Part of crf04/statsplus#50

🤖 Generated with [Claude Code](https://claude.com/claude-code)