### PR TITLE
Say View Details / Edit on the Target card link

### DIFF
--- a/src/targets/TargetsPage.js
+++ b/src/targets/TargetsPage.js
@@ -41,7 +41,7 @@ function TargetCard({ target, entry, read, resolutionStatus }) {
             </span>
           )}
           <Link className="target-card-go" to={`/targets/${target.id}`}>
-            Edit →
+            View Details / Edit
           </Link>
         </div>
         <div className="target-card-criteria">

--- a/src/targets/TargetsPage.test.js
+++ b/src/targets/TargetsPage.test.js
@@ -225,7 +225,7 @@ test('shows every saved Target as a card carrying the stored title, Qualifiers, 
   const cards = await screen.findAllByRole('article');
   expect(cards).toHaveLength(2);
   expect(cards[0]).toHaveAccessibleName('OKC vs Corner 3 ≥ 40% (v2)');
-  expect(within(cards[0]).getByRole('link', { name: 'Edit →' })).toHaveAttribute(
+  expect(within(cards[0]).getByRole('link', { name: 'View Details / Edit' })).toHaveAttribute(
     'href',
     '/targets/7',
   );
@@ -860,7 +860,7 @@ test('cards state tonight’s fits as pills and keep criteria and logs read-only
     'href',
     '/matchups/0022500584',
   );
-  expect(within(card).getByRole('link', { name: 'Edit →' })).toHaveAttribute('href', '/targets/7');
+  expect(within(card).getByRole('link', { name: 'View Details / Edit' })).toHaveAttribute('href', '/targets/7');
   expect(within(card).getByRole('listitem')).toHaveTextContent('44%');
   expect(within(card).getByRole('listitem')).toHaveTextContent('25.4 ppg');
   expect(within(card).queryByRole('spinbutton')).not.toBeInTheDocument();


### PR DESCRIPTION
The Targets page card links to the Target's own page, which is where a Target is both viewed in full and edited. The label said only `Edit →`; it now says `View Details / Edit`.

- src/targets/TargetsPage.js — card link label
- src/targets/TargetsPage.test.js — accessible-name assertions

Verification: npm run lint clean; src/targets/TargetsPage.test.js 44/44 passing.