### PR TITLE
Lab: live Backtest beneath every Target form

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -105,7 +105,9 @@ A Target's backtest is composed the same way but league-wide and season-to-date.
 player either Matchup publishes, excludes the thin Diets rather than flagging them, derives its
 outcome columns from each Qualifier's slice, and averages a player's season over the games the
 game-log route serves for that player — so a backtest row and the Log Workspace that row hands off
-to show the same game. The slate route reports pool freshness that matches the evidence resolution
+to show the same game. Its summary is the contract's own arithmetic over those games. The preview a
+Draft Target's Lab reads is the same composition for a Target that is stored nowhere, with a `today`
+block resolved against the current Slate date. The slate route reports pool freshness that matches the evidence resolution
 reports for the same date — a fresh pool on the scheduled date, none on the completed one — so a
 journey never sees one route call a pool unavailable while the other lists players from it.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -107,7 +107,8 @@ outcome columns from each Qualifier's slice, and averages a player's season over
 game-log route serves for that player — so a backtest row and the Log Workspace that row hands off
 to show the same game. Its summary is the contract's own arithmetic over those games. The preview a
 Draft Target's Lab reads is the same composition for a Target that is stored nowhere, with a `today`
-block resolved against the current Slate date. The slate route reports pool freshness that matches the evidence resolution
+block resolved against the current Slate date; it refuses a missing bearer, an unknown base or slice,
+and more than ten Qualifiers with the backend's envelopes. The slate route reports pool freshness that matches the evidence resolution
 reports for the same date — a fresh pool on the scheduled date, none on the completed one — so a
 journey never sees one route call a pool unavailable while the other lists players from it.
 

--- a/e2e/fixtures/courtai.js
+++ b/e2e/fixtures/courtai.js
@@ -1442,34 +1442,50 @@ const canonicalQualifiers = (qualifiers) =>
  * see it. See crf04/statsplus
  * docs/adr/0001-targets-store-player-criteria-not-team-readings.md.
  */
