### PR TITLE
Default Matchups to March 11 during the offseason

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The natural-language path is the one I cared most about — the structured filte
 ## Routes and navigation
 
 The shared navigation exposes the game-log search at `/` and the date-based NBA slate at
-`/matchups?date=YYYY-MM-DD`. Omitting `date` opens today's Eastern-time slate. Unknown client-side
+`/matchups?date=YYYY-MM-DD`. Omitting `date` temporarily opens March 11, 2026 for the offseason. The Today button opens the current Eastern-time slate. Unknown client-side
 paths return to `/`, and Vercel's SPA fallback keeps direct links to `/matchups` working. Signed-out
 visitors keep the shared shell and see a sign-in prompt on the matchups route rather than being
 redirected.

--- a/e2e/specs/slate.spec.js
+++ b/e2e/specs/slate.spec.js
@@ -89,9 +89,9 @@ test('@critical authenticated user opens a slate and navigates dates', async ({
   await page.screenshot({ path: testInfo.outputPath('slate-empty.png'), fullPage: true });
 
   await page.getByLabel('Slate date').fill('');
-  await expect(page).toHaveURL(/\/matchups$/);
+  await expect(page).toHaveURL(/\/matchups\?date=2026-01-15$/);
   await expect(page.getByRole('heading', { name: 'Thursday, January 15, 2026' })).toBeVisible();
-  expect(requests.some((url) => !new URL(url).searchParams.has('date'))).toBe(true);
+  expect(requests.some((url) => new URL(url).searchParams.get('date') === '2026-01-15')).toBe(true);
 
   await page.getByLabel('Slate date').fill('2026-01-10');
   await expect(page).toHaveURL(/date=2026-01-10/);
@@ -108,7 +108,7 @@ test('@critical authenticated user opens a slate and navigates dates', async ({
 
   // Today is reachable from any date, not only as recovery from a bad one.
   await page.getByRole('button', { name: 'Today' }).click();
-  await expect(page).toHaveURL(/\/matchups$/);
+  await expect(page).toHaveURL(/\/matchups\?date=2026-01-15$/);
   await expect(page.getByRole('heading', { name: 'Thursday, January 15, 2026' })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Today' })).toBeDisabled();
 });
@@ -175,10 +175,11 @@ test('a rejected slate request leaves date navigation available', async ({
 test('an invalid requested date stays neutral until the backend rejects it', async ({
   authenticatedPage: page,
 }) => {
+  await page.clock.setFixedTime(new Date('2026-01-15T12:00:00Z'));
   await installApiContract(page, {
     '/api/games/slate': (request) => {
       const date = new URL(request.url()).searchParams.get('date');
-      if (date) {
+      if (date === '2026-02-30') {
         return {
           status: 400,
           body: { error: { code: 'invalid_input', message: 'Enter a valid date.' } },
@@ -198,7 +199,7 @@ test('an invalid requested date stays neutral until the backend rejects it', asy
   await expect(page.getByRole('button', { name: 'Today' })).toBeVisible();
 
   await page.getByRole('button', { name: 'Today' }).click();
-  await expect(page).toHaveURL(/\/matchups$/);
+  await expect(page).toHaveURL(/\/matchups\?date=2026-01-15$/);
   await expect(page.getByRole('heading', { name: 'Thursday, January 15, 2026' })).toBeVisible();
 });
 

--- a/src/SlatePage.js
+++ b/src/SlatePage.js
@@ -197,10 +197,13 @@ function SlateBoard({ games, renderExtra }) {
   );
 }
 
+// Temporary offseason landing date; remove when current slates resume.
+const defaultSlateDate = '2026-03-11';
+
 export default function SlatePage() {
   const { isAuthenticated, loading: authLoading } = useAuth();
   const [searchParams, setSearchParams] = useSearchParams();
-  const requestedDate = searchParams.get('date');
+  const requestedDate = searchParams.get('date') ?? defaultSlateDate;
   const todaySlateDate = getTodaySlateDate();
   const parsedRequestedDate = parseCalendarDate(requestedDate);
   const invalidRequestedDate = requestedDate !== null && !parsedRequestedDate;
@@ -287,7 +290,7 @@ export default function SlatePage() {
             <input
               type="date"
               value={slateDate || ''}
-              onChange={(event) => navigate(event.target.value)}
+              onChange={(event) => navigate(event.target.value || todaySlateDate)}
             />
           </label>
           <button
@@ -305,7 +308,7 @@ export default function SlatePage() {
             className="today-reset"
             type="button"
             disabled={slateDate === todaySlateDate}
-            onClick={() => navigate('')}
+            onClick={() => navigate(todaySlateDate)}
           >
             Today
           </button>

--- a/src/SlatePage.test.js
+++ b/src/SlatePage.test.js
@@ -59,6 +59,24 @@ afterEach(() => {
   jest.clearAllMocks();
 });
 
+test('opens March 11 by default during the offseason and can return to today', async () => {
+  jest.setSystemTime(new Date('2026-09-11T12:00:00Z'));
+  fetchSlate.mockImplementation(async (date) => ({ ...slate, slateDate: date }));
+  render(
+    <MemoryRouter initialEntries={['/matchups']}>
+      <SlatePage />
+    </MemoryRouter>,
+  );
+
+  expect(screen.getByLabelText('Slate date')).toHaveValue('2026-03-11');
+  await screen.findByRole('heading', { name: 'Wednesday, March 11, 2026' });
+  expect(fetchSlate).toHaveBeenCalledWith('2026-03-11', expect.any(Object));
+
+  fireEvent.click(screen.getByRole('button', { name: 'Today' }));
+  await screen.findByRole('heading', { name: 'Friday, September 11, 2026' });
+  expect(fetchSlate).toHaveBeenLastCalledWith('2026-09-11', expect.any(Object));
+});
+
 test('shows an age for every available freshness surface and names degraded surfaces', async () => {
   render(
     <MemoryRouter initialEntries={['/matchups?date=2026-01-15']}>
@@ -155,7 +173,7 @@ test('clearing the date requests today without entering an invalid state', async
 
   fireEvent.change(screen.getByLabelText('Slate date'), { target: { value: '' } });
 
-  await waitFor(() => expect(fetchSlate).toHaveBeenCalledWith(undefined, expect.any(Object)));
+  await waitFor(() => expect(fetchSlate).toHaveBeenCalledWith('2026-01-15', expect.any(Object)));
   expect(screen.queryByRole('heading', { name: 'Invalid slate date' })).not.toBeInTheDocument();
   expect(screen.getByLabelText('Slate date')).toHaveValue('2026-01-15');
 });
@@ -176,7 +194,7 @@ test('offers Today as a recovery from an invalid requested date', async () => {
 
   fireEvent.click(screen.getByRole('button', { name: 'Today' }));
 
-  await waitFor(() => expect(fetchSlate).toHaveBeenCalledWith(undefined, expect.any(Object)));
+  await waitFor(() => expect(fetchSlate).toHaveBeenCalledWith('2026-01-15', expect.any(Object)));
   expect(screen.queryByRole('heading', { name: 'Invalid slate date' })).not.toBeInTheDocument();
 });
 
@@ -282,7 +300,7 @@ test('offers Today from any other date and marks it inert on today', async () =>
 
   fireEvent.click(screen.getByRole('button', { name: 'Today' }));
 
-  await waitFor(() => expect(fetchSlate).toHaveBeenCalledWith(undefined, expect.any(Object)));
+  await waitFor(() => expect(fetchSlate).toHaveBeenCalledWith('2026-01-15', expect.any(Object)));
 });
 
 test('opens Team Sheets from anywhere on the row', async () => {


### PR DESCRIPTION
## Change

Opening `/matchups` without a date now requests March 11, 2026 so offseason visitors see six completed games. Explicit date links and previous/next navigation still work. Today and clearing the picker select the current Eastern date explicitly.

The default is temporary and should be removed when current slates resume. No backend contract changes.

Source of truth: user request, unedited: “Make the default matchups page be like 3/11 right now just for the offseason, there's no games right now”. No issue hierarchy was published; this request authorizes the PR.

## Verification

Tested frontend **1818700e09040c1c771220f062dafc48c0ebc8df**, based on `d49975a`, in `/Users/chrisfu/.t3/worktrees/statsplus-frontend/offseason-matchups`.

| Check | Result | Revisions, command, and evidence |
| --- | --- | --- |
| Frontend completion gate | Passed | `npm ci`, `npm run lint`, `npm run format:check`, `npm run test:ci` (747 tests), `npm run build`, `npm run test:e2e` (108 passed, 2 deployment-only skips) |
| QA user journey | Passed | Real Firebase auth; backend `ab9b92c533973e43d50a04170963056672fa736b`; all 47 journey commands passed against an isolated database |
| Production read-only compatibility | Passed | Same frontend against Railway; all 47 commands passed, desktop 1440×900 and phone 390×844 screenshots below |
| Independent Claude review | Passed | No material findings on final diff; reverting the default in an isolated copy made the new regression test fail; restoring it passed all 32 SlatePage tests |
| Coordination gate | Passed with QA backend | `STATSPLUS_FRONTEND_ROOT=/Users/chrisfu/.t3/worktrees/statsplus-frontend/offseason-matchups STATSPLUS_BACKEND_ROOT=/Users/chrisfu/statsplus-local/backend python3 scripts/check.py` |

QA and production both verified the default date plus real game rows, next/previous dates, reload, phone Today and offseason empty state, picker navigation, invalid-date HTTP 400, and recovery. Response status and exact date parameters were asserted alongside visible results.

Commands from the coordination worktree:

```sh
node .agents/skills/verify-statsplus/scripts/control-statsplus.mjs \
  --frontend /Users/chrisfu/.t3/worktrees/statsplus-frontend/offseason-matchups \
  --backend /Users/chrisfu/statsplus-local/backend \
  --out /tmp/statsplus-offseason-pr-evidence/qa \
  < /tmp/statsplus-offseason-pr-evidence/journey.jsonl

node .agents/skills/verify-statsplus/scripts/control-statsplus.mjs \
  --environment production \
  --frontend /Users/chrisfu/.t3/worktrees/statsplus-frontend/offseason-matchups \
  --backend /Users/chrisfu/statsplus-backend \
  --out /tmp/statsplus-offseason-pr-evidence/production \
  < /tmp/statsplus-offseason-pr-evidence/journey.jsonl
```

QA snapshot SHA-256: `3fe69266e135d9ed9e6f671d01e7034c7d529a6ee3a9fa6395851b003ee222f5`.

[Evidence bundle: executed journeys, hashes, source metadata, QA screenshots and action videos](https://github.com/crf04/statsplus-frontend/tree/24d5d4f8fcd50ff74b8ffdd77741b3357010668b/docs/screenshots/offseason-matchups). Both sessions report `cleanedUp: true`; owned runtime directories are absent. Evidence lives on a separate branch so this PR contains only the four implementation files.

### Production-backed screenshots

Desktop:

![March 11 default, desktop](https://raw.githubusercontent.com/crf04/statsplus-frontend/24d5d4f8fcd50ff74b8ffdd77741b3357010668b/docs/screenshots/offseason-matchups/production/offseason-desktop.png)

Phone:

![March 11 default, phone](https://raw.githubusercontent.com/crf04/statsplus-frontend/24d5d4f8fcd50ff74b8ffdd77741b3357010668b/docs/screenshots/offseason-matchups/production/offseason-phone.png)

### Limits

- Full-page phone captures show a white background below the original viewport. Phone date controls, game rows and overflow assertions passed; this PR changes no styling.
- Historical player-pool unavailability is shown as returned by the API. QA disables paid AI and external DFS/injury providers; those integrations and the Google login popup are outside this check.
- Railway's deployed SHA is unknown; the production command's local backend revision is credential/source context only.
- Running the coordination check with the default resolver instead of the selected QA backend exposes existing missing routes/catalogue in the older research checkout (`af5574d`). The selected QA backend passes all 13 contract checks.