-const BACKEND_SLICE_LABELS = {
-  'Restricted Area': 'Restricted area',
-  'In The Paint (Non-RA)': 'Paint (non-RA)',
-  'Mid-Range': 'Mid-range',
-  'Corner 3': 'Corner 3',
-  'Above the Break 3': 'Above-break 3',
-  // Deliberately not the page's wording for this slice. The title is the
-  // backend's to derive, so a surface that showed its own preview where it
-  // promised the stored title would read 'Transition' here and be wrong.
-  Transition: 'Transition offense',
-  Isolation: 'Isolation',
-  PRBallHandler: 'P&R ball handler',
-  PRRollMan: 'P&R roll man',
-  Spotup: 'Spot up',
-  Cut: 'Cut',
-  Handoff: 'Handoff',
-  OffScreen: 'Off screen',
-  Postup: 'Post up',
-  OffRebound: 'Putback',
-  'Catch and Shoot': 'Catch & shoot',
-  Pullups: 'Pull-up',
-  'Less Than 10 ft': 'Inside 10 ft',
-  Arc3Assists: 'Arc 3 assists',
-  Corner3Assists: 'Corner 3 assists',
-  AtRimAssists: 'At-rim assists',
-  ShortMidRangeAssists: 'Short mid assists',
-  LongMidRangeAssists: 'Long mid assists',
+const BACKEND_BASE_SLICE_LABELS = {
+  shot_zones: {
+    'Restricted Area': 'Restricted area',
+    'In The Paint (Non-RA)': 'Paint (non-RA)',
+    'Mid-Range': 'Mid-range',
+    'Corner 3': 'Corner 3',
+    'Above the Break 3': 'Above-break 3',
+  },
+  play_types: {
+    // Deliberately not the page's wording for this slice. The title is the
+    // backend's to derive, so a surface that showed its own preview where it
+    // promised the stored title would read 'Transition' here and be wrong.
+    Transition: 'Transition offense',
+    Isolation: 'Isolation',
+    PRBallHandler: 'P&R ball handler',
+    PRRollMan: 'P&R roll man',
+    Spotup: 'Spot up',
+    Cut: 'Cut',
+    Handoff: 'Handoff',
+    OffScreen: 'Off screen',
+    Postup: 'Post up',
+    OffRebound: 'Putback',
+  },
+  shot_types: {
+    'Catch and Shoot': 'Catch & shoot',
+    Pullups: 'Pull-up',
+    'Less Than 10 ft': 'Inside 10 ft',
+  },
+  assist_locations: {
+    Arc3Assists: 'Arc 3 assists',
+    Corner3Assists: 'Corner 3 assists',
+    AtRimAssists: 'At-rim assists',
+    ShortMidRangeAssists: 'Short mid assists',
+    LongMidRangeAssists: 'Long mid assists',
+  },
 };
+
+const BACKEND_SLICE_LABELS = Object.assign({}, ...Object.values(BACKEND_BASE_SLICE_LABELS));
+
+// A slice is a slice of one base: 'Transition' is a play type and nothing
+// else, and an inherited key like `toString` is a slice of nothing.
+const knownSlice = (base, sliceKey) =>
+  Object.hasOwn(BACKEND_BASE_SLICE_LABELS, base) &&
+  Object.hasOwn(BACKEND_BASE_SLICE_LABELS[base], sliceKey);
 
 const backendShare = (share) => {
   const percent = (share * 100).toFixed(1);
@@ -1810,8 +1826,7 @@ const invalidTargetBody = (body) =>
   body.qualifiers.length > TARGET_QUALIFIER_LIMIT ||
   body.qualifiers.some(
     (qualifier) =>
-      !SLICE_MARKETS[qualifier.base] ||
-      !BACKEND_SLICE_LABELS[qualifier.slice_key] ||
+      !knownSlice(qualifier.base, qualifier.slice_key) ||
       !['at_or_above', 'at_or_below'].includes(qualifier.comparator) ||
       typeof qualifier.threshold !== 'number' ||
       qualifier.threshold < 0 ||

--- a/e2e/fixtures/courtai.js
+++ b/e2e/fixtures/courtai.js
@@ -1800,13 +1800,18 @@ const backtestTarget = (target) => {
  * The body is validated as create would validate it; the account cap and the
  * duplicate rule do not apply.
  */
+const TARGET_QUALIFIER_LIMIT = 10;
+
 const invalidTargetBody = (body) =>
   !body ||
   typeof body.opponent !== 'string' ||
   !Array.isArray(body.qualifiers) ||
   body.qualifiers.length === 0 ||
+  body.qualifiers.length > TARGET_QUALIFIER_LIMIT ||
   body.qualifiers.some(
     (qualifier) =>
+      !SLICE_MARKETS[qualifier.base] ||
+      !BACKEND_SLICE_LABELS[qualifier.slice_key] ||
       !['at_or_above', 'at_or_below'].includes(qualifier.comparator) ||
       typeof qualifier.threshold !== 'number' ||
       qualifier.threshold < 0 ||
@@ -2022,14 +2027,25 @@ export const installApiContract = async (page, overrides = {}) => {
       }
 
       // The backtest of a Draft Target, not a Target with the id "preview".
+      // A league-wide scan is not an open resource, so it refuses a missing
+      // bearer before it reads the body.
       if (targetId === 'preview' && method === 'POST') {
+        if (request.headers().authorization !== 'Bearer courtai-e2e-token') {
+          await route.fulfill({
+            status: 401,
+            json: {
+              error: { code: 'authentication_required', message: 'Sign in to preview a Target.' },
+            },
+          });
+          return;
+        }
         if (invalidTargetBody(body)) {
           await route.fulfill({
             status: 400,
             json: {
               error: {
                 code: 'invalid_input',
-                message: 'Every Qualifier needs a comparator and a threshold between 0 and 1.',
+                message: `Each of at most ${TARGET_QUALIFIER_LIMIT} Qualifiers needs a known base and slice, a comparator, and a threshold between 0 and 1.`,
               },
             },
           });

--- a/e2e/fixtures/courtai.js
+++ b/e2e/fixtures/courtai.js
@@ -1739,18 +1739,86 @@ const backtestPlayer = (target, statColumns, player) => {
   };
 };
 
+/*
+ * The backend's arithmetic over every listed game, so the Lab and the saved
+ * detail read the same figures: per market, the mean signed distance from
+ * each player's own season average and the share of games at or above it. A
+ * market with no game to average has no figure.
+ */
+const backtestSummary = (players, statColumns) => {
+  const games = players.flatMap((player) => player.games.map((game) => ({ player, game })));
+  return {
+    players: players.length,
+    games: games.length,
+    columns: Object.fromEntries(
+      statColumns.map((market) => {
+        const differences = games.map(
+          ({ player, game }) => game.stats[market] - player.season_averages[market],
+        );
+        if (differences.length === 0) {
+          return [market, { mean_difference: null, over_average_share: null }];
+        }
+        return [
+          market,
+          {
+            mean_difference:
+              Math.round(
+                (differences.reduce((total, value) => total + value, 0) / differences.length) * 100,
+              ) / 100,
+            over_average_share:
+              Math.round(
+                (differences.filter((value) => value >= 0).length / differences.length) * 1000,
+              ) / 1000,
+          },
+        ];
+      }),
+    ),
+  };
+};
+
 const backtestTarget = (target) => {
   const statColumns = [...new Set(target.qualifiers.flatMap(sliceMarkets))];
+  const players = leaguePlayers
+    .map((player) => backtestPlayer(target, statColumns, player))
+    .filter(Boolean)
+    // Season scoring descending, as every player list the product shows is.
+    .sort((first, second) => second.season_scoring - first.season_scoring);
   return {
     target,
     season: '2025-26',
     proxy: 'Outcomes are box-score proxies; there are no per-game slice splits.',
     stat_columns: statColumns,
-    players: leaguePlayers
-      .map((player) => backtestPlayer(target, statColumns, player))
-      .filter(Boolean)
-      // Season scoring descending, as every player list the product shows is.
-      .sort((first, second) => second.season_scoring - first.season_scoring),
+    summary: backtestSummary(players, statColumns),
+    players,
+  };
+};
+
+/*
+ * The preview is the backtest of a Draft Target, which is stored nowhere: the
+ * same composition over the same league, with the draft echoed back under its
+ * derived title and no id, plus whether it fires on the current Slate date.
+ * The body is validated as create would validate it; the account cap and the
+ * duplicate rule do not apply.
+ */
+const invalidTargetBody = (body) =>
+  !body ||
+  typeof body.opponent !== 'string' ||
+  !Array.isArray(body.qualifiers) ||
+  body.qualifiers.length === 0 ||
+  body.qualifiers.some(
+    (qualifier) =>
+      !['at_or_above', 'at_or_below'].includes(qualifier.comparator) ||
+      typeof qualifier.threshold !== 'number' ||
+      qualifier.threshold < 0 ||
+      qualifier.threshold > 1,
+  );
+
+const previewTarget = (draft) => {
+  const target = { ...draft, title: backendTargetTitle(draft) };
+  const [entry] = resolveTargets(DEFAULT_SLATE_DATE, [target]).targets;
+  return {
+    ...backtestTarget(target),
+    today: entry.game ? { game: entry.game, fit_count: entry.players.length } : null,
   };
 };
 
@@ -1949,6 +2017,33 @@ export const installApiContract = async (page, overrides = {}) => {
         }
         await route.fulfill({
           json: { success: true, ...resolveTargets(date || DEFAULT_SLATE_DATE, targets) },
+        });
+        return;
+      }
+
+      // The backtest of a Draft Target, not a Target with the id "preview".
+      if (targetId === 'preview' && method === 'POST') {
+        if (invalidTargetBody(body)) {
+          await route.fulfill({
+            status: 400,
+            json: {
+              error: {
+                code: 'invalid_input',
+                message: 'Every Qualifier needs a comparator and a threshold between 0 and 1.',
+              },
+            },
+          });
+          return;
+        }
+        await route.fulfill({
+          json: {
+            success: true,
+            ...previewTarget({
+              opponent: body.opponent,
+              qualifiers: body.qualifiers.map(toStored),
+              note: body.note || '',
+            }),
+          },
         });
         return;
       }

--- a/e2e/specs/matchup-detail.spec.js
+++ b/e2e/specs/matchup-detail.spec.js
@@ -831,15 +831,23 @@ test('@critical a Defense Sheet row becomes a Target the Targets page then holds
     animations: 'disabled',
   });
 
+  // Closing hands the keyboard back to the row the capture started from.
+  await dialog.getByRole('button', { name: 'Cancel' }).click();
+  await expect(page.getByRole('dialog')).toHaveCount(0);
+  await expect(rowAction).toBeFocused();
+
   // The prefill is a starting point: the threshold is the reader's to move.
+  await rowAction.click();
   await dialog.getByLabel('Qualifier 1 threshold percent').fill('26');
   await dialog
     .getByLabel('Note · optional, never the title')
     .fill('Rim leaks against big lineups.');
   await dialog.getByRole('button', { name: 'Save Target' }).click();
 
-  // The title in the confirmation is the one the backend derived and stored.
-  await expect(dialog.getByText('BOS vs Restricted area ≥ 26%')).toBeVisible();
+  // The saved draft is the record, and opens on its own page under the title
+  // the backend derived and stored.
+  await expect(page).toHaveURL(/\/targets\/\d+$/);
+  await expect(page.getByRole('heading', { name: 'BOS vs Restricted area ≥ 26%' })).toBeVisible();
   expect(created).toEqual([
     {
       opponent: 'BOS',
@@ -854,11 +862,9 @@ test('@critical a Defense Sheet row becomes a Target the Targets page then holds
       ],
     },
   ]);
-  await dialog.getByRole('button', { name: 'Back to the Defense Sheet' }).click();
-  await expect(page.getByRole('dialog')).toHaveCount(0);
-  await expect(rowAction).toBeFocused();
 
   // The same row saved again is the duplicate the account already holds.
+  await page.goto('/matchups/0022500584');
   await rowAction.click();
   await dialog.getByLabel('Qualifier 1 threshold percent').fill('26');
   await dialog.getByRole('button', { name: 'Save Target' }).click();
@@ -876,7 +882,8 @@ test('@critical a Defense Sheet row becomes a Target the Targets page then holds
   await expect(dialog.getByLabel('Qualifier 1 threshold percent')).toHaveValue('9');
   await expect(dialog.getByText('BOS vs Transition ≥ 9%')).toBeVisible();
   await dialog.getByRole('button', { name: 'Save Target' }).click();
-  await expect(dialog.getByText('BOS vs Transition offense ≥ 9%')).toBeVisible();
+  await expect(page).toHaveURL(/\/targets\/\d+$/);
+  await expect(page.getByRole('heading', { name: 'BOS vs Transition offense ≥ 9%' })).toBeVisible();
   expect(created[created.length - 1]).toEqual({
     opponent: 'BOS',
     note: '',
@@ -889,7 +896,7 @@ test('@critical a Defense Sheet row becomes a Target the Targets page then holds
       },
     ],
   });
-  await dialog.getByRole('link', { name: 'Go to Targets' }).click();
+  await page.getByRole('link', { name: '← All Targets' }).click();
 
   await expect(page).toHaveURL('/targets');
   await expect(page.getByRole('heading', { name: '2 Targets', exact: true })).toBeVisible();

--- a/e2e/specs/matchup-detail.spec.js
+++ b/e2e/specs/matchup-detail.spec.js
@@ -820,6 +820,10 @@ test('@critical a Defense Sheet row becomes a Target the Targets page then holds
   // 20% is the league average this row is already being read against.
   await expect(dialog.getByLabel('Qualifier 1 threshold percent')).toHaveValue('20');
   await expect(dialog.getByText('BOS vs Restricted area ≥ 20%')).toBeVisible();
+  // The Lab reads the prefilled draft beneath the form: BOS plays tonight and
+  // nobody qualifying has faced them yet.
+  await expect(dialog.getByText(/fit tonight vs BOS/)).toBeVisible();
+  await expect(dialog.getByText('Nobody qualifying has faced BOS yet.')).toBeVisible();
   // The dialog is fixed to the viewport, so a full-page capture would show the
   // page it floats over; its fade is finished rather than waited out.
   await page.screenshot({
@@ -913,6 +917,7 @@ test('capture stays reachable and the sheet stays unscrolled at a phone width', 
   await page.getByRole('button', { name: 'Save Restricted Area FGA as a Target' }).click();
   const dialog = page.getByRole('dialog');
   await expect(dialog.getByLabel('Qualifier 1 threshold percent')).toHaveValue('20');
+  await expect(dialog.getByText(/fit tonight vs BOS/)).toBeVisible();
   await page.screenshot({
     path: testInfo.outputPath('matchup-capture-narrow.png'),
     animations: 'disabled',

--- a/e2e/specs/targets.spec.js
+++ b/e2e/specs/targets.spec.js
@@ -9,14 +9,18 @@ const composeTarget = async (page, { opponent, base, slice, percent, note }) => 
 };
 
 /*
- * A saved Target leaves a blank form behind. Composing the next one before
- * that reset lands would be typing into a draft about to be replaced, so this
- * waits for the blank form the reset produces.
+ * Saving opens the new Target on its own page, so composing the next one means
+ * going back to the grid and its blank form.
  */
 const saveTarget = async (page) => {
   await page.getByRole('button', { name: 'Save Target' }).click();
+  await expect(page).toHaveURL(/\/targets\/\d+$/);
+  await page.getByRole('link', { name: '← All Targets' }).click();
   await expect(page.getByLabel('Qualifier 1 threshold percent')).toHaveValue('');
 };
+
+const summaryItem = (scope, label) =>
+  scope.getByRole('list', { name: 'Backtest summary' }).getByRole('listitem', { name: label });
 
 test('@critical authenticated user creates, opens, edits, and deletes a Target', async ({
   authenticatedPage: page,
@@ -41,13 +45,17 @@ test('@critical authenticated user creates, opens, edits, and deletes a Target',
   await page.screenshot({ path: testInfo.outputPath('targets-form.png'), fullPage: true });
   await page.getByRole('button', { name: 'Save Target' }).click();
 
+  // The saved draft is the record, and opens on its own page.
+  await expect(page).toHaveURL(/\/targets\/\d+$/);
+  await expect(page.getByRole('heading', { name: 'OKC vs Corner 3 ≥ 40%' })).toBeVisible();
+  await page.getByRole('link', { name: '← All Targets' }).click();
   const okcCard = page.getByRole('link', { name: 'Open OKC vs Corner 3 ≥ 40%' });
   await expect(okcCard).toBeVisible();
   await expect(page.getByRole('heading', { name: '1 Target', exact: true })).toBeVisible();
   await expect(okcCard).toContainText('Switches everything and leaves the corner late.');
 
-  // A saved Target leaves a blank form behind, so the same idea has to be
-  // typed again to be refused as the duplicate it is.
+  // The grid has a blank form, so the same idea has to be typed again to be
+  // refused as the duplicate it is.
   await expect(page.getByLabel('Qualifier 1 threshold percent')).toHaveValue('');
   await composeTarget(page, { opponent: 'OKC', slice: 'Corner 3', percent: '40' });
   await page.getByRole('button', { name: 'Save Target' }).click();
@@ -57,7 +65,7 @@ test('@critical authenticated user creates, opens, edits, and deletes a Target',
   // A second Target, so that opening one is a choice between two rather than
   // whatever the account happens to hold.
   await composeTarget(page, { opponent: 'MIA', slice: 'Restricted Area', percent: '22' });
-  await page.getByRole('button', { name: 'Save Target' }).click();
+  await saveTarget(page);
   await expect(page.getByRole('heading', { name: '2 Targets', exact: true })).toBeVisible();
   const cards = page.getByRole('link', { name: /^Open / });
   await expect(cards).toHaveCount(2);
@@ -96,7 +104,12 @@ test('the Targets page reads and works at a phone width', async ({ authenticated
   await page.goto('/targets');
 
   await composeTarget(page, { opponent: 'BOS', slice: 'Mid-Range', percent: '30' });
-  await page.getByRole('button', { name: 'Save Target' }).click();
+  // The Lab reads beneath the form at this width too, without widening it.
+  await expect(page.getByText(/fit tonight vs BOS/)).toBeVisible();
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(
+    true,
+  );
+  await saveTarget(page);
   await expect(page.getByRole('link', { name: 'Open BOS vs Mid-range ≥ 30%' })).toBeVisible();
   expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(
     true,
@@ -330,4 +343,78 @@ test('@critical a backtest is read on demand and hands off into the Log Workspac
   expect(gameLogRequests.at(-1).searchParams.get('opponent_tricode')).toBe('ATL');
   expect(gameLogRequests.at(-1).searchParams.get('player_name')).toBe('LeBron James');
   await expect(page.getByRole('cell', { name: 'ATL', exact: true })).toBeVisible();
+});
+
+/*
+ * The Lab: composing a Target while watching its Backtest. The draft is read
+ * once it holds still, a nudged threshold moves the strip, tonight is one line
+ * that comes and goes with the opponent's game, and the saved Target's own
+ * page reads the same summary the Lab did — nothing was stored until Save.
+ */
+test('@critical the Lab reads a draft live, and the saved Target reads the same', async ({
+  authenticatedPage: page,
+}, testInfo) => {
+  await installApiContract(page);
+  const previewRequests = [];
+  page.on('request', (request) => {
+    if (new URL(request.url()).pathname === '/api/user/targets/preview')
+      previewRequests.push(request.postDataJSON());
+  });
+  await page.goto('/targets');
+
+  // A blank draft is not sent anywhere.
+  await expect(page.getByText('Complete the Qualifiers to see the Backtest.')).toBeVisible();
+  expect(previewRequests).toHaveLength(0);
+
+  // ATL is on every player's season and plays on no slate: a backtest with
+  // rows and no tonight. Four players with a Diet worth leaning on clear 30%
+  // of at-rim assists, each with one game against ATL.
+  await composeTarget(page, {
+    opponent: 'ATL',
+    base: 'assist_locations',
+    slice: 'AtRimAssists',
+    percent: '30',
+  });
+  const strip = page.getByRole('list', { name: 'Backtest summary' });
+  await expect(summaryItem(page, 'Players')).toHaveText(/4$/);
+  await expect(summaryItem(page, 'Games')).toHaveText(/4$/);
+  await expect(page.getByText(/box-score proxies/)).toBeVisible();
+  await expect(page.getByText(/fit tonight/)).toHaveCount(0);
+  const table = page.getByRole('table', { name: 'Backtest for ATL vs At-rim assists ≥ 30%' });
+  await expect(table.getByRole('row', { name: /Kawhi Leonard/ })).toBeVisible();
+  // Composing was several edits and one read, made once the draft held still.
+  expect(previewRequests).toHaveLength(1);
+  expect(previewRequests[0].qualifiers[0].threshold).toBe(0.3);
+
+  // One nudge up drops the player sitting exactly on 30%, and the strip says so.
+  await page.getByRole('button', { name: 'Qualifier 1 threshold up 1%' }).click();
+  await expect(page.getByLabel('Qualifier 1 threshold percent')).toHaveValue('31');
+  await expect(summaryItem(page, 'Players')).toHaveText(/3$/);
+  await expect(
+    page.getByRole('table', { name: 'Backtest for ATL vs At-rim assists ≥ 31%' }),
+  ).toBeVisible();
+  await expect(page.getByRole('row', { name: /Kawhi Leonard/ })).toHaveCount(0);
+  await expect.poll(() => previewRequests.length).toBe(2);
+  expect(previewRequests[1].qualifiers[0].threshold).toBe(0.31);
+  await page.screenshot({ path: testInfo.outputPath('targets-lab.png'), fullPage: true });
+
+  // BOS plays tonight and nobody has faced them yet: tonight, and no table.
+  await page.getByLabel('Opponent').selectOption('BOS');
+  await expect(page.getByText('2 fit tonight vs BOS')).toBeVisible();
+  await expect(page.getByText('Nobody qualifying has faced BOS yet.')).toBeVisible();
+  await expect(strip).toHaveCount(0);
+
+  await page.getByLabel('Opponent').selectOption('ATL');
+  await expect(summaryItem(page, 'Players')).toHaveText(/3$/);
+  await expect(page.getByText(/fit tonight/)).toHaveCount(0);
+  const labSummary = await strip.textContent();
+
+  // Save, and the Target's own page reads the summary the Lab did.
+  await page.getByRole('button', { name: 'Save Target' }).click();
+  await expect(page).toHaveURL(/\/targets\/\d+$/);
+  await expect(page.getByRole('heading', { name: 'ATL vs At-rim assists ≥ 31%' })).toBeVisible();
+  await page.getByRole('button', { name: 'Expand backtest' }).click();
+  await expect(page.getByRole('list', { name: 'Backtest summary' })).toHaveText(labSummary);
+  await expect(page.getByRole('row', { name: /Kawhi Leonard/ })).toHaveCount(0);
+  await page.screenshot({ path: testInfo.outputPath('target-detail-summary.png'), fullPage: true });
 });

--- a/e2e/specs/targets.spec.js
+++ b/e2e/specs/targets.spec.js
@@ -398,11 +398,14 @@ test('@critical the Lab reads a draft live, and the saved Target reads the same'
   expect(previewRequests[1].qualifiers[0].threshold).toBe(0.31);
   await page.screenshot({ path: testInfo.outputPath('targets-lab.png'), fullPage: true });
 
-  // BOS plays tonight and nobody has faced them yet: tonight, and no table.
+  // BOS plays tonight and nobody has faced them yet: tonight, a summary of
+  // nothing, and no table.
   await page.getByLabel('Opponent').selectOption('BOS');
   await expect(page.getByText('2 fit tonight vs BOS')).toBeVisible();
   await expect(page.getByText('Nobody qualifying has faced BOS yet.')).toBeVisible();
-  await expect(strip).toHaveCount(0);
+  await expect(summaryItem(page, 'Players')).toHaveText(/0$/);
+  await expect(summaryItem(page, 'AST')).toContainText('—');
+  await expect(page.getByRole('table')).toHaveCount(0);
 
   await page.getByLabel('Opponent').selectOption('ATL');
   await expect(summaryItem(page, 'Players')).toHaveText(/3$/);

--- a/src/config.js
+++ b/src/config.js
@@ -22,6 +22,7 @@ const config = {
     NL_QUERY: '/api/nl-query',
     SAVED_FILTER_SETS: '/api/user/saved-filter-sets',
     TARGETS: '/api/user/targets',
+    TARGET_PREVIEW: '/api/user/targets/preview',
   },
 
   // Application settings

--- a/src/matchups/MatchupDetailPage.test.js
+++ b/src/matchups/MatchupDetailPage.test.js
@@ -2,13 +2,16 @@ import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
-import { createTarget } from '../targets/targetsApi';
+import { createTarget, fetchTargetPreview } from '../targets/targetsApi';
 import { fetchMatchup, fetchMatchupSelection } from './matchupApi';
 import MatchupDetailPage from './MatchupDetailPage';
 
 jest.mock('../contexts/AuthContext');
 jest.mock('./matchupApi');
-jest.mock('../targets/targetsApi', () => ({ createTarget: jest.fn() }));
+jest.mock('../targets/targetsApi', () => ({
+  createTarget: jest.fn(),
+  fetchTargetPreview: jest.fn(),
+}));
 
 const value = (allowedPer48, percentVsLeagueAverage, sigmaDeviation, rank) => ({
   allowedPer48,
@@ -255,6 +258,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   useAuth.mockReturnValue({ isAuthenticated: true, loading: false });
   fetchMatchup.mockResolvedValue(matchup);
+  fetchTargetPreview.mockResolvedValue(capturePreview);
   fetchMatchupSelection.mockResolvedValue({
     playerId: 2544,
     h2h: {
@@ -1357,6 +1361,50 @@ const storedTarget = (overrides = {}) => ({
   ...overrides,
 });
 
+/*
+ * The season behind the capture's draft, as the Lab beneath the dialog's form
+ * reads it. Nobody qualifying has faced BOS, so the strip is the only figure.
+ */
+const capturePreview = {
+  target: {
+    opponent: 'BOS',
+    title: 'BOS vs Transition offense ≥ 9%',
+    note: '',
+    qualifiers: [
+      { base: 'play_types', sliceKey: 'transition', comparator: 'at_or_above', threshold: 0.09 },
+    ],
+  },
+  proxy: 'Outcomes are box-score proxies; there are no per-game slice splits.',
+  statColumns: ['PTS'],
+  summary: {
+    players: 2,
+    games: 4,
+    columns: { PTS: { meanDifference: 3.1, overAverageShare: 0.75 } },
+  },
+  players: [
+    {
+      canonicalId: 2544,
+      name: 'LeBron James',
+      tricode: 'LAL',
+      shares: [{ share: 0.12, leagueAverageShare: 0.094 }],
+      seasonAverages: { PTS: 25.4 },
+      games: [{ gameDate: '2026-01-12', stats: { PTS: 31 } }],
+    },
+  ],
+  today: {
+    game: {
+      gameId: 'game-1',
+      scheduledAt: '2026-01-16T00:30:00.000Z',
+      status: { state: 'scheduled', label: 'Scheduled' },
+      away: { tricode: 'LAL' },
+      home: { tricode: 'BOS' },
+      opponent: { tricode: 'BOS' },
+      opposingTeam: { tricode: 'LAL' },
+    },
+    fitCount: 3,
+  },
+};
+
 const openCapture = async (rowLabel) => {
   await screen.findByRole('heading', { name: /Defense Sheet$/ });
   const rowAction = screen.getByRole('button', { name: `Save ${rowLabel} as a Target` });
@@ -1425,6 +1473,38 @@ test('prefills the capture form from the row and saves what the reader made of i
   expect(screen.queryByText('A title only the backend could have written')).not.toBeInTheDocument();
   await userEvent.keyboard('{Escape}');
   await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+});
+
+/*
+ * A Target born from a Defense Sheet row is tuned right there: the Lab reads
+ * the prefilled draft beneath the dialog's form, against the season the row
+ * prompted a look at.
+ */
+test('the capture dialog reads the prefilled draft live beneath its form', async () => {
+  renderMatchup();
+
+  const { dialog } = await openCapture('Transition');
+  expect(within(dialog).getByText('Lab · Backtest · season to date · vs BOS')).toBeVisible();
+  // The prefill is a complete draft, so it is read without a keystroke.
+  const strip = await within(dialog).findByRole(
+    'list',
+    { name: 'Backtest summary' },
+    { timeout: 3000 },
+  );
+  expect(fetchTargetPreview).toHaveBeenCalledWith(
+    expect.objectContaining({
+      opponent: 'BOS',
+      qualifiers: [
+        { base: 'play_types', sliceKey: 'transition', comparator: 'at_or_above', threshold: 0.09 },
+      ],
+    }),
+  );
+  expect(within(strip).getByRole('listitem', { name: 'Players' })).toHaveTextContent('2');
+  expect(within(strip).getByRole('listitem', { name: 'PTS' })).toHaveTextContent('+3.1');
+  expect(within(dialog).getByText(/fit tonight/)).toHaveTextContent('3 fit tonight vs BOS');
+  expect(
+    within(dialog).getByRole('table', { name: 'Backtest for BOS vs Transition offense ≥ 9%' }),
+  ).toBeVisible();
 });
 
 test('captures against whichever team’s sheet is open', async () => {

--- a/src/matchups/MatchupDetailPage.test.js
+++ b/src/matchups/MatchupDetailPage.test.js
@@ -1,6 +1,6 @@
 import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { createTarget, fetchTargetPreview } from '../targets/targetsApi';
 import { fetchMatchup, fetchMatchupSelection } from './matchupApi';
@@ -999,12 +999,16 @@ const historicalMatchup = () => {
   return candidate;
 };
 
+const LocationProbe = () => <output data-testid="location">{useLocation().pathname}</output>;
+
 const renderMatchup = (path = '/matchups/game-1') =>
   render(
     <MemoryRouter initialEntries={[path]}>
       <Routes>
         <Route path="/matchups/:gameId" element={<MatchupDetailPage />} />
+        <Route path="/targets/:targetId" element={<p>One Target</p>} />
       </Routes>
+      <LocationProbe />
     </MemoryRouter>,
   );
 
@@ -1438,17 +1442,28 @@ test('prefills the capture form from the row and saves what the reader made of i
   // 9.4% league average, offered as the whole percent a reader would type.
   expect(thresholdField(dialog)).toHaveValue(9);
 
-  // The prefill is a starting point: the threshold is the reader's to move and
-  // more Qualifiers can be added before saving.
-  await userEvent.clear(thresholdField(dialog));
-  await userEvent.type(thresholdField(dialog), '12');
-  await userEvent.click(within(dialog).getByRole('button', { name: '+ Add a Qualifier' }));
+  // Closing hands the keyboard back to the row the capture started from, and
+  // Escape closes it as the dialog it is.
+  await userEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+  await waitFor(() => expect(rowAction).toHaveFocus());
+  await openCapture('Transition');
+  await userEvent.keyboard('{Escape}');
+  await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+
+  // The same row opened again is a fresh capture. The prefill is a starting
+  // point: the threshold is the reader's to move and more Qualifiers can be
+  // added before saving.
+  const reopened = (await openCapture('Transition')).dialog;
+  expect(thresholdField(reopened)).toHaveValue(9);
+  await userEvent.clear(thresholdField(reopened));
+  await userEvent.type(thresholdField(reopened), '12');
+  await userEvent.click(within(reopened).getByRole('button', { name: '+ Add a Qualifier' }));
   await userEvent.selectOptions(
-    within(dialog).getByRole('combobox', { name: 'Qualifier 2 slice' }),
+    within(reopened).getByRole('combobox', { name: 'Qualifier 2 slice' }),
     'Corner 3',
   );
-  await userEvent.type(thresholdField(dialog, 2), '40');
-  await userEvent.click(within(dialog).getByRole('button', { name: 'Save Target' }));
+  await userEvent.type(thresholdField(reopened, 2), '40');
+  await userEvent.click(within(reopened).getByRole('button', { name: 'Save Target' }));
 
   expect(createTarget).toHaveBeenCalledWith({
     opponent: 'BOS',
@@ -1458,21 +1473,10 @@ test('prefills the capture form from the row and saves what the reader made of i
       { base: 'shot_zones', sliceKey: 'Corner 3', comparator: 'at_or_above', threshold: 0.4 },
     ],
   });
-  // The title is the backend's, so the confirmation says the one it derived.
-  expect(await screen.findByText('A title only the backend could have written')).toBeVisible();
-  expect(screen.getByRole('link', { name: 'Go to Targets' })).toHaveAttribute('href', '/targets');
-
-  // Closing hands the keyboard back to the row the capture started from.
-  await userEvent.click(screen.getByRole('button', { name: 'Back to the Defense Sheet' }));
-  await waitFor(() => expect(rowAction).toHaveFocus());
-
-  // The same row opened again is a fresh capture, not the receipt for the last
-  // one, and Escape closes it as the dialog it is.
-  const reopened = await openCapture('Transition');
-  expect(thresholdField(reopened.dialog)).toHaveValue(9);
-  expect(screen.queryByText('A title only the backend could have written')).not.toBeInTheDocument();
-  await userEvent.keyboard('{Escape}');
-  await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+  // The saved draft is the record, and opens on its own page: the one the
+  // backend stored, by the id it answered with.
+  expect(await screen.findByText('One Target')).toBeVisible();
+  expect(screen.getByTestId('location')).toHaveTextContent(/^\/targets\/4$/);
 });
 
 /*
@@ -1564,7 +1568,7 @@ test('a save in flight cannot be sent twice', async () => {
   expect(createTarget).toHaveBeenCalledTimes(1);
 
   await act(async () => settle());
-  expect(await screen.findByText('A title only the backend could have written')).toBeVisible();
+  expect(await screen.findByText('One Target')).toBeVisible();
 });
 
 test('a duplicate Target keeps the composed draft and says why it was refused', async () => {

--- a/src/matchups/MatchupDetailPage.test.js
+++ b/src/matchups/MatchupDetailPage.test.js
@@ -1571,6 +1571,39 @@ test('a save in flight cannot be sent twice', async () => {
   expect(await screen.findByText('One Target')).toBeVisible();
 });
 
+/*
+ * A save answered after the dialog was dismissed is nobody's any more. Acting
+ * on it would open a Target the reader had moved on from, over whatever they
+ * were composing next.
+ */
+test('a save that resolves after the dialog was dismissed does not navigate', async () => {
+  let settle;
+  createTarget.mockReturnValue(
+    new Promise((resolve) => {
+      settle = () => resolve(storedTarget());
+    }),
+  );
+  renderMatchup();
+
+  const { dialog } = await openCapture('Transition');
+  await userEvent.click(within(dialog).getByRole('button', { name: 'Save Target' }));
+  await userEvent.keyboard('{Escape}');
+  await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+
+  // Another row, another draft, before the first save answers.
+  const next = (await openCapture('Above-break three')).dialog;
+  await userEvent.type(thresholdField(next), '32');
+  await act(async () => settle());
+
+  expect(screen.getByTestId('location')).toHaveTextContent(/^\/matchups\/game-1$/);
+  expect(screen.queryByText('One Target')).not.toBeInTheDocument();
+  expect(screen.getByRole('dialog')).toBeVisible();
+  expect(thresholdField(screen.getByRole('dialog'))).toHaveValue(32);
+  expect(
+    within(screen.getByRole('dialog')).getByRole('button', { name: 'Save Target' }),
+  ).toBeEnabled();
+});
+
 test('a duplicate Target keeps the composed draft and says why it was refused', async () => {
   createTarget.mockRejectedValue({
     response: { data: { error: { message: 'You already have that Target for BOS.' } } },

--- a/src/targets/TargetBacktest.js
+++ b/src/targets/TargetBacktest.js
@@ -109,6 +109,69 @@ function BacktestTable({ backtest }) {
   );
 }
 
+/*
+ * The number that moves when a threshold is nudged, one glance away: how many
+ * players and games the table below holds, and per outcome market the mean
+ * signed distance from the players' own season averages and the share of games
+ * at or above them. The mean is read at the precision the table reads a game
+ * at, so a season that lands on the average is exactly zero and coloured as
+ * neither a hit nor a miss.
+ */
+function BacktestSummary({ summary, statColumns }) {
+  return (
+    <ul className="target-summary" aria-label="Backtest summary">
+      <li aria-label="Players">
+        <span className="target-label">Players</span>
+        <b className="num">{summary.players}</b>
+      </li>
+      <li aria-label="Games">
+        <span className="target-label">Games</span>
+        <b className="num">{summary.games}</b>
+      </li>
+      {statColumns.map((column) => {
+        const { meanDifference, overAverageShare } = summary.columns[column];
+        const difference = meanDifference === null ? null : Math.round(meanDifference * 10) / 10;
+        const tone = !difference ? '' : difference > 0 ? ' is-hit' : ' is-miss';
+        return (
+          <li aria-label={column} key={column}>
+            <span className="target-label">{column} · vs season avg</span>
+            <b className={`num${tone}`}>{difference === null ? '—' : signed(difference)}</b>
+            <small>
+              {overAverageShare === null ? '—' : formatObservedShare(overAverageShare)} of games
+              over
+            </small>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+/*
+ * One backtest, read out: the proxy note, the summary, then the games. The
+ * saved detail and the Lab both show a backtest through this, so a Draft
+ * Target reads exactly as it will once saved.
+ */
+export function BacktestEvidence({ backtest, children }) {
+  return (
+    <>
+      {/* Box-score outcomes are the closest thing to a slice the game logs
+          hold, and saying so is the difference between reading "points" and
+          reading "corner 3s made". */}
+      <p className="target-backtest-proxy">{backtest.proxy}</p>
+      {children}
+      {backtest.players.length === 0 ? (
+        <p className="target-empty">Nobody qualifying has faced {backtest.target.opponent} yet.</p>
+      ) : (
+        <>
+          <BacktestSummary summary={backtest.summary} statColumns={backtest.statColumns} />
+          <BacktestTable backtest={backtest} />
+        </>
+      )}
+    </>
+  );
+}
+
 export default function TargetBacktest({ target }) {
   const [open, setOpen] = useState(false);
   const { status, backtest, error, read } = useTargetBacktest(target.id);
@@ -149,21 +212,7 @@ export default function TargetBacktest({ target }) {
               {error}
             </p>
           )}
-          {status === 'ready' && (
-            <>
-              {/* Box-score outcomes are the closest thing to a slice the game
-                  logs hold, and saying so is the difference between reading
-                  "points" and reading "corner 3s made". */}
-              <p className="target-backtest-proxy">{backtest.proxy}</p>
-              {backtest.players.length === 0 ? (
-                <p className="target-empty">
-                  Nobody qualifying has faced {backtest.target.opponent} yet.
-                </p>
-              ) : (
-                <BacktestTable backtest={backtest} />
-              )}
-            </>
-          )}
+          {status === 'ready' && <BacktestEvidence backtest={backtest} />}
         </div>
       )}
     </section>

--- a/src/targets/TargetBacktest.js
+++ b/src/targets/TargetBacktest.js
@@ -150,7 +150,9 @@ function BacktestSummary({ summary, statColumns }) {
 /*
  * One backtest, read out: the proxy note, the summary, then the games. The
  * saved detail and the Lab both show a backtest through this, so a Draft
- * Target reads exactly as it will once saved.
+ * Target reads exactly as it will once saved. The summary leads even when
+ * there is nothing to summarise: zero players and zero games is the number
+ * that moved when a threshold was nudged too far.
  */
 export function BacktestEvidence({ backtest, children }) {
   return (
@@ -160,13 +162,11 @@ export function BacktestEvidence({ backtest, children }) {
           reading "corner 3s made". */}
       <p className="target-backtest-proxy">{backtest.proxy}</p>
       {children}
+      <BacktestSummary summary={backtest.summary} statColumns={backtest.statColumns} />
       {backtest.players.length === 0 ? (
         <p className="target-empty">Nobody qualifying has faced {backtest.target.opponent} yet.</p>
       ) : (
-        <>
-          <BacktestSummary summary={backtest.summary} statColumns={backtest.statColumns} />
-          <BacktestTable backtest={backtest} />
-        </>
+        <BacktestTable backtest={backtest} />
       )}
     </>
   );

--- a/src/targets/TargetCaptureModal.js
+++ b/src/targets/TargetCaptureModal.js
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Modal } from 'react-bootstrap';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { getRequestErrorMessage } from '../gameLogsApi';
 import TargetForm from './TargetForm';
 import TargetLab from './TargetLab';
@@ -45,35 +45,26 @@ export const captureDraft = ({ opponent, base, sliceKey, leagueAverageShare }) =
  * and clears whatever the last save said.
  */
 export default function TargetCaptureModal({ capture, onHide }) {
-  const [state, setState] = useState({
-    capture: null,
-    draft: null,
-    saving: false,
-    error: null,
-    saved: null,
-  });
+  const navigate = useNavigate();
+  const [state, setState] = useState({ capture: null, draft: null, saving: false, error: null });
 
   if (capture && capture !== state.capture) {
-    setState({
-      capture,
-      draft: captureDraft(capture),
-      saving: false,
-      error: null,
-      saved: null,
-    });
+    setState({ capture, draft: captureDraft(capture), saving: false, error: null });
   }
 
-  const { draft, saving, error, saved } = state;
+  const { draft, saving, error } = state;
 
   /*
-   * A refused save keeps the draft exactly as it was composed: a duplicate is
-   * one edit away from a Target worth keeping, not a retype.
+   * The saved draft is the record, and opens on its own page, where the
+   * evidence the Lab showed reads the same. A refused save keeps the draft
+   * exactly as it was composed: a duplicate is one edit away from a Target
+   * worth keeping, not a retype.
    */
   const save = async (request) => {
     setState((current) => ({ ...current, saving: true, error: null }));
     try {
       const target = await createTarget(request);
-      setState((current) => ({ ...current, saving: false, saved: target }));
+      navigate(`/targets/${target.id}`);
     } catch (requestError) {
       setState((current) => ({
         ...current,
@@ -102,49 +93,34 @@ export default function TargetCaptureModal({ capture, onHide }) {
         </Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        {saved ? (
-          <div className="target-capture-saved">
-            <p className="target-label">Target saved · title derived from the Qualifiers</p>
-            <p className="target-title">{saved.title}</p>
-            <div className="target-form-actions">
-              <Link className="target-primary" to="/targets">
-                Go to Targets
-              </Link>
-              <button type="button" className="target-ghost" onClick={onHide}>
-                Back to the Defense Sheet
-              </button>
-            </div>
-          </div>
-        ) : (
-          draft && (
-            <>
-              <p className="target-capture-source">
-                From the {state.capture.opponent} Defense Sheet ·{' '}
-                {targetSliceLabel(state.capture.base, state.capture.sliceKey)}
-                {typeof state.capture.leagueAverageShare === 'number'
-                  ? ' · threshold starts at the league average'
-                  : ' · no league average published for this slice'}
+        {draft && (
+          <>
+            <p className="target-capture-source">
+              From the {state.capture.opponent} Defense Sheet ·{' '}
+              {targetSliceLabel(state.capture.base, state.capture.sliceKey)}
+              {typeof state.capture.leagueAverageShare === 'number'
+                ? ' · threshold starts at the league average'
+                : ' · no league average published for this slice'}
+            </p>
+            <TargetForm
+              draft={draft}
+              busy={saving}
+              lockOpponent
+              onChange={(patch) =>
+                setState((current) => ({ ...current, draft: { ...current.draft, ...patch } }))
+              }
+              onSubmit={save}
+              onCancel={onHide}
+            />
+            {error && (
+              <p className="target-error" role="alert">
+                {error}
               </p>
-              <TargetForm
-                draft={draft}
-                busy={saving}
-                lockOpponent
-                onChange={(patch) =>
-                  setState((current) => ({ ...current, draft: { ...current.draft, ...patch } }))
-                }
-                onSubmit={save}
-                onCancel={onHide}
-              />
-              {error && (
-                <p className="target-error" role="alert">
-                  {error}
-                </p>
-              )}
-              {/* A Target born from a Defense Sheet row is tuned right here,
-                  against the season the row prompted a look at. */}
-              <TargetLab draft={draft} />
-            </>
-          )
+            )}
+            {/* A Target born from a Defense Sheet row is tuned right here,
+                against the season the row prompted a look at. */}
+            <TargetLab draft={draft} />
+          </>
         )}
       </Modal.Body>
     </Modal>

--- a/src/targets/TargetCaptureModal.js
+++ b/src/targets/TargetCaptureModal.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Modal } from 'react-bootstrap';
 import { useNavigate } from 'react-router-dom';
 import { getRequestErrorMessage } from '../gameLogsApi';
@@ -47,6 +47,18 @@ export const captureDraft = ({ opponent, base, sliceKey, leagueAverageShare }) =
 export default function TargetCaptureModal({ capture, onHide }) {
   const navigate = useNavigate();
   const [state, setState] = useState({ capture: null, draft: null, saving: false, error: null });
+  // The capture that is open right now, kept where a save that started under
+  // an earlier one can see it: a save whose answer arrives after the dialog
+  // was dismissed, or after another row opened a fresh capture, is not this
+  // reader's any more and must not act on their behalf.
+  const live = useRef(capture);
+  live.current = capture;
+  useEffect(
+    () => () => {
+      live.current = null;
+    },
+    [],
+  );
 
   if (capture && capture !== state.capture) {
     setState({ capture, draft: captureDraft(capture), saving: false, error: null });
@@ -61,11 +73,14 @@ export default function TargetCaptureModal({ capture, onHide }) {
    * worth keeping, not a retype.
    */
   const save = async (request) => {
+    const started = capture;
     setState((current) => ({ ...current, saving: true, error: null }));
     try {
       const target = await createTarget(request);
+      if (live.current !== started) return;
       navigate(`/targets/${target.id}`);
     } catch (requestError) {
+      if (live.current !== started) return;
       setState((current) => ({
         ...current,
         saving: false,

--- a/src/targets/TargetCaptureModal.js
+++ b/src/targets/TargetCaptureModal.js
@@ -41,27 +41,43 @@ export const captureDraft = ({ opponent, base, sliceKey, leagueAverageShare }) =
 
 /*
  * The modal stays mounted so that closing it hands focus back to the row action
- * that opened it. Each capture is a fresh object, so a new one resets the draft
- * and clears whatever the last save said.
+ * that opened it. Every opening is counted, so each one — a fresh capture or
+ * the same row again — starts from its prefill with nothing left over from the
+ * last, and a save that started under an earlier opening can tell.
  */
 export default function TargetCaptureModal({ capture, onHide }) {
   const navigate = useNavigate();
-  const [state, setState] = useState({ capture: null, draft: null, saving: false, error: null });
-  // The capture that is open right now, kept where a save that started under
-  // an earlier one can see it: a save whose answer arrives after the dialog
-  // was dismissed, or after another row opened a fresh capture, is not this
-  // reader's any more and must not act on their behalf.
-  const live = useRef(capture);
-  live.current = capture;
+  const [state, setState] = useState({
+    opening: 0,
+    capture: null,
+    draft: null,
+    saving: false,
+    error: null,
+  });
+  const shown = useRef(undefined);
+  const opening = useRef(0);
+  if (capture !== shown.current) {
+    shown.current = capture;
+    opening.current += 1;
+  }
+  // Going away is one more opening nobody will save under.
   useEffect(
     () => () => {
-      live.current = null;
+      opening.current += 1;
     },
     [],
   );
 
-  if (capture && capture !== state.capture) {
-    setState({ capture, draft: captureDraft(capture), saving: false, error: null });
+  // The opened capture is kept for the dialog's own use: the body is still
+  // drawn while the dialog fades out after the prop has gone.
+  if (capture && state.opening !== opening.current) {
+    setState({
+      opening: opening.current,
+      capture,
+      draft: captureDraft(capture),
+      saving: false,
+      error: null,
+    });
   }
 
   const { draft, saving, error } = state;
@@ -73,14 +89,16 @@ export default function TargetCaptureModal({ capture, onHide }) {
    * worth keeping, not a retype.
    */
   const save = async (request) => {
-    const started = capture;
+    // A save answered after this opening was dismissed, or after the row was
+    // opened again, is nobody's any more and acts on no one's behalf.
+    const started = opening.current;
     setState((current) => ({ ...current, saving: true, error: null }));
     try {
       const target = await createTarget(request);
-      if (live.current !== started) return;
+      if (opening.current !== started) return;
       navigate(`/targets/${target.id}`);
     } catch (requestError) {
-      if (live.current !== started) return;
+      if (opening.current !== started) return;
       setState((current) => ({
         ...current,
         saving: false,

--- a/src/targets/TargetCaptureModal.js
+++ b/src/targets/TargetCaptureModal.js
@@ -3,6 +3,7 @@ import { Modal } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 import { getRequestErrorMessage } from '../gameLogsApi';
 import TargetForm from './TargetForm';
+import TargetLab from './TargetLab';
 import { shareToThresholdPercent, targetSliceLabel } from './targetCatalog';
 import { createTarget } from './targetsApi';
 import './TargetsPage.css';
@@ -90,7 +91,8 @@ export default function TargetCaptureModal({ capture, onHide }) {
       show={Boolean(capture)}
       onHide={onHide}
       centered
-      size="lg"
+      // Wide enough for the Lab's table beneath the form.
+      size="xl"
       contentClassName="target-capture"
       aria-labelledby="target-capture-title"
     >
@@ -138,6 +140,9 @@ export default function TargetCaptureModal({ capture, onHide }) {
                   {error}
                 </p>
               )}
+              {/* A Target born from a Defense Sheet row is tuned right here,
+                  against the season the row prompted a look at. */}
+              <TargetLab draft={draft} />
             </>
           )
         )}

--- a/src/targets/TargetCaptureModal.test.js
+++ b/src/targets/TargetCaptureModal.test.js
@@ -1,0 +1,103 @@
+import { act, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import TargetCaptureModal from './TargetCaptureModal';
+import { createTarget, fetchTargetPreview } from './targetsApi';
+
+jest.mock('./targetsApi', () => ({ createTarget: jest.fn(), fetchTargetPreview: jest.fn() }));
+jest.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ isAuthenticated: true, loading: false }),
+}));
+
+/*
+ * The one capture object a row hands the dialog, held by the host across a
+ * dismissal and a reopening, as a host that memoises its row action would.
+ */
+const capture = {
+  opponent: 'BOS',
+  base: 'shot_zones',
+  sliceKey: 'Restricted Area',
+  leagueAverageShare: 0.2,
+};
+
+const LocationProbe = () => <span data-testid="location">{useLocation().pathname}</span>;
+
+function Host() {
+  const [open, setOpen] = useState(true);
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        Reopen
+      </button>
+      <TargetCaptureModal capture={open ? capture : null} onHide={() => setOpen(false)} />
+    </>
+  );
+}
+
+const renderHost = () =>
+  render(
+    <MemoryRouter initialEntries={['/matchups/0022500584']}>
+      <Routes>
+        <Route path="/matchups/:gameId" element={<Host />} />
+        <Route path="/targets/:targetId" element={<p>One Target</p>} />
+      </Routes>
+      <LocationProbe />
+    </MemoryRouter>,
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  fetchTargetPreview.mockReturnValue(new Promise(() => {}));
+});
+
+/*
+ * A save is this opening's. Dismissing the dialog and opening the same row
+ * again is a new opening — the same capture object or not — and the first
+ * save's late answer must not open a Target over the draft now being composed.
+ */
+test('a save that resolves after the same capture was dismissed and reopened does not navigate', async () => {
+  let settle;
+  createTarget.mockReturnValue(
+    new Promise((resolve) => {
+      settle = () => resolve({ id: 4, opponent: 'BOS', title: 'BOS vs Restricted area ≥ 20%' });
+    }),
+  );
+  renderHost();
+
+  const dialog = await screen.findByRole('dialog');
+  await userEvent.click(within(dialog).getByRole('button', { name: 'Save Target' }));
+  expect(createTarget).toHaveBeenCalledTimes(1);
+  await userEvent.keyboard('{Escape}');
+  await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+
+  await userEvent.click(screen.getByRole('button', { name: 'Reopen' }));
+  const reopened = await screen.findByRole('dialog');
+  // The reopening starts from the prefill, with nothing left over from the
+  // save still in flight: it is saveable again.
+  const threshold = within(reopened).getByRole('spinbutton', {
+    name: 'Qualifier 1 threshold percent',
+  });
+  expect(threshold).toHaveValue(20);
+  expect(within(reopened).getByRole('button', { name: 'Save Target' })).toBeEnabled();
+  await userEvent.clear(threshold);
+  await userEvent.type(threshold, '26');
+
+  await act(async () => settle());
+
+  expect(screen.getByTestId('location')).toHaveTextContent(/^\/matchups\/0022500584$/);
+  expect(screen.queryByText('One Target')).not.toBeInTheDocument();
+  expect(screen.getByRole('dialog')).toBeVisible();
+  expect(threshold).toHaveValue(26);
+});
+
+test('a save answered while its own opening is still current opens the Target', async () => {
+  createTarget.mockResolvedValue({ id: 4, opponent: 'BOS', title: 'BOS vs Restricted area ≥ 20%' });
+  renderHost();
+
+  const dialog = await screen.findByRole('dialog');
+  await userEvent.click(within(dialog).getByRole('button', { name: 'Save Target' }));
+
+  expect(await screen.findByText('One Target')).toBeVisible();
+  expect(screen.getByTestId('location')).toHaveTextContent(/^\/targets\/4$/);
+});

--- a/src/targets/TargetDetailPage.js
+++ b/src/targets/TargetDetailPage.js
@@ -4,6 +4,7 @@ import { formatCalendarDate, formatTip } from '../calendarDate';
 import { getRequestErrorMessage } from '../gameLogsApi';
 import TargetBacktest from './TargetBacktest';
 import TargetForm, { targetToDraft } from './TargetForm';
+import TargetLab from './TargetLab';
 import { TargetContext, TargetFitTable } from './TargetFits';
 import { findTargetBase, formatQualifier, targetBaseLabel } from './targetCatalog';
 import { deleteTarget, updateTarget } from './targetsApi';
@@ -144,15 +145,20 @@ function TargetDetail({ target, resolved, entry, reload }) {
       )}
 
       {draft ? (
-        <TargetForm
-          draft={draft}
-          busy={busy}
-          lockOpponent
-          submitLabel="Save changes"
-          onChange={(patch) => setDraft({ ...draft, ...patch })}
-          onSubmit={save}
-          onCancel={() => setDraft(null)}
-        />
+        <>
+          <TargetForm
+            draft={draft}
+            busy={busy}
+            lockOpponent
+            submitLabel="Save changes"
+            onChange={(patch) => setDraft({ ...draft, ...patch })}
+            onSubmit={save}
+            onCancel={() => setDraft(null)}
+          />
+          {/* Editing is tuning too: the draft's season reads beneath the form
+              while the saved sections wait behind it. */}
+          <TargetLab draft={draft} />
+        </>
       ) : (
         <>
           <section className="target-detail-section" aria-labelledby="qualifiers-heading">

--- a/src/targets/TargetDetailPage.test.js
+++ b/src/targets/TargetDetailPage.test.js
@@ -5,6 +5,7 @@ import {
   deleteTarget,
   fetchResolvedTargets,
   fetchTargetBacktest,
+  fetchTargetPreview,
   fetchTargets,
   updateTarget,
 } from './targetsApi';
@@ -13,6 +14,7 @@ jest.mock('./targetsApi', () => ({
   fetchTargets: jest.fn(),
   fetchResolvedTargets: jest.fn(),
   fetchTargetBacktest: jest.fn(),
+  fetchTargetPreview: jest.fn(),
   updateTarget: jest.fn(),
   deleteTarget: jest.fn(),
 }));
@@ -123,6 +125,16 @@ const backtest = {
   target,
   proxy: 'Outcomes are box-score proxies; there are no per-game slice splits.',
   statColumns: ['PTS', '3PM'],
+  // The backend's arithmetic over the three games below: +5.6, -2.9 and 0.0
+  // in points, two of three at or over.
+  summary: {
+    players: 1,
+    games: 3,
+    columns: {
+      PTS: { meanDifference: 0.913, overAverageShare: 0.667 },
+      '3PM': { meanDifference: 0.333, overAverageShare: 0.667 },
+    },
+  },
   players: [
     {
       canonicalId: 2544,
@@ -156,6 +168,35 @@ const backtestOfAnotherTarget = {
   },
 };
 
+/*
+ * What the Lab reads for the edit form's draft. It is the season behind the
+ * draft rather than the saved Target, so it is deliberately not the saved
+ * backtest above: a Lab that showed the saved one would pass a shared fixture.
+ */
+const preview = {
+  ...backtest,
+  target: {
+    opponent: 'OKC',
+    title: 'OKC vs Corner 3 ≥ 40%',
+    note: '',
+    qualifiers: target.qualifiers,
+  },
+  summary: {
+    players: 3,
+    games: 8,
+    columns: {
+      PTS: { meanDifference: 1.5, overAverageShare: 0.5 },
+      '3PM': { meanDifference: 0.2, overAverageShare: 0.5 },
+    },
+  },
+  today: null,
+};
+
+const summaryItem = (label) =>
+  within(screen.getByRole('list', { name: 'Backtest summary' })).getByRole('listitem', {
+    name: label,
+  });
+
 const expandBacktest = async () => {
   const toggle = await screen.findByRole('button', { name: 'Expand backtest' });
   await act(async () => {
@@ -187,6 +228,11 @@ beforeEach(() => {
   updateTarget.mockResolvedValue(undefined);
   deleteTarget.mockResolvedValue(undefined);
   fetchTargetBacktest.mockResolvedValue(backtest);
+  fetchTargetPreview.mockResolvedValue(preview);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
 });
 
 test('shows one Target with its Qualifiers, note, creation date, and a way back', async () => {
@@ -667,4 +713,82 @@ test('a refused backtest leaves the rest of the Target intact and can be asked f
   await expandBacktest();
   expect(screen.getByRole('table')).toBeVisible();
   expect(fetchTargetBacktest).toHaveBeenCalledTimes(2);
+});
+
+/*
+ * The summary the backend computed leads the games it summarises, so the
+ * saved detail and the Lab show the same numbers for the same Target.
+ */
+test('an expanded backtest leads with its summary, read at one decimal', async () => {
+  renderDetail();
+  await expandBacktest();
+
+  expect(summaryItem('Players')).toHaveTextContent('1');
+  expect(summaryItem('Games')).toHaveTextContent('3');
+  expect(summaryItem('PTS')).toHaveTextContent('+0.9');
+  expect(summaryItem('PTS')).toHaveTextContent('67% of games over');
+  expect(within(summaryItem('PTS')).getByText('+0.9')).toHaveClass('is-hit');
+  expect(summaryItem('3PM')).toHaveTextContent('+0.3');
+  // The strip sits above the table it summarises.
+  const strip = screen.getByRole('list', { name: 'Backtest summary' });
+  expect(strip.compareDocumentPosition(screen.getByRole('table'))).toBe(
+    Node.DOCUMENT_POSITION_FOLLOWING,
+  );
+});
+
+test('a summary that lands on the average is coloured as neither a hit nor a miss', async () => {
+  fetchTargetBacktest.mockResolvedValue({
+    ...backtest,
+    summary: {
+      ...backtest.summary,
+      columns: {
+        PTS: { meanDifference: -0.04, overAverageShare: 0.5 },
+        '3PM': { meanDifference: -1.2, overAverageShare: 0 },
+      },
+    },
+  });
+  renderDetail();
+  await expandBacktest();
+
+  const level = within(summaryItem('PTS')).getByText('0.0');
+  expect(level).not.toHaveClass('is-hit');
+  expect(level).not.toHaveClass('is-miss');
+  expect(within(summaryItem('3PM')).getByText('-1.2')).toHaveClass('is-miss');
+  expect(summaryItem('3PM')).toHaveTextContent('0% of games over');
+});
+
+/*
+ * Editing is tuning too: the Lab reads the draft's season beneath the edit
+ * form, in place of the saved sections, and is gone again once the form is.
+ */
+test('the edit form reads the draft live beneath it', async () => {
+  jest.useFakeTimers();
+  renderDetail();
+  fireEvent.click(await screen.findByRole('button', { name: 'Edit' }));
+
+  // The saved Target's own backtest waits behind the form.
+  expect(screen.queryByRole('button', { name: 'Expand backtest' })).not.toBeInTheDocument();
+  expect(screen.getByText('Lab · Backtest · season to date · vs OKC')).toBeVisible();
+  // The stored Qualifiers are a complete draft, so the Lab reads it as it is.
+  await act(async () => {
+    jest.advanceTimersByTime(600);
+  });
+  expect(fetchTargetPreview).toHaveBeenCalledTimes(1);
+  expect(fetchTargetPreview).toHaveBeenCalledWith(
+    expect.objectContaining({
+      opponent: 'OKC',
+      note: 'Leaks the corner late.',
+      qualifiers: [
+        { base: 'shot_zones', sliceKey: 'Corner 3', comparator: 'at_or_above', threshold: 0.4 },
+      ],
+    }),
+  );
+  expect(summaryItem('Players')).toHaveTextContent('3');
+  expect(summaryItem('Games')).toHaveTextContent('8');
+  // OKC is idle on the fixture's day, so there is no tonight to speak of.
+  expect(screen.queryByText(/fit tonight/)).not.toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+  expect(screen.queryByText(/^Lab · /)).not.toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Expand backtest' })).toBeInTheDocument();
 });

--- a/src/targets/TargetDetailPage.test.js
+++ b/src/targets/TargetDetailPage.test.js
@@ -682,12 +682,28 @@ test('a backtest row opens the Log Workspace with the player and the opponent fi
 test('a backtest nobody has played into says so rather than showing an empty table', async () => {
   // Named after the opponent the backtest was run against, not the one the
   // page happens to be showing.
-  fetchTargetBacktest.mockResolvedValue({ ...backtestOfAnotherTarget, players: [] });
+  fetchTargetBacktest.mockResolvedValue({
+    ...backtestOfAnotherTarget,
+    players: [],
+    summary: {
+      players: 0,
+      games: 0,
+      columns: {
+        PTS: { meanDifference: null, overAverageShare: null },
+        '3PM': { meanDifference: null, overAverageShare: null },
+      },
+    },
+  });
   renderDetail();
   await expandBacktest();
 
   expect(screen.getByText('Nobody qualifying has faced DEN yet.')).toBeVisible();
   expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  // The summary still leads: zero is the number that moved.
+  expect(summaryItem('Players')).toHaveTextContent('0');
+  expect(summaryItem('Games')).toHaveTextContent('0');
+  expect(summaryItem('PTS')).toHaveTextContent('—');
+  expect(summaryItem('PTS')).toHaveTextContent('— of games over');
 });
 
 /*
@@ -777,7 +793,6 @@ test('the edit form reads the draft live beneath it', async () => {
   expect(fetchTargetPreview).toHaveBeenCalledWith(
     expect.objectContaining({
       opponent: 'OKC',
-      note: 'Leaks the corner late.',
       qualifiers: [
         { base: 'shot_zones', sliceKey: 'Corner 3', comparator: 'at_or_above', threshold: 0.4 },
       ],

--- a/src/targets/TargetForm.js
+++ b/src/targets/TargetForm.js
@@ -4,6 +4,7 @@ import {
   TARGET_COMPARATORS,
   TARGET_SLICES,
   deriveTargetTitle,
+  nudgeThresholdPercent,
   parseThresholdPercent,
   shareToThresholdPercent,
 } from './targetCatalog';
@@ -185,8 +186,21 @@ export default function TargetForm({
           </div>
           {/* A step would let the browser refuse a share the form had just
               previewed as a title. The parser is the only judge of a threshold,
-              and it rounds to the decimal the title is written at. */}
+              and it rounds to the decimal the title is written at. Tuning is a
+              series of small moves, so the steppers and the arrow keys nudge
+              by one whole percent. */}
           <span className="target-threshold">
+            <button
+              type="button"
+              aria-label={`Qualifier ${index + 1} threshold down 1%`}
+              onClick={() =>
+                patchQualifier(index, {
+                  thresholdPercent: nudgeThresholdPercent(qualifier.thresholdPercent, -1),
+                })
+              }
+            >
+              −
+            </button>
             <input
               type="number"
               min="0"
@@ -195,8 +209,27 @@ export default function TargetForm({
               aria-label={`Qualifier ${index + 1} threshold percent`}
               value={qualifier.thresholdPercent}
               onChange={(event) => patchQualifier(index, { thresholdPercent: event.target.value })}
+              onKeyDown={(event) => {
+                const delta = { ArrowUp: 1, ArrowDown: -1 }[event.key];
+                if (!delta) return;
+                event.preventDefault();
+                patchQualifier(index, {
+                  thresholdPercent: nudgeThresholdPercent(qualifier.thresholdPercent, delta),
+                });
+              }}
             />
             <span>%</span>
+            <button
+              type="button"
+              aria-label={`Qualifier ${index + 1} threshold up 1%`}
+              onClick={() =>
+                patchQualifier(index, {
+                  thresholdPercent: nudgeThresholdPercent(qualifier.thresholdPercent, 1),
+                })
+              }
+            >
+              +
+            </button>
           </span>
           <button
             type="button"

--- a/src/targets/TargetLab.js
+++ b/src/targets/TargetLab.js
@@ -1,0 +1,54 @@
+import { BacktestEvidence } from './TargetBacktest';
+import { describeDraft } from './TargetForm';
+import { useTargetPreview } from './useTargets';
+import './TargetFits.css';
+
+/*
+ * The Lab: the season-to-date Backtest of the Draft Target above it, read
+ * live as the draft is composed. It is not a destination; wherever a draft is
+ * edited, this is the evidence beneath the form. Nothing is stored until Save,
+ * and Save is the form's own — the Lab never touches it, so a slow or refused
+ * read never blocks saving.
+ */
+export default function TargetLab({ draft }) {
+  const { valid, request } = describeDraft(draft);
+  const { status, preview, error, pending } = useTargetPreview(valid ? request : null);
+  // The result on screen describes the draft it was read for; the moment the
+  // draft moves on, the result is stale, whether or not the read has begun.
+  const stale = pending || status !== 'ready';
+
+  return (
+    <section
+      className="target-lab"
+      aria-labelledby="target-lab-heading"
+      aria-busy={status === 'loading'}
+    >
+      <h2 id="target-lab-heading" className="target-section-heading">
+        Lab · Backtest · season to date · vs {draft.opponent}
+      </h2>
+      {/* A half-typed draft is not a Target to evaluate, so it is not sent. */}
+      {!valid && <p className="target-empty">Complete the Qualifiers to see the Backtest.</p>}
+      {status === 'loading' && <p role="status">Reading the season…</p>}
+      {status === 'error' && (
+        <p className="target-error" role="alert">
+          {error}
+        </p>
+      )}
+      {preview && (
+        /* What was last read stays on screen, dimmed, while the next answer is
+           on its way: a keystroke never blanks the screen. */
+        <div className={`target-lab-result${stale ? ' is-stale' : ''}`}>
+          <BacktestEvidence backtest={preview}>
+            {/* Season to date is the evidence; whether the idea is actionable
+                tonight is one line, present only when the opponent plays. */}
+            {preview.today && (
+              <p className={`target-lab-tonight${preview.today.fitCount ? ' has-fits' : ''}`}>
+                <b>{preview.today.fitCount}</b> fit tonight vs {preview.target.opponent}
+              </p>
+            )}
+          </BacktestEvidence>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/targets/TargetLab.js
+++ b/src/targets/TargetLab.js
@@ -12,9 +12,11 @@ import './TargetFits.css';
 const describeLab = ({ valid, status, pending }) => {
   if (!valid) return 'Complete the Qualifiers to see the Backtest.';
   if (status === 'loading') return 'Reading the season…';
+  // A refusal is the answer to the draft in hand, so it outranks the draft
+  // having moved on; the next read replaces both.
+  if (status === 'error') return 'Backtest not updated.';
   if (pending) return 'Draft changed · reading shortly…';
   if (status === 'ready') return 'Backtest up to date.';
-  if (status === 'error') return 'Backtest not updated.';
   return '';
 };
 

--- a/src/targets/TargetLab.js
+++ b/src/targets/TargetLab.js
@@ -4,6 +4,21 @@ import { useTargetPreview } from './useTargets';
 import './TargetFits.css';
 
 /*
+ * One line that always says where the Lab stands, so a reader who cannot see
+ * the results dim hears the draft change, the read begin, and the answer land.
+ * A half-typed draft is not a Target to evaluate, so it is not sent, and the
+ * line says what would make it one.
+ */
+const describeLab = ({ valid, status, pending }) => {
+  if (!valid) return 'Complete the Qualifiers to see the Backtest.';
+  if (status === 'loading') return 'Reading the season…';
+  if (pending) return 'Draft changed · reading shortly…';
+  if (status === 'ready') return 'Backtest up to date.';
+  if (status === 'error') return 'Backtest not updated.';
+  return '';
+};
+
+/*
  * The Lab: the season-to-date Backtest of the Draft Target above it, read
  * live as the draft is composed. It is not a destination; wherever a draft is
  * edited, this is the evidence beneath the form. Nothing is stored until Save,
@@ -18,17 +33,13 @@ export default function TargetLab({ draft }) {
   const stale = pending || status !== 'ready';
 
   return (
-    <section
-      className="target-lab"
-      aria-labelledby="target-lab-heading"
-      aria-busy={status === 'loading'}
-    >
+    <section className="target-lab" aria-labelledby="target-lab-heading">
       <h2 id="target-lab-heading" className="target-section-heading">
         Lab · Backtest · season to date · vs {draft.opponent}
       </h2>
-      {/* A half-typed draft is not a Target to evaluate, so it is not sent. */}
-      {!valid && <p className="target-empty">Complete the Qualifiers to see the Backtest.</p>}
-      {status === 'loading' && <p role="status">Reading the season…</p>}
+      <p role="status" className="target-lab-status">
+        {describeLab({ valid, status, pending })}
+      </p>
       {status === 'error' && (
         <p className="target-error" role="alert">
           {error}
@@ -37,7 +48,10 @@ export default function TargetLab({ draft }) {
       {preview && (
         /* What was last read stays on screen, dimmed, while the next answer is
            on its way: a keystroke never blanks the screen. */
-        <div className={`target-lab-result${stale ? ' is-stale' : ''}`}>
+        <div
+          className={`target-lab-result${stale ? ' is-stale' : ''}`}
+          aria-busy={status === 'loading'}
+        >
           <BacktestEvidence backtest={preview}>
             {/* Season to date is the evidence; whether the idea is actionable
                 tonight is one line, present only when the opponent plays. */}

--- a/src/targets/TargetsPage.css
+++ b/src/targets/TargetsPage.css
@@ -125,7 +125,7 @@
 
 .target-qualifier {
   display: grid;
-  grid-template-columns: 140px minmax(140px, 1fr) auto 86px 28px;
+  grid-template-columns: 140px minmax(140px, 1fr) auto auto 28px;
   gap: 6px;
   align-items: center;
 }
@@ -176,6 +176,25 @@
   width: 58px;
   text-align: right;
   font-family: var(--ct-mono);
+}
+
+/* The steppers are the arrow keys made visible: two small moves either side
+   of the number, styled as the comparator pill's buttons are. */
+.target-threshold button {
+  min-width: 28px;
+  min-height: 34px;
+  border: 1px solid var(--ct-line-strong);
+  border-radius: var(--ct-radius-ctl);
+  background: transparent;
+  color: var(--ct-dim);
+  font-family: var(--ct-mono);
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.target-threshold button:hover {
+  border-color: var(--ct-gold);
+  color: var(--ct-gold);
 }
 
 .target-remove {
@@ -552,6 +571,80 @@
   font-style: normal;
 }
 
+/* --- the Lab --- */
+
+.target-lab {
+  display: grid;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+/* What was last read, while the next answer is on its way. */
+.target-lab-result {
+  display: grid;
+  gap: 10px;
+  transition: opacity 120ms ease;
+}
+
+.target-lab-result.is-stale {
+  opacity: 0.45;
+}
+
+.target-lab-tonight {
+  margin: 0;
+  color: var(--ct-dim);
+  font-family: var(--ct-mono);
+  font-size: 0.74rem;
+}
+
+.target-lab-tonight b {
+  color: var(--ct-text);
+  font-size: 1rem;
+}
+
+.target-lab-tonight.has-fits b {
+  color: var(--ct-hit);
+}
+
+/* The summary strip: a few figures in a row, each under its own label. */
+.target-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 20px;
+  margin: 0;
+  padding: 8px 0;
+  border-top: 1px solid var(--ct-line);
+  border-bottom: 1px solid var(--ct-line);
+  list-style: none;
+}
+
+.target-summary li {
+  display: grid;
+  gap: 2px;
+  min-width: 72px;
+}
+
+.target-summary b {
+  font-family: var(--ct-mono);
+  font-size: 1.1rem;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.1;
+}
+
+.target-summary small {
+  color: var(--ct-dim);
+  font-family: var(--ct-mono);
+  font-size: 0.62rem;
+}
+
+.target-summary .is-hit {
+  color: var(--ct-hit);
+}
+
+.target-summary .is-miss {
+  color: var(--ct-miss);
+}
+
 @media (max-width: 820px) {
   .target-qualifier {
     grid-template-columns: 1fr 1fr;
@@ -563,5 +656,15 @@
 
   .target-detail-head {
     flex-direction: column;
+  }
+}
+
+@media (max-width: 620px) {
+  .target-summary {
+    gap: 8px 14px;
+  }
+
+  .target-summary li {
+    min-width: 0;
   }
 }

--- a/src/targets/TargetsPage.css
+++ b/src/targets/TargetsPage.css
@@ -312,25 +312,6 @@
   font-size: 0.68rem;
 }
 
-.target-capture-saved {
-  display: grid;
-  gap: 10px;
-}
-
-.target-capture-saved .target-title {
-  margin: 0;
-  font-size: 1.05rem;
-  font-weight: 650;
-}
-
-/* The saved confirmation offers a link where the form offered a button, so the
-   link has to sit on the same line as one. */
-.target-capture-saved .target-primary {
-  display: inline-flex;
-  align-items: center;
-  text-decoration: none;
-}
-
 /* --- the card grid --- */
 
 .target-grid {
@@ -577,6 +558,14 @@
   display: grid;
   gap: 10px;
   margin-top: 12px;
+}
+
+/* Where the Lab stands, in one line that is always there to be announced. */
+.target-lab-status {
+  margin: 0;
+  color: var(--ct-dim);
+  font-family: var(--ct-mono);
+  font-size: 0.68rem;
 }
 
 /* What was last read, while the next answer is on its way. */

--- a/src/targets/TargetsPage.js
+++ b/src/targets/TargetsPage.js
@@ -1,7 +1,8 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { getRequestErrorMessage } from '../gameLogsApi';
 import TargetForm, { blankTargetDraft } from './TargetForm';
+import TargetLab from './TargetLab';
 import { formatQualifierParts } from './targetCatalog';
 import { createTarget } from './targetsApi';
 import TargetsSignedOut from './TargetsSignedOut';
@@ -65,7 +66,8 @@ function TargetCard({ target, entry }) {
 }
 
 export default function TargetsPage() {
-  const { authLoading, isAuthenticated, status, targets, error, reload } = useTargets();
+  const navigate = useNavigate();
+  const { authLoading, isAuthenticated, status, targets, error } = useTargets();
   /*
    * What each Target is worth today, read for the current Slate Date. It is a
    * second read over the same list, so a day that will not resolve costs the
@@ -81,17 +83,17 @@ export default function TargetsPage() {
   }
 
   /*
-   * A refused save keeps the draft exactly as it was typed: a duplicate or a
-   * full account is one edit away from a Target worth keeping, not a retype.
+   * A saved draft becomes the record and opens on its own page, where the
+   * evidence the Lab showed reads the same. A refused save keeps the draft
+   * exactly as it was typed: a duplicate or a full account is one edit away
+   * from a Target worth keeping, not a retype.
    */
   const save = async (request) => {
     setSaving(true);
     setSaveError(null);
     try {
-      await createTarget(request);
-      setDraft(blankTargetDraft());
-      reload();
-      resolved.reload();
+      const target = await createTarget(request);
+      navigate(`/targets/${target.id}`);
     } catch (requestError) {
       setSaveError(
         getRequestErrorMessage(requestError, 'Unable to save this Target. Please try again.'),
@@ -132,6 +134,7 @@ export default function TargetsPage() {
             {saveError}
           </p>
         )}
+        <TargetLab draft={draft} />
       </section>
 
       {status === 'loading' && <p role="status">Loading your Targets…</p>}

--- a/src/targets/TargetsPage.test.js
+++ b/src/targets/TargetsPage.test.js
@@ -492,12 +492,78 @@ test('the Lab reads a draft once it has held still, so several quick edits are o
   expect(fetchTargetPreview).toHaveBeenCalledWith(
     expect.objectContaining({
       opponent: 'OKC',
-      note: '',
       qualifiers: [
         { base: 'shot_zones', sliceKey: 'Corner 3', comparator: 'at_or_above', threshold: 0.42 },
       ],
     }),
   );
+  // The note is never part of the evidence, so it is not sent for evaluation.
+  expect(fetchTargetPreview.mock.calls[0][0]).not.toHaveProperty('note');
+});
+
+test('editing the note is not a new draft, so the Lab does not read again', async () => {
+  jest.useFakeTimers();
+  renderPage();
+  await screen.findAllByRole('link', { name: /^Open / });
+  composeQualifier();
+  await settle();
+  const result = screen
+    .getByRole('list', { name: 'Backtest summary' })
+    .closest('.target-lab-result');
+
+  fireEvent.change(screen.getByLabelText('Note · optional, never the title'), {
+    target: { value: 'Leaks the corner late.' },
+  });
+  expect(result).not.toHaveClass('is-stale');
+  await settle();
+  expect(fetchTargetPreview).toHaveBeenCalledTimes(1);
+  expect(screen.getByText('Backtest up to date.')).toBeVisible();
+});
+
+/*
+ * The draft can move on while a read for the old one is still in flight —
+ * waiting on a token, say. That read is abandoned the moment the draft
+ * changes, and if its answer arrives anyway it is not the draft's and is not
+ * shown.
+ */
+test('a read for a draft that has moved on is abandoned, and its late answer is not shown', async () => {
+  jest.useFakeTimers();
+  const publishers = [];
+  fetchTargetPreview.mockImplementation(
+    () =>
+      new Promise((resolve) => {
+        publishers.push(resolve);
+      }),
+  );
+  renderPage();
+  await screen.findAllByRole('link', { name: /^Open / });
+
+  composeQualifier();
+  await settle();
+  expect(fetchTargetPreview).toHaveBeenCalledTimes(1);
+  const first = fetchTargetPreview.mock.calls[0][0].signal;
+  expect(first.aborted).toBe(false);
+
+  // Edited again before the first answer: the first read is abandoned at once.
+  fireEvent.change(screen.getByLabelText('Qualifier 1 threshold percent'), {
+    target: { value: '45' },
+  });
+  expect(first.aborted).toBe(true);
+  expect(fetchTargetPreview).toHaveBeenCalledTimes(1);
+
+  await act(async () => {
+    publishers[0](preview);
+  });
+  expect(screen.queryByRole('list', { name: 'Backtest summary' })).not.toBeInTheDocument();
+
+  // The second read is the draft's, and its answer is the one shown.
+  await settle();
+  expect(fetchTargetPreview).toHaveBeenCalledTimes(2);
+  expect(fetchTargetPreview.mock.calls[1][0].qualifiers[0].threshold).toBe(0.45);
+  await act(async () => {
+    publishers[1]({ ...preview, summary: { ...preview.summary, players: 7 } });
+  });
+  expect(summaryItem('Players')).toHaveTextContent('7');
 });
 
 test('an incomplete draft asks for nothing and says what to complete', async () => {
@@ -522,6 +588,42 @@ test('an incomplete draft asks for nothing and says what to complete', async () 
   await settle();
   expect(fetchTargetPreview).not.toHaveBeenCalled();
   expect(screen.getByText('Complete the Qualifiers to see the Backtest.')).toBeVisible();
+});
+
+/*
+ * A keystroke never blanks the screen, and clearing a field to retype it is a
+ * keystroke. The evidence that was on screen stays, dimmed, under the line
+ * that says what would make the draft whole again.
+ */
+test('a draft that stops being complete keeps the last evidence, dimmed', async () => {
+  jest.useFakeTimers();
+  renderPage();
+  await screen.findAllByRole('link', { name: /^Open / });
+  composeQualifier();
+  await settle();
+  const result = screen
+    .getByRole('list', { name: 'Backtest summary' })
+    .closest('.target-lab-result');
+  expect(result).not.toHaveClass('is-stale');
+
+  fireEvent.change(screen.getByLabelText('Qualifier 1 threshold percent'), {
+    target: { value: '' },
+  });
+  expect(screen.getByText('Complete the Qualifiers to see the Backtest.')).toBeVisible();
+  expect(result).toHaveClass('is-stale');
+  expect(summaryItem('Players')).toHaveTextContent('2');
+  expect(screen.getByRole('table')).toBeInTheDocument();
+  await settle();
+  expect(fetchTargetPreview).toHaveBeenCalledTimes(1);
+
+  // Typed whole again as it was, it is the draft that was read: current, not
+  // re-read.
+  fireEvent.change(screen.getByLabelText('Qualifier 1 threshold percent'), {
+    target: { value: '40' },
+  });
+  expect(result).not.toHaveClass('is-stale');
+  await settle();
+  expect(fetchTargetPreview).toHaveBeenCalledTimes(1);
 });
 
 test('the Lab leads with the summary and whether the draft fires tonight, then the games', async () => {
@@ -595,8 +697,10 @@ test('a nudged draft keeps the last result on screen, dimmed, until the next one
     }),
   );
   fireEvent.click(screen.getByRole('button', { name: 'Qualifier 1 threshold up 1%' }));
-  // Stale from the edit, before the read has even started.
+  // Stale from the edit, before the read has even started — and said aloud,
+  // since a dimmed table is silent to a screen reader.
   expect(result).toHaveClass('is-stale');
+  expect(screen.getByText('Draft changed · reading shortly…')).toBeVisible();
   expect(fetchTargetPreview).toHaveBeenCalledTimes(1);
 
   await settle();
@@ -605,6 +709,7 @@ test('a nudged draft keeps the last result on screen, dimmed, until the next one
     expect.objectContaining({ qualifiers: [expect.objectContaining({ threshold: 0.41 })] }),
   );
   expect(screen.getByText('Reading the season…')).toBeVisible();
+  expect(result).toHaveAttribute('aria-busy', 'true');
   expect(result).toHaveClass('is-stale');
   expect(summaryItem('Players')).toHaveTextContent('2');
   expect(screen.getByRole('table')).toBeInTheDocument();
@@ -613,7 +718,8 @@ test('a nudged draft keeps the last result on screen, dimmed, until the next one
     publish({ ...preview, summary: { ...preview.summary, players: 1, games: 3 } });
   });
   expect(result).not.toHaveClass('is-stale');
-  expect(screen.queryByText('Reading the season…')).not.toBeInTheDocument();
+  expect(result).toHaveAttribute('aria-busy', 'false');
+  expect(screen.getByText('Backtest up to date.')).toBeVisible();
   expect(summaryItem('Players')).toHaveTextContent('1');
   expect(summaryItem('Games')).toHaveTextContent('3');
 });

--- a/src/targets/TargetsPage.test.js
+++ b/src/targets/TargetsPage.test.js
@@ -1,11 +1,12 @@
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 import TargetsPage from './TargetsPage';
-import { createTarget, fetchResolvedTargets, fetchTargets } from './targetsApi';
+import { createTarget, fetchResolvedTargets, fetchTargetPreview, fetchTargets } from './targetsApi';
 
 jest.mock('./targetsApi', () => ({
   fetchTargets: jest.fn(),
   fetchResolvedTargets: jest.fn(),
+  fetchTargetPreview: jest.fn(),
   createTarget: jest.fn(),
 }));
 
@@ -88,12 +89,68 @@ const resolution = {
   ],
 };
 
+/*
+ * What the Lab reads for a draft: the backtest a saved Target would have, with
+ * the draft echoed back under its derived title, and whether it fires tonight.
+ * The figures are the backend's; the strip reads them at one decimal and
+ * colours them by direction.
+ */
+const preview = {
+  target: {
+    opponent: 'OKC',
+    title: 'OKC vs Corner 3 ≥ 40%',
+    note: '',
+    qualifiers: [
+      { base: 'shot_zones', sliceKey: 'Corner 3', comparator: 'at_or_above', threshold: 0.4 },
+    ],
+  },
+  proxy: 'Outcomes are box-score proxies; there are no per-game slice splits.',
+  statColumns: ['PTS', '3PM'],
+  summary: {
+    players: 2,
+    games: 5,
+    columns: {
+      PTS: { meanDifference: 2.46, overAverageShare: 0.6 },
+      '3PM': { meanDifference: -0.8, overAverageShare: 0.4 },
+    },
+  },
+  players: [
+    {
+      canonicalId: 2544,
+      name: 'LeBron James',
+      tricode: 'LAL',
+      shares: [{ share: 0.44, leagueAverageShare: 0.2 }],
+      seasonAverages: { PTS: 25.4, '3PM': 2 },
+      games: [{ gameDate: '2026-01-12', stats: { PTS: 31, '3PM': 4 } }],
+    },
+  ],
+  today: {
+    game: resolution.entries[0].game,
+    fitCount: 1,
+  },
+};
+
+const storedTarget = { ...targets[0], id: 9, title: 'A title only the backend could have written' };
+
+const LocationProbe = () => <output data-testid="location">{useLocation().pathname}</output>;
+
 const renderPage = () =>
   render(
     <MemoryRouter initialEntries={['/targets']}>
       <TargetsPage />
+      <LocationProbe />
     </MemoryRouter>,
   );
+
+const summaryItem = (label) =>
+  within(screen.getByRole('list', { name: 'Backtest summary' })).getByRole('listitem', {
+    name: label,
+  });
+
+const settle = () =>
+  act(async () => {
+    jest.advanceTimersByTime(600);
+  });
 
 const composeQualifier = ({ opponent = 'OKC', slice = 'Corner 3', percent = '40' } = {}) => {
   fireEvent.change(screen.getByLabelText('Opponent'), { target: { value: opponent } });
@@ -109,7 +166,12 @@ beforeEach(() => {
   auth.loading = false;
   fetchTargets.mockResolvedValue(targets);
   fetchResolvedTargets.mockResolvedValue(resolution);
-  createTarget.mockResolvedValue(undefined);
+  fetchTargetPreview.mockResolvedValue(preview);
+  createTarget.mockResolvedValue(storedTarget);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
 });
 
 test('shows every saved Target as a card carrying the stored title, Qualifiers, and note', async () => {
@@ -225,7 +287,7 @@ test('refuses to save a Target with no Qualifier at all', async () => {
   expect(screen.getByText('Add at least one Qualifier before saving.')).toBeInTheDocument();
 });
 
-test('saves several Qualifiers as one Target and reloads the list the backend returns', async () => {
+test('saves several Qualifiers as one Target and opens the Target the backend stored', async () => {
   renderPage();
   await screen.findAllByRole('link', { name: /^Open / });
 
@@ -260,10 +322,8 @@ test('saves several Qualifiers as one Target and reloads the list the backend re
       { base: 'play_types', sliceKey: 'Transition', comparator: 'at_or_below', threshold: 0.15 },
     ],
   });
-  expect(fetchTargets).toHaveBeenCalledTimes(2);
-  // A saved Target leaves a blank form behind, ready for the next idea.
-  expect(screen.getByLabelText('Qualifier 1 threshold percent')).toHaveValue(null);
-  expect(screen.queryByLabelText('Qualifier 2 threshold percent')).not.toBeInTheDocument();
+  // The tuned draft is now the record, and its own page is where it reads.
+  expect(screen.getByTestId('location')).toHaveTextContent(/^\/targets\/9$/);
 });
 
 test('a note is stored without the whitespace it was typed with', async () => {
@@ -400,4 +460,235 @@ test('a live Target nobody fits says so rather than staying silent', async () =>
   renderPage();
 
   expect(await screen.findByText('0 fit today')).toBeVisible();
+});
+
+/*
+ * The Lab: the season behind the draft, read while it is composed. It is the
+ * one read on this page that fires on a keystroke, so the first thing to prove
+ * is that it waits — several quick edits are one request, made once the draft
+ * has held still — and that a half-typed draft is never sent at all.
+ */
+test('the Lab reads a draft once it has held still, so several quick edits are one read', async () => {
+  jest.useFakeTimers();
+  renderPage();
+  await screen.findAllByRole('link', { name: /^Open / });
+
+  composeQualifier();
+  expect(fetchTargetPreview).not.toHaveBeenCalled();
+  act(() => {
+    jest.advanceTimersByTime(300);
+  });
+  fireEvent.change(screen.getByLabelText('Qualifier 1 threshold percent'), {
+    target: { value: '42' },
+  });
+  act(() => {
+    jest.advanceTimersByTime(500);
+  });
+  // 800 ms since the first edit, 500 ms since the last: still nothing.
+  expect(fetchTargetPreview).not.toHaveBeenCalled();
+
+  await settle();
+  expect(fetchTargetPreview).toHaveBeenCalledTimes(1);
+  expect(fetchTargetPreview).toHaveBeenCalledWith(
+    expect.objectContaining({
+      opponent: 'OKC',
+      note: '',
+      qualifiers: [
+        { base: 'shot_zones', sliceKey: 'Corner 3', comparator: 'at_or_above', threshold: 0.42 },
+      ],
+    }),
+  );
+});
+
+test('an incomplete draft asks for nothing and says what to complete', async () => {
+  jest.useFakeTimers();
+  renderPage();
+  await screen.findAllByRole('link', { name: /^Open / });
+
+  // The blank form: a threshold has not been typed.
+  expect(screen.getByText('Complete the Qualifiers to see the Backtest.')).toBeVisible();
+  await settle();
+  expect(fetchTargetPreview).not.toHaveBeenCalled();
+
+  // A threshold outside the share range is not a threshold either.
+  fireEvent.change(screen.getByLabelText('Qualifier 1 threshold percent'), {
+    target: { value: '140' },
+  });
+  await settle();
+  expect(fetchTargetPreview).not.toHaveBeenCalled();
+
+  // And a draft with no Qualifier at all has nothing to evaluate.
+  fireEvent.click(screen.getByRole('button', { name: 'Remove Qualifier 1' }));
+  await settle();
+  expect(fetchTargetPreview).not.toHaveBeenCalled();
+  expect(screen.getByText('Complete the Qualifiers to see the Backtest.')).toBeVisible();
+});
+
+test('the Lab leads with the summary and whether the draft fires tonight, then the games', async () => {
+  jest.useFakeTimers();
+  renderPage();
+  await screen.findAllByRole('link', { name: /^Open / });
+
+  composeQualifier();
+  await settle();
+
+  expect(screen.getByText('Lab · Backtest · season to date · vs OKC')).toBeVisible();
+  expect(
+    screen.getByText('Outcomes are box-score proxies; there are no per-game slice splits.'),
+  ).toBeVisible();
+  // Tonight, in one line, from the resolve rule the backend applied.
+  expect(screen.getByText(/fit tonight/)).toHaveTextContent('1 fit tonight vs OKC');
+
+  // The strip: how many players and games, then per market the mean signed
+  // distance from the players' own averages, coloured by direction, and the
+  // share of games over.
+  expect(summaryItem('Players')).toHaveTextContent('2');
+  expect(summaryItem('Games')).toHaveTextContent('5');
+  expect(summaryItem('PTS')).toHaveTextContent('+2.5');
+  expect(summaryItem('PTS')).toHaveTextContent('60% of games over');
+  expect(within(summaryItem('PTS')).getByText('+2.5')).toHaveClass('is-hit');
+  expect(summaryItem('3PM')).toHaveTextContent('-0.8');
+  expect(summaryItem('3PM')).toHaveTextContent('40% of games over');
+  expect(within(summaryItem('3PM')).getByText('-0.8')).toHaveClass('is-miss');
+
+  // The same table the saved detail shows, labelled by the draft's title.
+  expect(screen.getByRole('table', { name: 'Backtest for OKC vs Corner 3 ≥ 40%' })).toBeVisible();
+  expect(screen.getByRole('row', { name: /2026-01-12/ })).toHaveTextContent('+5.6');
+  expect(
+    screen.queryByText('Complete the Qualifiers to see the Backtest.'),
+  ).not.toBeInTheDocument();
+});
+
+test('the tonight line is absent when the opponent has no game', async () => {
+  jest.useFakeTimers();
+  fetchTargetPreview.mockResolvedValue({ ...preview, today: null });
+  renderPage();
+  await screen.findAllByRole('link', { name: /^Open / });
+
+  composeQualifier();
+  await settle();
+
+  expect(summaryItem('Players')).toHaveTextContent('2');
+  expect(screen.queryByText(/fit tonight/)).not.toBeInTheDocument();
+});
+
+/*
+ * A keystroke never blanks the screen. The result on screen describes the
+ * draft it was read for, so once the draft moves on it reads as stale, and
+ * stays until the next answer replaces it.
+ */
+test('a nudged draft keeps the last result on screen, dimmed, until the next one lands', async () => {
+  jest.useFakeTimers();
+  renderPage();
+  await screen.findAllByRole('link', { name: /^Open / });
+  composeQualifier();
+  await settle();
+  const result = screen
+    .getByRole('list', { name: 'Backtest summary' })
+    .closest('.target-lab-result');
+  expect(result).not.toHaveClass('is-stale');
+
+  let publish;
+  fetchTargetPreview.mockReturnValue(
+    new Promise((resolve) => {
+      publish = resolve;
+    }),
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'Qualifier 1 threshold up 1%' }));
+  // Stale from the edit, before the read has even started.
+  expect(result).toHaveClass('is-stale');
+  expect(fetchTargetPreview).toHaveBeenCalledTimes(1);
+
+  await settle();
+  expect(fetchTargetPreview).toHaveBeenCalledTimes(2);
+  expect(fetchTargetPreview).toHaveBeenLastCalledWith(
+    expect.objectContaining({ qualifiers: [expect.objectContaining({ threshold: 0.41 })] }),
+  );
+  expect(screen.getByText('Reading the season…')).toBeVisible();
+  expect(result).toHaveClass('is-stale');
+  expect(summaryItem('Players')).toHaveTextContent('2');
+  expect(screen.getByRole('table')).toBeInTheDocument();
+
+  await act(async () => {
+    publish({ ...preview, summary: { ...preview.summary, players: 1, games: 3 } });
+  });
+  expect(result).not.toHaveClass('is-stale');
+  expect(screen.queryByText('Reading the season…')).not.toBeInTheDocument();
+  expect(summaryItem('Players')).toHaveTextContent('1');
+  expect(summaryItem('Games')).toHaveTextContent('3');
+});
+
+/*
+ * The Lab is evidence, not a gate. A read the backend refuses says so and
+ * leaves the form and Save exactly as they were.
+ */
+test('a refused read says so and leaves the draft and Save usable', async () => {
+  jest.useFakeTimers();
+  fetchTargetPreview.mockRejectedValue({
+    response: {
+      status: 400,
+      data: { error: { code: 'invalid_input', message: 'That slice is not evaluable.' } },
+    },
+  });
+  renderPage();
+  await screen.findAllByRole('link', { name: /^Open / });
+
+  composeQualifier();
+  await settle();
+
+  expect(screen.getByRole('alert')).toHaveTextContent('That slice is not evaluable.');
+  expect(screen.getByLabelText('Qualifier 1 threshold percent')).toHaveValue(40);
+  expect(screen.getByText('OKC vs Corner 3 ≥ 40%')).toBeInTheDocument();
+  const save = screen.getByRole('button', { name: 'Save Target' });
+  expect(save).toBeEnabled();
+
+  await act(async () => {
+    fireEvent.click(save);
+  });
+  expect(createTarget).toHaveBeenCalledWith(
+    expect.objectContaining({ qualifiers: [expect.objectContaining({ threshold: 0.4 })] }),
+  );
+  expect(screen.getByTestId('location')).toHaveTextContent(/^\/targets\/9$/);
+});
+
+/*
+ * Tuning is a series of small moves: one whole percent either way, from the
+ * steppers or the arrow keys, clamped to the share range and keeping whatever
+ * decimal was typed.
+ */
+test('the steppers and the arrow keys move a threshold by one percent', async () => {
+  renderPage();
+  await screen.findAllByRole('link', { name: /^Open / });
+  const threshold = screen.getByLabelText('Qualifier 1 threshold percent');
+  const up = screen.getByRole('button', { name: 'Qualifier 1 threshold up 1%' });
+  const down = screen.getByRole('button', { name: 'Qualifier 1 threshold down 1%' });
+
+  composeQualifier();
+  fireEvent.click(up);
+  expect(threshold).toHaveValue(41);
+  // The title follows the nudge, as it follows typing.
+  expect(screen.getByText('OKC vs Corner 3 ≥ 41%')).toBeInTheDocument();
+  fireEvent.click(down);
+  fireEvent.click(down);
+  expect(threshold).toHaveValue(39);
+
+  fireEvent.keyDown(threshold, { key: 'ArrowUp' });
+  expect(threshold).toHaveValue(40);
+  fireEvent.keyDown(threshold, { key: 'ArrowDown' });
+  fireEvent.keyDown(threshold, { key: 'ArrowDown' });
+  expect(threshold).toHaveValue(38);
+
+  // A decimal keeps its decimal; the bounds hold; a blank field starts at zero.
+  fireEvent.change(threshold, { target: { value: '40.5' } });
+  fireEvent.click(up);
+  expect(threshold).toHaveValue(41.5);
+  fireEvent.change(threshold, { target: { value: '100' } });
+  fireEvent.click(up);
+  expect(threshold).toHaveValue(100);
+  fireEvent.change(threshold, { target: { value: '0' } });
+  fireEvent.click(down);
+  expect(threshold).toHaveValue(0);
+  fireEvent.change(threshold, { target: { value: '' } });
+  fireEvent.keyDown(threshold, { key: 'ArrowUp' });
+  expect(threshold).toHaveValue(1);
 });

--- a/src/targets/TargetsPage.test.js
+++ b/src/targets/TargetsPage.test.js
@@ -132,7 +132,8 @@ const preview = {
 
 const storedTarget = { ...targets[0], id: 9, title: 'A title only the backend could have written' };
 
-const LocationProbe = () => <output data-testid="location">{useLocation().pathname}</output>;
+// A plain span, so the Lab's status line is the page's one live region.
+const LocationProbe = () => <span data-testid="location">{useLocation().pathname}</span>;
 
 const renderPage = () =>
   render(
@@ -151,6 +152,17 @@ const settle = () =>
   act(async () => {
     jest.advanceTimersByTime(600);
   });
+
+/*
+ * The Lab's one live region: what a screen reader is told. It has to be a
+ * status role of its own, and sit outside the busy results, or nothing is
+ * announced while they load.
+ */
+const labStatus = () => {
+  const status = screen.getByRole('status');
+  expect(status.closest('[aria-busy]')).toBeNull();
+  return status;
+};
 
 const composeQualifier = ({ opponent = 'OKC', slice = 'Corner 3', percent = '40' } = {}) => {
   fireEvent.change(screen.getByLabelText('Opponent'), { target: { value: opponent } });
@@ -517,7 +529,7 @@ test('editing the note is not a new draft, so the Lab does not read again', asyn
   expect(result).not.toHaveClass('is-stale');
   await settle();
   expect(fetchTargetPreview).toHaveBeenCalledTimes(1);
-  expect(screen.getByText('Backtest up to date.')).toBeVisible();
+  expect(labStatus()).toHaveTextContent('Backtest up to date.');
 });
 
 /*
@@ -572,7 +584,7 @@ test('an incomplete draft asks for nothing and says what to complete', async () 
   await screen.findAllByRole('link', { name: /^Open / });
 
   // The blank form: a threshold has not been typed.
-  expect(screen.getByText('Complete the Qualifiers to see the Backtest.')).toBeVisible();
+  expect(labStatus()).toHaveTextContent('Complete the Qualifiers to see the Backtest.');
   await settle();
   expect(fetchTargetPreview).not.toHaveBeenCalled();
 
@@ -609,7 +621,7 @@ test('a draft that stops being complete keeps the last evidence, dimmed', async 
   fireEvent.change(screen.getByLabelText('Qualifier 1 threshold percent'), {
     target: { value: '' },
   });
-  expect(screen.getByText('Complete the Qualifiers to see the Backtest.')).toBeVisible();
+  expect(labStatus()).toHaveTextContent('Complete the Qualifiers to see the Backtest.');
   expect(result).toHaveClass('is-stale');
   expect(summaryItem('Players')).toHaveTextContent('2');
   expect(screen.getByRole('table')).toBeInTheDocument();
@@ -700,7 +712,7 @@ test('a nudged draft keeps the last result on screen, dimmed, until the next one
   // Stale from the edit, before the read has even started — and said aloud,
   // since a dimmed table is silent to a screen reader.
   expect(result).toHaveClass('is-stale');
-  expect(screen.getByText('Draft changed · reading shortly…')).toBeVisible();
+  expect(labStatus()).toHaveTextContent('Draft changed · reading shortly…');
   expect(fetchTargetPreview).toHaveBeenCalledTimes(1);
 
   await settle();
@@ -708,8 +720,9 @@ test('a nudged draft keeps the last result on screen, dimmed, until the next one
   expect(fetchTargetPreview).toHaveBeenLastCalledWith(
     expect.objectContaining({ qualifiers: [expect.objectContaining({ threshold: 0.41 })] }),
   );
-  expect(screen.getByText('Reading the season…')).toBeVisible();
   expect(result).toHaveAttribute('aria-busy', 'true');
+  // Announced from outside the busy results, or it would not be announced.
+  expect(labStatus()).toHaveTextContent('Reading the season…');
   expect(result).toHaveClass('is-stale');
   expect(summaryItem('Players')).toHaveTextContent('2');
   expect(screen.getByRole('table')).toBeInTheDocument();
@@ -719,7 +732,7 @@ test('a nudged draft keeps the last result on screen, dimmed, until the next one
   });
   expect(result).not.toHaveClass('is-stale');
   expect(result).toHaveAttribute('aria-busy', 'false');
-  expect(screen.getByText('Backtest up to date.')).toBeVisible();
+  expect(labStatus()).toHaveTextContent('Backtest up to date.');
   expect(summaryItem('Players')).toHaveTextContent('1');
   expect(summaryItem('Games')).toHaveTextContent('3');
 });
@@ -743,16 +756,31 @@ test('a refused read says so and leaves the draft and Save usable', async () => 
   await settle();
 
   expect(screen.getByRole('alert')).toHaveTextContent('That slice is not evaluable.');
+  // The refusal is the answer to this draft, and is what the status says
+  // until the next read replaces it — not that a read is coming.
+  expect(labStatus()).toHaveTextContent('Backtest not updated.');
+  await settle();
+  expect(labStatus()).toHaveTextContent('Backtest not updated.');
   expect(screen.getByLabelText('Qualifier 1 threshold percent')).toHaveValue(40);
   expect(screen.getByText('OKC vs Corner 3 ≥ 40%')).toBeInTheDocument();
   const save = screen.getByRole('button', { name: 'Save Target' });
   expect(save).toBeEnabled();
 
+  // An edit after a refusal is read again, and recovers.
+  fetchTargetPreview.mockResolvedValue(preview);
+  fireEvent.click(screen.getByRole('button', { name: 'Qualifier 1 threshold up 1%' }));
+  expect(labStatus()).toHaveTextContent('Backtest not updated.');
+  await settle();
+  expect(fetchTargetPreview).toHaveBeenCalledTimes(2);
+  expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  expect(labStatus()).toHaveTextContent('Backtest up to date.');
+  expect(summaryItem('Players')).toHaveTextContent('2');
+
   await act(async () => {
     fireEvent.click(save);
   });
   expect(createTarget).toHaveBeenCalledWith(
-    expect.objectContaining({ qualifiers: [expect.objectContaining({ threshold: 0.4 })] }),
+    expect.objectContaining({ qualifiers: [expect.objectContaining({ threshold: 0.41 })] }),
   );
   expect(screen.getByTestId('location')).toHaveTextContent(/^\/targets\/9$/);
 });

--- a/src/targets/targetCatalog.js
+++ b/src/targets/targetCatalog.js
@@ -171,3 +171,14 @@ export const parseThresholdPercent = (percentText) => {
  */
 export const shareToThresholdPercent = (share, { whole = false } = {}) =>
   String(whole ? Math.round(share * 100) : Math.round(share * 1000) / 10);
+
+/*
+ * A threshold moved by the stepper or the arrow keys: one whole percent from
+ * where it is, clamped to the share range and kept at the decimal the parser
+ * keeps. A blank field is nudged from zero, so the first press puts a number
+ * where there was none rather than doing nothing.
+ */
+export const nudgeThresholdPercent = (percentText, delta) => {
+  const current = Number(String(percentText).trim()) || 0;
+  return String(Math.min(100, Math.max(0, Math.round((current + delta) * 10) / 10)));
+};

--- a/src/targets/targetsApi.js
+++ b/src/targets/targetsApi.js
@@ -34,29 +34,31 @@ const decodeQualifier = (item) => {
  * arrives with the record rather than being rebuilt from it. See
  * crf04/statsplus docs/adr/0001-targets-store-player-criteria-not-team-readings.md.
  */
-const decodeTarget = (item) => {
+const decodeDraftTarget = (item) => {
   if (!item || typeof item !== 'object') throw createInvalidResponseError();
-  const { id, opponent, title, note, created_at: createdAt, qualifiers } = item;
-  const hasId = typeof id === 'string' || typeof id === 'number';
+  const { opponent, title, note, qualifiers } = item;
   if (
-    !hasId ||
     typeof opponent !== 'string' ||
     typeof title !== 'string' ||
-    typeof createdAt !== 'string' ||
     !Array.isArray(qualifiers) ||
     qualifiers.length === 0 ||
     (note !== null && note !== undefined && typeof note !== 'string')
   ) {
     throw createInvalidResponseError();
   }
-  return {
-    id,
-    opponent,
-    title,
-    note: note || '',
-    createdAt,
-    qualifiers: qualifiers.map(decodeQualifier),
-  };
+  return { opponent, title, note: note || '', qualifiers: qualifiers.map(decodeQualifier) };
+};
+
+/*
+ * A saved Target is a Draft Target with a record behind it: the id it is
+ * opened by and the day it was set.
+ */
+const decodeTarget = (item) => {
+  const draft = decodeDraftTarget(item);
+  const { id, created_at: createdAt } = item;
+  const hasId = typeof id === 'string' || typeof id === 'number';
+  if (!hasId || typeof createdAt !== 'string') throw createInvalidResponseError();
+  return { id, ...draft, createdAt };
 };
 
 export const decodeTargets = (payload = {}) => {
@@ -298,7 +300,38 @@ const decodeBacktestPlayer = (player, statColumns, qualifierCount) => {
   };
 };
 
-export const decodeBacktest = (payload = {}) => {
+/*
+ * The summary is the backend's arithmetic over every listed game, in the same
+ * columns as the table: the mean signed difference from the player's season
+ * average, and the share of games at or above it. A column with no game to
+ * average has no figure, which is null rather than zero.
+ */
+const decodeSummaryColumn = (column) => {
+  if (!isRecord(column)) throw createInvalidResponseError();
+  const overAverageShare = requireNumberOrNull(column.over_average_share);
+  if (overAverageShare !== null && (overAverageShare < 0 || overAverageShare > 1)) {
+    throw createInvalidResponseError();
+  }
+  return { meanDifference: requireNumberOrNull(column.mean_difference), overAverageShare };
+};
+
+const decodeSummary = (summary, statColumns) => {
+  if (!isRecord(summary) || !isRecord(summary.columns)) throw createInvalidResponseError();
+  return {
+    players: requireNumber(summary.players),
+    games: requireNumber(summary.games),
+    columns: Object.fromEntries(
+      statColumns.map((column) => [column, decodeSummaryColumn(summary.columns[column])]),
+    ),
+  };
+};
+
+/*
+ * Everything a backtest carries besides the Target it was run for. The saved
+ * read and the Draft Target preview share it, which is what makes the Lab show
+ * exactly what the detail will show after saving.
+ */
+const decodeBacktestBody = (payload, target) => {
   if (
     !isRecord(payload) ||
     !Array.isArray(payload.stat_columns) ||
@@ -307,18 +340,49 @@ export const decodeBacktest = (payload = {}) => {
   ) {
     throw createInvalidResponseError();
   }
-  // The Target travels with its own backtest, so the rows are labelled by the
-  // Qualifiers the backend actually ran rather than by whatever the page
-  // happens to be holding.
-  const target = decodeTarget(payload.target);
   const statColumns = payload.stat_columns.map(requireString);
   return {
     target,
     proxy: requireString(payload.proxy),
     statColumns,
+    summary: decodeSummary(payload.summary, statColumns),
     players: payload.players.map((player) =>
       decodeBacktestPlayer(player, statColumns, target.qualifiers.length),
     ),
+  };
+};
+
+export const decodeBacktest = (payload = {}) => {
+  if (!isRecord(payload)) throw createInvalidResponseError();
+  // The Target travels with its own backtest, so the rows are labelled by the
+  // Qualifiers the backend actually ran rather than by whatever the page
+  // happens to be holding.
+  return decodeBacktestBody(payload, decodeTarget(payload.target));
+};
+
+/*
+ * Whether the draft fires on the current Slate date: null when the opponent
+ * is idle, else the game and how many opposing players meet every Qualifier
+ * by the resolve rule. A game without a count, or a count without a game, is
+ * half an answer.
+ */
+const decodeToday = (today) => {
+  if (today === null) return null;
+  if (!isRecord(today)) throw createInvalidResponseError();
+  const game = decodeGame(today.game);
+  if (game === null) throw createInvalidResponseError();
+  return { game, fitCount: requireNumber(today.fit_count) };
+};
+
+/*
+ * The preview is the backtest of a Draft Target: the same shape, with the
+ * validated draft echoed back in place of a stored record, plus `today`.
+ */
+export const decodePreview = (payload = {}) => {
+  if (!isRecord(payload) || payload.today === undefined) throw createInvalidResponseError();
+  return {
+    ...decodeBacktestBody(payload, decodeDraftTarget(payload.target)),
+    today: decodeToday(payload.today),
   };
 };
 
@@ -358,6 +422,20 @@ export const fetchTargetBacktest = async ({ id, signal } = {}) => {
     signal,
   });
   return decodeBacktest(response.data);
+};
+
+/*
+ * The same scan for a Target that is not saved: the create body goes up and
+ * the backtest comes back, with nothing stored. The Lab asks for this after
+ * every settled edit, so the read is abortable by the edit after it.
+ */
+export const fetchTargetPreview = async ({ opponent, qualifiers, note, signal } = {}) => {
+  const response = await apiClient.post(
+    targetsUrl('/preview'),
+    { opponent, qualifiers: qualifiers.map(encodeQualifier), note },
+    { signal },
+  );
+  return decodePreview(response.data);
 };
 
 /*

--- a/src/targets/targetsApi.js
+++ b/src/targets/targetsApi.js
@@ -431,7 +431,7 @@ export const fetchTargetBacktest = async ({ id, signal } = {}) => {
  */
 export const fetchTargetPreview = async ({ opponent, qualifiers, note, signal } = {}) => {
   const response = await apiClient.post(
-    targetsUrl('/preview'),
+    getApiUrl('TARGET_PREVIEW'),
     { opponent, qualifiers: qualifiers.map(encodeQualifier), note },
     { signal },
   );

--- a/src/targets/targetsApi.test.js
+++ b/src/targets/targetsApi.test.js
@@ -2,11 +2,13 @@ import { apiClient } from '../config';
 import {
   createTarget,
   decodeBacktest,
+  decodePreview,
   decodeResolvedTargets,
   decodeTargets,
   deleteTarget,
   fetchResolvedTargets,
   fetchTargetBacktest,
+  fetchTargetPreview,
   fetchTargets,
   updateTarget,
 } from './targetsApi';
@@ -505,6 +507,17 @@ const wireBacktest = {
   season: '2025-26',
   proxy: 'Outcomes are box-score proxies; there are no per-game slice splits.',
   stat_columns: ['PTS', '3PM'],
+  // The summary is the backend's arithmetic over every listed game, so the
+  // saved detail and the Lab read the same numbers: +5.6 and -3.2 in points
+  // average +1.2, and one of the two games was over.
+  summary: {
+    players: 2,
+    games: 2,
+    columns: {
+      PTS: { mean_difference: 1.2, over_average_share: 0.5 },
+      '3PM': { mean_difference: 0.5, over_average_share: 0.5 },
+    },
+  },
   players: [
     {
       canonical_id: 2544,
@@ -563,6 +576,14 @@ test('decodes the backtest to the rows the table reads, in the backend order', (
     },
     proxy: 'Outcomes are box-score proxies; there are no per-game slice splits.',
     statColumns: ['PTS', '3PM'],
+    summary: {
+      players: 2,
+      games: 2,
+      columns: {
+        PTS: { meanDifference: 1.2, overAverageShare: 0.5 },
+        '3PM': { meanDifference: 0.5, overAverageShare: 0.5 },
+      },
+    },
     // The backend orders the players by season scoring; a decoder that sorted
     // or grouped them would put the table in an order nobody chose.
     players: [
@@ -649,6 +670,122 @@ test('refuses a backtest whose rows would be read under the wrong heading', () =
       ],
     }),
   ).toThrow(/invalid response/i);
+
+  // The summary is computed by the backend so that the Lab and the saved
+  // detail agree; a backtest without one, or one that skips a column the
+  // table shows, would leave the strip to guess.
+  expect(() => decodeBacktest({ ...wireBacktest, summary: undefined })).toThrow(
+    /invalid response/i,
+  );
+  expect(() =>
+    decodeBacktest({
+      ...wireBacktest,
+      summary: { ...wireBacktest.summary, columns: { PTS: wireBacktest.summary.columns.PTS } },
+    }),
+  ).toThrow(/invalid response/i);
+  // A share of games is a share.
+  expect(() =>
+    decodeBacktest({
+      ...wireBacktest,
+      summary: {
+        ...wireBacktest.summary,
+        columns: {
+          ...wireBacktest.summary.columns,
+          PTS: { mean_difference: 1.2, over_average_share: 50 },
+        },
+      },
+    }),
+  ).toThrow(/invalid response/i);
+});
+
+/*
+ * A Draft Target is evaluated exactly as a saved one would be, so its preview
+ * is the backtest shape with two differences: the Target echoed back is the
+ * validated draft with its derived title and no id, and `today` says whether
+ * the draft fires on the current Slate date.
+ */
+const wireDraft = {
+  opponent: 'OKC',
+  title: 'OKC vs Corner 3 ≥ 40%',
+  note: '',
+  qualifiers: wireTarget.qualifiers,
+};
+
+const wirePreview = {
+  ...wireBacktest,
+  target: wireDraft,
+  today: { game: wireResolvedLive.game, fit_count: 2 },
+};
+
+test('decodes a preview to the backtest the Lab reads, plus whether it fires tonight', () => {
+  const preview = decodePreview(wirePreview);
+  expect(preview.target).toEqual({
+    opponent: 'OKC',
+    title: 'OKC vs Corner 3 ≥ 40%',
+    note: '',
+    qualifiers: [
+      { base: 'shot_zones', sliceKey: 'Corner 3', comparator: 'at_or_above', threshold: 0.4 },
+    ],
+  });
+  expect(preview.summary).toEqual(decodeBacktest(wireBacktest).summary);
+  expect(preview.players).toEqual(decodeBacktest(wireBacktest).players);
+  expect(preview.today).toEqual({
+    game: {
+      gameId: '0022500584',
+      scheduledAt: '2026-01-16T00:30:00.000Z',
+      status: { state: 'scheduled', label: 'Scheduled' },
+      away: { tricode: 'LAL' },
+      home: { tricode: 'OKC' },
+      opponent: { tricode: 'OKC' },
+      opposingTeam: { tricode: 'LAL' },
+    },
+    fitCount: 2,
+  });
+
+  // An opponent with no game on the Slate date has no tonight to speak of.
+  expect(decodePreview({ ...wirePreview, today: null }).today).toBeNull();
+});
+
+test('refuses a preview that could not honestly say whether the draft fires', () => {
+  // A game without a count, or a count without a game, is half an answer.
+  expect(() => decodePreview({ ...wirePreview, today: { game: wireResolvedLive.game } })).toThrow(
+    /invalid response/i,
+  );
+  expect(() => decodePreview({ ...wirePreview, today: { game: null, fit_count: 2 } })).toThrow(
+    /invalid response/i,
+  );
+  expect(() => decodePreview({ ...wirePreview, today: undefined })).toThrow(/invalid response/i);
+  // The draft's title is the backend's to derive, as a saved Target's is.
+  expect(() =>
+    decodePreview({ ...wirePreview, target: { ...wireDraft, title: undefined } }),
+  ).toThrow(/invalid response/i);
+});
+
+test('previews a draft at the documented path with the create body', async () => {
+  apiClient.post.mockResolvedValue({ data: wirePreview });
+  const controller = new AbortController();
+
+  await expect(
+    fetchTargetPreview({
+      opponent: 'OKC',
+      note: '',
+      qualifiers: [
+        { base: 'shot_zones', sliceKey: 'Corner 3', comparator: 'at_or_above', threshold: 0.4 },
+      ],
+      signal: controller.signal,
+    }),
+  ).resolves.toEqual(expect.objectContaining({ today: expect.objectContaining({ fitCount: 2 }) }));
+  expect(apiClient.post).toHaveBeenCalledWith(
+    '/api/user/targets/preview',
+    {
+      opponent: 'OKC',
+      note: '',
+      qualifiers: [
+        { base: 'shot_zones', slice_key: 'Corner 3', comparator: 'at_or_above', threshold: 0.4 },
+      ],
+    },
+    { signal: controller.signal },
+  );
 });
 
 test("reads one Target's backtest from the documented path", async () => {

--- a/src/targets/targetsApi.test.js
+++ b/src/targets/targetsApi.test.js
@@ -15,7 +15,8 @@ import {
 
 jest.mock('../config', () => ({
   apiClient: { get: jest.fn(), post: jest.fn(), patch: jest.fn(), delete: jest.fn() },
-  getApiUrl: (name) => `/api/user/${name.toLowerCase()}`,
+  getApiUrl: (name) =>
+    ({ TARGETS: '/api/user/targets', TARGET_PREVIEW: '/api/user/targets/preview' })[name],
 }));
 
 const wireTarget = {

--- a/src/targets/useTargets.js
+++ b/src/targets/useTargets.js
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { getRequestErrorMessage, isRequestCancelled } from '../gameLogsApi';
 import {
@@ -15,7 +15,6 @@ const PREVIEW_FAILURE = 'Unable to read the season for this draft. Please try ag
 const EMPTY_LIST = { targets: [] };
 const EMPTY_RESOLUTION = { slateDate: null, entries: [] };
 const EMPTY_BACKTEST = { backtest: null };
-const EMPTY_PREVIEW = { preview: null };
 
 /*
  * How long a draft has to hold still before the Lab reads it. Long enough that
@@ -33,8 +32,6 @@ const readList = ({ signal }) => fetchTargets({ signal }).then((targets) => ({ t
 const readResolution = ({ scope, signal }) => fetchResolvedTargets({ date: scope, signal });
 const readBacktest = ({ scope, signal }) =>
   fetchTargetBacktest({ id: scope, signal }).then((backtest) => ({ backtest }));
-const readPreview = ({ scope, signal }) =>
-  fetchTargetPreview({ ...scope, signal }).then((preview) => ({ preview }));
 
 /*
  * One account-private read, in the three shapes the Target surfaces need. All
@@ -45,42 +42,33 @@ const readPreview = ({ scope, signal }) =>
  *
  * A `lazy` read makes no request until it is asked for: its request count
  * starts at zero and stays there until `reload` raises it, which is what keeps
- * a read nobody has asked for off the wire. A `skip`ped read has nothing to
- * ask about yet and holds the empty state until it does. A read that `keep`s
- * shows what it last returned while the next answer is on its way, rather
- * than blanking on every request.
+ * a read nobody has asked for off the wire.
  */
-const useAccountRead = (
-  read,
-  empty,
-  scope,
-  { lazy = false, skip = false, keep = false, failure = LOAD_FAILURE } = {},
-) => {
+const useAccountRead = (read, empty, scope, { lazy = false, failure = LOAD_FAILURE } = {}) => {
   const { isAuthenticated, loading: authLoading } = useAuth();
   const [state, setState] = useState({ status: 'idle', error: null, ...empty });
   const [requests, setRequests] = useState(lazy ? 0 : 1);
 
   useEffect(() => {
-    if (skip || requests === 0 || authLoading || !isAuthenticated) {
+    if (requests === 0 || authLoading || !isAuthenticated) {
       setState({ status: 'idle', error: null, ...empty });
       return undefined;
     }
     const controller = new AbortController();
-    const held = (current) => (keep ? current : { ...current, ...empty });
-    setState((current) => ({ ...held(current), status: 'loading', error: null }));
+    setState({ status: 'loading', error: null, ...empty });
     read({ scope, signal: controller.signal })
       .then((data) => setState({ status: 'ready', error: null, ...data }))
       .catch((error) => {
         if (!isRequestCancelled(error)) {
-          setState((current) => ({
-            ...held(current),
+          setState({
             status: 'error',
             error: getRequestErrorMessage(error, failure),
-          }));
+            ...empty,
+          });
         }
       });
     return () => controller.abort();
-  }, [authLoading, isAuthenticated, scope, read, empty, failure, requests, skip, keep]);
+  }, [authLoading, isAuthenticated, scope, read, empty, failure, requests]);
 
   const reload = useCallback(() => setRequests((count) => count + 1), []);
 
@@ -116,33 +104,78 @@ export const useTargetBacktest = (id) => {
   return { ...state, read: reload };
 };
 
+const EMPTY_PREVIEW = { status: 'idle', error: null, preview: null, key: null };
+
+/*
+ * What a Draft Target is evaluated by: the opponent and the Qualifiers. The
+ * note is never part of the evidence, so editing it is not a new draft.
+ */
+const previewKey = (request) =>
+  request ? JSON.stringify({ opponent: request.opponent, qualifiers: request.qualifiers }) : null;
+
 /*
  * The season behind a Draft Target, read while it is composed. The draft is
  * compared by value, so a re-render is not a new draft and neither is retyping
  * the same threshold; a changed one is read only once it has held still for
- * the delay, so several quick edits are one request. Nothing is asked about a
- * draft that is not complete, and what was last read stays in hand, to be
- * shown dimmed, until the next answer lands. `pending` says the draft has
- * moved on from what was last read, whether or not the read has started.
+ * the delay, so several quick edits are one request. The moment the draft
+ * changes, whatever was in flight for the old one is abandoned, and a late
+ * answer from it is never shown.
+ *
+ * What was last read stays in hand — through the next edit, an incomplete
+ * draft, and a refusal — so a keystroke never blanks the screen; it is dropped
+ * only when the account signs out or the host goes away. `pending` says the
+ * draft has moved on from what was last read, whether or not the read has
+ * started; the caller shows the result dimmed until it is current again.
  */
 export const useTargetPreview = (request) => {
-  const key = request ? JSON.stringify(request) : null;
-  const [settled, setSettled] = useState(null);
+  const { isAuthenticated, loading: authLoading } = useAuth();
+  const key = previewKey(request);
+  const [state, setState] = useState(EMPTY_PREVIEW);
+  // The draft the result in hand was read for, kept where the effect can see
+  // it without re-running for it: a draft typed back to what was last read is
+  // not a new draft either.
+  const readKey = useRef(null);
 
   useEffect(() => {
-    if (key === null) {
-      setSettled(null);
+    if (authLoading || !isAuthenticated) {
+      readKey.current = null;
+      setState(EMPTY_PREVIEW);
       return undefined;
     }
-    const timer = setTimeout(() => setSettled(key), PREVIEW_DELAY_MS);
-    return () => clearTimeout(timer);
-  }, [key]);
+    if (key === null || key === readKey.current) {
+      // Nothing to read, and the read that was under way was abandoned when
+      // the draft moved. What was last read stays.
+      setState((current) => ({
+        ...current,
+        status: current.preview ? 'ready' : 'idle',
+        error: null,
+      }));
+      return undefined;
+    }
+    const controller = new AbortController();
+    const timer = setTimeout(() => {
+      setState((current) => ({ ...current, status: 'loading', error: null }));
+      fetchTargetPreview({ ...JSON.parse(key), signal: controller.signal })
+        .then((preview) => {
+          if (controller.signal.aborted) return;
+          readKey.current = key;
+          setState({ status: 'ready', error: null, preview, key });
+        })
+        .catch((error) => {
+          if (controller.signal.aborted || isRequestCancelled(error)) return;
+          setState((current) => ({
+            ...current,
+            status: 'error',
+            error: getRequestErrorMessage(error, PREVIEW_FAILURE),
+          }));
+        });
+    }, PREVIEW_DELAY_MS);
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [key, authLoading, isAuthenticated]);
 
-  const scope = useMemo(() => (settled === null ? null : JSON.parse(settled)), [settled]);
-  const state = useAccountRead(readPreview, EMPTY_PREVIEW, scope, {
-    skip: scope === null,
-    keep: true,
-    failure: PREVIEW_FAILURE,
-  });
-  return { ...state, pending: key !== settled };
+  const { key: shownKey, ...read } = state;
+  return { ...read, pending: key !== shownKey };
 };

--- a/src/targets/useTargets.js
+++ b/src/targets/useTargets.js
@@ -1,14 +1,28 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { getRequestErrorMessage, isRequestCancelled } from '../gameLogsApi';
-import { fetchResolvedTargets, fetchTargetBacktest, fetchTargets } from './targetsApi';
+import {
+  fetchResolvedTargets,
+  fetchTargetBacktest,
+  fetchTargetPreview,
+  fetchTargets,
+} from './targetsApi';
 
 const LOAD_FAILURE = 'Unable to load your Targets. Please try again.';
 const BACKTEST_FAILURE = 'Unable to load this backtest. Please try again.';
+const PREVIEW_FAILURE = 'Unable to read the season for this draft. Please try again.';
 
 const EMPTY_LIST = { targets: [] };
 const EMPTY_RESOLUTION = { slateDate: null, entries: [] };
 const EMPTY_BACKTEST = { backtest: null };
+const EMPTY_PREVIEW = { preview: null };
+
+/*
+ * How long a draft has to hold still before the Lab reads it. Long enough that
+ * typing "35" is one request rather than two, short enough to feel like the
+ * table answered the keystroke.
+ */
+export const PREVIEW_DELAY_MS = 600;
 
 /*
  * Each read returns the state it contributes, so the hook below can hold any
@@ -19,6 +33,8 @@ const readList = ({ signal }) => fetchTargets({ signal }).then((targets) => ({ t
 const readResolution = ({ scope, signal }) => fetchResolvedTargets({ date: scope, signal });
 const readBacktest = ({ scope, signal }) =>
   fetchTargetBacktest({ id: scope, signal }).then((backtest) => ({ backtest }));
+const readPreview = ({ scope, signal }) =>
+  fetchTargetPreview({ ...scope, signal }).then((preview) => ({ preview }));
 
 /*
  * One account-private read, in the three shapes the Target surfaces need. All
@@ -29,33 +45,42 @@ const readBacktest = ({ scope, signal }) =>
  *
  * A `lazy` read makes no request until it is asked for: its request count
  * starts at zero and stays there until `reload` raises it, which is what keeps
- * a read nobody has asked for off the wire.
+ * a read nobody has asked for off the wire. A `skip`ped read has nothing to
+ * ask about yet and holds the empty state until it does. A read that `keep`s
+ * shows what it last returned while the next answer is on its way, rather
+ * than blanking on every request.
  */
-const useAccountRead = (read, empty, scope, { lazy = false, failure = LOAD_FAILURE } = {}) => {
+const useAccountRead = (
+  read,
+  empty,
+  scope,
+  { lazy = false, skip = false, keep = false, failure = LOAD_FAILURE } = {},
+) => {
   const { isAuthenticated, loading: authLoading } = useAuth();
   const [state, setState] = useState({ status: 'idle', error: null, ...empty });
   const [requests, setRequests] = useState(lazy ? 0 : 1);
 
   useEffect(() => {
-    if (requests === 0 || authLoading || !isAuthenticated) {
+    if (skip || requests === 0 || authLoading || !isAuthenticated) {
       setState({ status: 'idle', error: null, ...empty });
       return undefined;
     }
     const controller = new AbortController();
-    setState({ status: 'loading', error: null, ...empty });
+    const held = (current) => (keep ? current : { ...current, ...empty });
+    setState((current) => ({ ...held(current), status: 'loading', error: null }));
     read({ scope, signal: controller.signal })
       .then((data) => setState({ status: 'ready', error: null, ...data }))
       .catch((error) => {
         if (!isRequestCancelled(error)) {
-          setState({
+          setState((current) => ({
+            ...held(current),
             status: 'error',
             error: getRequestErrorMessage(error, failure),
-            ...empty,
-          });
+          }));
         }
       });
     return () => controller.abort();
-  }, [authLoading, isAuthenticated, scope, read, empty, failure, requests]);
+  }, [authLoading, isAuthenticated, scope, read, empty, failure, requests, skip, keep]);
 
   const reload = useCallback(() => setRequests((count) => count + 1), []);
 
@@ -89,4 +114,35 @@ export const useTargetBacktest = (id) => {
   });
   // The first reload of a read that has never run is that read.
   return { ...state, read: reload };
+};
+
+/*
+ * The season behind a Draft Target, read while it is composed. The draft is
+ * compared by value, so a re-render is not a new draft and neither is retyping
+ * the same threshold; a changed one is read only once it has held still for
+ * the delay, so several quick edits are one request. Nothing is asked about a
+ * draft that is not complete, and what was last read stays in hand, to be
+ * shown dimmed, until the next answer lands. `pending` says the draft has
+ * moved on from what was last read, whether or not the read has started.
+ */
+export const useTargetPreview = (request) => {
+  const key = request ? JSON.stringify(request) : null;
+  const [settled, setSettled] = useState(null);
+
+  useEffect(() => {
+    if (key === null) {
+      setSettled(null);
+      return undefined;
+    }
+    const timer = setTimeout(() => setSettled(key), PREVIEW_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [key]);
+
+  const scope = useMemo(() => (settled === null ? null : JSON.parse(settled)), [settled]);
+  const state = useAccountRead(readPreview, EMPTY_PREVIEW, scope, {
+    skip: scope === null,
+    keep: true,
+    failure: PREVIEW_FAILURE,
+  });
+  return { ...state, pending: key !== settled };
 };


### PR DESCRIPTION
The **Lab**: composing a Target while watching its Backtest update. Beneath the Target form in all three hosts (Targets page create form, detail edit form, Matchup capture dialog), a panel calls `POST /api/user/targets/preview` ~600 ms after any change to opponent or Qualifiers (note edits excluded), aborts obsolete requests, keeps the previous evidence dimmed while a new read loads or while the draft is incomplete, and shows: the proxy sentence, a 'N fit tonight vs OPP' line when the opponent plays today, a summary strip (players, games, mean signed difference and over-average share per stat column), then the Backtest table. The saved detail's Backtest gains the same strip. Thresholds get ±1% steppers and arrow-key nudging. A persistent status line announces pending / loading / updated / not updated. Save from the capture dialog now lands on the created Target's detail, guarded so a dismissed Save never navigates later.

Reviewed by gpt-6-astra at high effort (spec, correctness, standards, mutation of every new test) with two fix rounds and re-reviews; all findings resolved.

## Screenshots

**Deferred** until crf04/statsplus-backend's preview endpoint (#253) deploys; the Lab needs it on production data. Live desktop and phone captures will be commented onto this PR afterwards.

Merge after: crf04/statsplus-backend#256

Closes #94
Part of crf04/statsplus#55

🤖 Generated with [Claude Code](https://claude.com/claude-code)
